### PR TITLE
search improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ L'idée est ici d'**expérimenter la conception d'un MCP rendant les données et
 
 ## Mises en garde
 
-- Ce développement est un POC en incubation avec IgnFab (archivage en cours de [mborne/geocontext](https://github.com/mborne/geocontext))
+- Ce développement est un POC en incubation au sein d'ignfab (archivage en cours de [mborne/geocontext](https://github.com/mborne/geocontext))
 - S'il s'avère utile de l'industrialiser, le dépôt sera migré sous responsabilité IGN et l'outil sera renommé (ex : `IGNF/mcp-gpf-server`)
 - Plusieurs problèmes et améliorations possibles ont été identifiés et sont en cours de mitigation/résolution (c.f. [issues](https://github.com/ignfab/geocontext/issues?q=is%3Aissue%20state%3Aopen%20label%3Ametadata)).
 - Cet outil n'est pas magique (voir [Fonctionnalités](#fonctionnalités) pour avoir une idée de ses capacités)
@@ -74,6 +74,8 @@ npm run build
 
 ### Utilisation de la version locale
 
+#### Avec un client MCP compatible JSON
+
 ```json
 {
   "mcpServers": {
@@ -84,6 +86,27 @@ npm run build
   }
 }
 ```
+
+#### Avec Codex CLI / VS Code
+
+Avec Codex CLI ou l'extension Codex pour VS Code, la configuration se fait dans `~/.codex/config.toml` :
+
+```toml
+[mcp_servers.geocontext]
+command = "node"
+args = ["/chemin/absolu/vers/geocontext/dist/index.js"]
+
+# Définition d'un corporate proxy si nécessaire
+[mcp_servers.geocontext.env]
+HTTPS_PROXY = "http://proxy.domain.fr:3128"
+HTTP_PROXY = "http://proxy.domain.fr:3128"
+NO_PROXY = "localhost,127.0.0.1"
+http_proxy = "http://proxy.domain.fr:3128"
+https_proxy = "http://proxy.domain.fr:3128"
+no_proxy = "localhost,127.0.0.1"
+```
+
+Après mise à jour de `~/.codex/config.toml`, relancer la session Codex CLI ou recharger VS Code si l'extension Codex est déjà ouverte.
 
 ### Debug de la version locale
 
@@ -98,15 +121,15 @@ Pour une utilisation avancée :
 | Nom              | Description                                                                                                          | Valeur par défaut |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | `TRANSPORT_TYPE` | [Transport](https://mcp-framework.com/docs/Transports/transports-overview) permet de choisir entre "stdio" et "http" | "stdio"           |
-| `GPF_WFS_SEARCH_OPTIONS` | Chaîne JSON optionnelle pour ajuster la recherche `gpf_wfs_search_types` (`fuzzy`, `boost.namespace`, `boost.name`, `boost.title`, `boost.description`, `boost.properties`). | options par défaut de `@ignfab/gpf-schema-store` |
+| `GPF_WFS_MINISEARCH_OPTIONS` | Chaîne JSON optionnelle pour ajuster les options MiniSearch utilisées par `gpf_wfs_search_types` (`fields`, `combineWith`, `fuzzy`, `boost.namespace`, `boost.name`, `boost.title`, `boost.description`, `boost.properties`, `boost.enums`, `boost.identifierTokens`). | options par défaut de `@ignfab/gpf-schema-store` |
 
 Exemple :
 
 ```bash
-export GPF_WFS_SEARCH_OPTIONS='{"fuzzy":0.05,"boost":{"title":4,"name":5}}'
+export GPF_WFS_MINISEARCH_OPTIONS='{"fields":["title","identifierTokens"],"combineWith":"OR","fuzzy":0.05,"boost":{"title":4,"name":5}}'
 ```
 
-Si `GPF_WFS_SEARCH_OPTIONS` est absent ou vide, les options par défaut restent celles de `@ignfab/gpf-schema-store`.
+Si `GPF_WFS_MINISEARCH_OPTIONS` est absent ou vide, les options par défaut restent celles de `@ignfab/gpf-schema-store`, y compris le comportement par défaut `OR` de MiniSearch pour `combineWith`.
 
 Remarque :
 
@@ -151,7 +174,7 @@ L'idée est ici de répondre à des précises en traitant côté serveur les app
 #### Explorer les tables
 
 * [gpf_wfs_list_types()](src/tools/GpfWfsListTypesTool.ts) pour **lister les tables connues du catalogue de schémas embarqué** - **déprécié (trop de résultats)**
-* [gpf_wfs_search_types(keywords,max_results=10)](src/tools/GpfWfsSearchTypesTool.ts) pour **rechercher des tables dans le catalogue de schémas embarqué**. La recherche est textuelle et configurable via `GPF_WFS_SEARCH_OPTIONS`.
+* [gpf_wfs_search_types(keywords,max_results=10)](src/tools/GpfWfsSearchTypesTool.ts) pour **rechercher des tables dans le catalogue de schémas embarqué**. La recherche est textuelle et configurable via `GPF_WFS_MINISEARCH_OPTIONS`.
 
 > - Quels sont les millésimes ADMINEXPRESS disponibles sur la Géoplateforme?
 > - Quelle est la table de la BDTOPO correspondant aux bâtiments?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@ignfab/geocontext",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ignfab/geocontext",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",
-        "@ignfab/gpf-schema-store": "^0.1.0",
+        "@ignfab/gpf-schema-store": "^0.1.1",
         "https-proxy-agent": "^7.0.6",
         "jsts": "^2.12.1",
         "lodash": "^4.17.21",
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@ignfab/gpf-schema-store": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ignfab/gpf-schema-store/-/gpf-schema-store-0.1.0.tgz",
-      "integrity": "sha512-R6W+GuHG9Y63b17QrpN8TTJF0cBt9o5yQI/Q0+PwLPblXS+Yljr2/qEs8A/Ly+r3qDutvtqjLJscERKX4xv9GQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@ignfab/gpf-schema-store/-/gpf-schema-store-0.1.1.tgz",
+      "integrity": "sha512-Q2Do3nEzyVuMk+5jCvfXV2vrCYGCZl/8wZeTKEDFVpaX8rg/4yMuhyIStkOkpHOGBGbrbrq22qNjaybUrIbdkQ==",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "https-proxy-agent": "^7.0.6",
         "jsts": "^2.12.1",
         "lodash": "^4.17.21",
-        "mcp-framework": "^0.2.17",
+        "mcp-framework": "^0.2.21",
         "node-fetch": "^3.3.2",
         "winston": "^3.18.3",
         "zod": "^3.25.76"
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3098,9 +3098,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3598,9 +3598,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4920,9 +4920,9 @@
       }
     },
     "node_modules/mcp-framework": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/mcp-framework/-/mcp-framework-0.2.18.tgz",
-      "integrity": "sha512-CXaVUdOgwO8oBgFA6YxPjsaB5kZvtNzeYwHVoai51JP528aDlGvgtMP5mIQS5TwxR/XTybiAPfz9/nR7KhBH3g==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/mcp-framework/-/mcp-framework-0.2.21.tgz",
+      "integrity": "sha512-Djd+jkZlIh0Nd6d/89svv/aY26+eQ6F5SXSw+vFz+vL2thTTUVyrFIVvRgnh5nfKqZP6RvoTnQ1nHkLZ0xT5zQ==",
       "dependencies": {
         "@types/prompts": "^2.4.9",
         "commander": "^12.1.0",
@@ -4935,7 +4935,7 @@
         "prompts": "^2.4.2",
         "raw-body": "^2.5.2",
         "typescript": "^5.3.3",
-        "zod": "^3.23.8"
+        "zod": "3.x"
       },
       "bin": {
         "mcp": "dist/cli/index.js",
@@ -4945,7 +4945,8 @@
         "node": ">=18.19.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "3.x"
       }
     },
     "node_modules/mcp-framework/node_modules/commander": {
@@ -5661,9 +5662,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "dependencies": {
     "@camptocamp/ogc-client": "^1.3.0",
-    "@ignfab/gpf-schema-store": "^0.1.0",
+    "@ignfab/gpf-schema-store": "^0.1.1",
     "https-proxy-agent": "^7.0.6",
     "jsts": "^2.12.1",
     "lodash": "^4.17.21",
-    "mcp-framework": "^0.2.17",
+    "mcp-framework": "^0.2.21",
     "node-fetch": "^3.3.2",
     "winston": "^3.18.3",
     "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignfab/geocontext",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "An experimental MCP server providing spatial context for LLM.",
   "type": "module",
   "bin": {

--- a/src/gpf/wfs.ts
+++ b/src/gpf/wfs.ts
@@ -4,37 +4,46 @@ import {
     Collection,
     getCollectionCatalog,
     MiniSearchCollectionSearchEngine,
-    MiniSearchCollectionSearchEngineOptions,
+    MiniSearchCollectionSearchOptions,
 } from '@ignfab/gpf-schema-store';
 
 // --- Constants ---
 
 export const GPF_WFS_URL = "https://data.geopf.fr/wfs";
 
-// Environment variable used to inject search engine options at runtime (JSON string).
-const GPF_WFS_SEARCH_OPTIONS_ENV = "GPF_WFS_SEARCH_OPTIONS";
+// Environment variable used to inject MiniSearch options at runtime (JSON string).
+const GPF_WFS_MINISEARCH_OPTIONS_ENV = "GPF_WFS_MINISEARCH_OPTIONS";
 
 // Keys accepted at the top level of the search options object.
-const TOP_LEVEL_SEARCH_OPTION_KEYS = ["fuzzy", "boost"] as const;
+const TOP_LEVEL_MINISEARCH_OPTION_KEYS = ["fields", "combineWith", "fuzzy", "boost"] as const;
 
-// Keys accepted inside the nested `boost` object.
-const BOOST_SEARCH_OPTION_KEYS = [
+// Shared keys used by both `fields` and `boost` in MiniSearchCollectionSearchOptions.
+const MINISEARCH_INDEXED_OPTION_KEYS = [
     "namespace",
     "name",
     "title",
     "description",
     "properties",
+    "enums",
+    "identifierTokens",
 ] as const;
+
+const MINISEARCH_FIELD_OPTION_KEYS = MINISEARCH_INDEXED_OPTION_KEYS;
+const MINISEARCH_COMBINE_WITH_VALUES = ["AND", "OR"] as const;
+const MINISEARCH_BOOST_OPTION_KEYS = MINISEARCH_INDEXED_OPTION_KEYS;
 
 // --- Types ---
 
-type BoostSearchOptionKey = typeof BOOST_SEARCH_OPTION_KEYS[number];
+type MiniSearchFieldOptionKey = typeof MINISEARCH_FIELD_OPTION_KEYS[number];
+type MiniSearchBoostOptionKey = typeof MINISEARCH_BOOST_OPTION_KEYS[number];
+type MiniSearchOptions = MiniSearchCollectionSearchOptions;
 
 // --- Errors ---
 
 export class FeatureTypeNotFoundError extends Error {
     constructor(name: string) {
         super(`Type '${name}' not found`);
+        this.name = "FeatureTypeNotFoundError";
     }
 }
 
@@ -49,25 +58,53 @@ function isFiniteNumber(value: unknown): value is number {
 }
 
 function invalidSearchOptionsError(reason: string): Error {
-    return new Error(`Invalid ${GPF_WFS_SEARCH_OPTIONS_ENV}: ${reason}`);
+    return new Error(`Invalid ${GPF_WFS_MINISEARCH_OPTIONS_ENV}: ${reason}`);
 }
 
 // --- Search options parsing ---
 
-// Parses and validates a plain-object value into MiniSearchCollectionSearchEngineOptions.
+// Parses and validates a plain-object value into MiniSearchCollectionSearchOptions.
 // Throws a descriptive error if the value has unexpected keys or wrong value types.
-function parseSearchOptions(value: unknown): MiniSearchCollectionSearchEngineOptions {
+function parseMiniSearchOptions(value: unknown): MiniSearchOptions {
     if (!isPlainObject(value)) {
         throw invalidSearchOptionsError("expected a JSON object");
     }
 
     for (const key of Object.keys(value)) {
-        if (!TOP_LEVEL_SEARCH_OPTION_KEYS.includes(key as typeof TOP_LEVEL_SEARCH_OPTION_KEYS[number])) {
+        if (!TOP_LEVEL_MINISEARCH_OPTION_KEYS.includes(key as typeof TOP_LEVEL_MINISEARCH_OPTION_KEYS[number])) {
             throw invalidSearchOptionsError(`unexpected key '${key}'`);
         }
     }
 
-    const options: MiniSearchCollectionSearchEngineOptions = {};
+    const options: MiniSearchOptions = {};
+
+    if (value.fields !== undefined) {
+        if (!Array.isArray(value.fields)) {
+            throw invalidSearchOptionsError("expected 'fields' to be an array");
+        }
+        const fields: MiniSearchFieldOptionKey[] = [];
+        for (const field of value.fields) {
+            if (typeof field !== "string") {
+                throw invalidSearchOptionsError("expected every 'fields' item to be a string");
+            }
+            if (!MINISEARCH_FIELD_OPTION_KEYS.includes(field as MiniSearchFieldOptionKey)) {
+                throw invalidSearchOptionsError(`unexpected value 'fields.${field}'`);
+            }
+            fields.push(field as MiniSearchFieldOptionKey);
+        }
+        options.fields = fields;
+    }
+
+    if (value.combineWith !== undefined) {
+        if (typeof value.combineWith !== "string") {
+            throw invalidSearchOptionsError("expected 'combineWith' to be a string");
+        }
+        const combineWith = value.combineWith as typeof MINISEARCH_COMBINE_WITH_VALUES[number];
+        if (!MINISEARCH_COMBINE_WITH_VALUES.includes(combineWith)) {
+            throw invalidSearchOptionsError("expected 'combineWith' to be 'AND' or 'OR'");
+        }
+        options.combineWith = combineWith;
+    }
 
     if (value.fuzzy !== undefined) {
         if (!isFiniteNumber(value.fuzzy)) {
@@ -81,16 +118,16 @@ function parseSearchOptions(value: unknown): MiniSearchCollectionSearchEngineOpt
             throw invalidSearchOptionsError("expected 'boost' to be an object");
         }
 
-        const boost: Partial<Record<BoostSearchOptionKey, number>> = {};
+        const boost: Partial<Record<MiniSearchBoostOptionKey, number>> = {};
         for (const key of Object.keys(value.boost)) {
-            if (!BOOST_SEARCH_OPTION_KEYS.includes(key as BoostSearchOptionKey)) {
+            if (!MINISEARCH_BOOST_OPTION_KEYS.includes(key as MiniSearchBoostOptionKey)) {
                 throw invalidSearchOptionsError(`unexpected key 'boost.${key}'`);
             }
             const rawScore = value.boost[key];
             if (!isFiniteNumber(rawScore)) {
                 throw invalidSearchOptionsError(`expected 'boost.${key}' to be a finite number`);
             }
-            boost[key as BoostSearchOptionKey] = rawScore;
+            boost[key as MiniSearchBoostOptionKey] = rawScore;
         }
         options.boost = boost;
     }
@@ -98,10 +135,20 @@ function parseSearchOptions(value: unknown): MiniSearchCollectionSearchEngineOpt
     return options;
 }
 
-// Reads search options from the GPF_WFS_SEARCH_OPTIONS environment variable.
+function createMiniSearchEngineOptions(miniSearch?: MiniSearchOptions) {
+    if (!miniSearch) {
+        return undefined;
+    }
+
+    return {
+        defaultSearchOptions: miniSearch,
+    };
+}
+
+// Reads MiniSearch options from the GPF_WFS_MINISEARCH_OPTIONS environment variable.
 // Returns undefined when the variable is absent or empty.
-export function loadSearchOptionsFromEnv(): MiniSearchCollectionSearchEngineOptions | undefined {
-    const rawValue = process.env[GPF_WFS_SEARCH_OPTIONS_ENV];
+export function loadMiniSearchOptionsFromEnv(): MiniSearchOptions | undefined {
+    const rawValue = process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV];
     if (!rawValue || rawValue.trim() === "") {
         return undefined;
     }
@@ -114,7 +161,7 @@ export function loadSearchOptionsFromEnv(): MiniSearchCollectionSearchEngineOpti
         throw invalidSearchOptionsError(`expected valid JSON (${reason})`);
     }
 
-    return parseSearchOptions(parsedValue);
+    return parseMiniSearchOptions(parsedValue);
 }
 
 // --- WFS client ---
@@ -125,10 +172,11 @@ export class WfsClient {
 
     constructor(
         public baseUrl: string = GPF_WFS_URL,
-        options: { search?: MiniSearchCollectionSearchEngineOptions } = {},
+        options: { miniSearch?: MiniSearchOptions } = {},
     ) {
+        const searchEngineOptions = createMiniSearchEngineOptions(options.miniSearch);
         this.catalog = getCollectionCatalog({
-            engineFactory: (items) => new MiniSearchCollectionSearchEngine(items, options.search),
+            engineFactory: (items) => new MiniSearchCollectionSearchEngine(items, searchEngineOptions),
         });
     }
 
@@ -139,7 +187,6 @@ export class WfsClient {
     async searchFeatureTypes(query: string, maxResults: number = 20): Promise<Collection[]> {
         return this.catalog.search(query, {
             limit: maxResults,
-            combineWith: 'AND',
         });
     }
 
@@ -155,7 +202,7 @@ export class WfsClient {
 
 // --- Default singleton ---
 
-// Pre-configured client using the default GPF endpoint and optional env-based search options.
+// Pre-configured client using the default GPF endpoint and optional env-based MiniSearch options.
 export const wfsClient = new WfsClient(undefined, {
-    search: loadSearchOptionsFromEnv(),
+    miniSearch: loadMiniSearchOptionsFromEnv(),
 });

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -23,12 +23,14 @@ class GpfWfsDescribeTypeTool extends MCPTool<GpfWfsDescribeTypeInput> {
   async execute(input: GpfWfsDescribeTypeInput) {
     try {
       return await wfsClient.getFeatureType(input.typename);
-    }catch(e){
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+
       return {
         type: "error",
-        message: e.message,
-        help: `Utiliser gpf_get_feature_types pour trouver les types disponibles`
-      }
+        message,
+        help: "Utiliser gpf_wfs_search_types pour trouver les types disponibles",
+      };
     }
   }
 }

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -9,7 +9,8 @@ interface GpfWfsDescribeTypeInput {
 class GpfWfsDescribeTypeTool extends MCPTool<GpfWfsDescribeTypeInput> {
   name = "gpf_wfs_describe_type";
   description = [
-    "Renvoie la description détaillée d'un type WFS donné par son nom fourni par gpf_wfs_search_types.",
+    "Renvoie la description détaillée d'un type WFS (propriétés, géométrie, valeurs possibles) à partir de son nom fourni par gpf_wfs_search_types.",
+    "NB : gpf_wfs_search_types renvoie déjà le titre et la description du type ; utiliser cet outil uniquement pour obtenir la liste des propriétés.",
   ].join("\r\n");
 
   schema = {

--- a/src/tools/GpfWfsListTypesTool.ts
+++ b/src/tools/GpfWfsListTypesTool.ts
@@ -19,8 +19,11 @@ class GpfWfsListTypesTools extends MCPTool<WfsTypesInput> {
 
   async execute(input: WfsTypesInput) {
     const featureTypes = await wfsClient.getFeatureTypes();
-    const featureTypeNames = featureTypes.map((featureType) => featureType.id);
-    return featureTypeNames;
+    return featureTypes.map((featureType) => ({
+      id: featureType.id,
+      title: featureType.title,
+      description: featureType.description,
+    }));
   }
 }
 

--- a/src/tools/GpfWfsSearchTypesTool.ts
+++ b/src/tools/GpfWfsSearchTypesTool.ts
@@ -31,8 +31,11 @@ class GpfWfsSearchTypesTool extends MCPTool<GpfWfsSearchTypesInput> {
   async execute(input: GpfWfsSearchTypesInput) {
     const maxResults = input.max_results || 10;
     const featureTypes = await wfsClient.searchFeatureTypes(input.query, maxResults);
-    const featureTypeNames = featureTypes.map((featureType) => featureType.id);
-    return featureTypeNames;
+    return featureTypes.map((featureType) => ({
+      id: featureType.id,
+      title: featureType.title,
+      description: featureType.description,
+    }));
   }
 }
 

--- a/test/gpf/wfs.test.ts
+++ b/test/gpf/wfs.test.ts
@@ -1,30 +1,32 @@
-import { FeatureTypeNotFoundError, WfsClient, wfsClient, loadSearchOptionsFromEnv } from "../../src/gpf/wfs";
+import { FeatureTypeNotFoundError, WfsClient, wfsClient, loadMiniSearchOptionsFromEnv } from "../../src/gpf/wfs";
 
-const GPF_WFS_SEARCH_OPTIONS_ENV = "GPF_WFS_SEARCH_OPTIONS";
+const GPF_WFS_MINISEARCH_OPTIONS_ENV = "GPF_WFS_MINISEARCH_OPTIONS";
 
 describe("Test WfsClient",() => {
-    let previousSearchOptionsEnv: string | undefined;
+    let previousMiniSearchOptionsEnv: string | undefined;
 
     beforeEach(() => {
-        previousSearchOptionsEnv = process.env[GPF_WFS_SEARCH_OPTIONS_ENV];
-        delete process.env[GPF_WFS_SEARCH_OPTIONS_ENV];
+        previousMiniSearchOptionsEnv = process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV];
+        delete process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV];
     });
 
     afterEach(() => {
-        if (previousSearchOptionsEnv === undefined) {
-            delete process.env[GPF_WFS_SEARCH_OPTIONS_ENV];
+        if (previousMiniSearchOptionsEnv === undefined) {
+            delete process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV];
             return;
         }
-        process.env[GPF_WFS_SEARCH_OPTIONS_ENV] = previousSearchOptionsEnv;
+        process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = previousMiniSearchOptionsEnv;
     });
 
-    describe("loadSearchOptionsFromEnv", () => {
+    describe("loadMiniSearchOptionsFromEnv", () => {
         it("should return undefined when env var is not set", () => {
-            expect(loadSearchOptionsFromEnv()).toBeUndefined();
+            expect(loadMiniSearchOptionsFromEnv()).toBeUndefined();
         });
 
         it("should parse valid JSON options", () => {
-            process.env[GPF_WFS_SEARCH_OPTIONS_ENV] = JSON.stringify({
+            process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = JSON.stringify({
+                fields: ["title", "identifierTokens"],
+                combineWith: "OR",
                 fuzzy: 0.05,
                 boost: {
                     title: 4,
@@ -32,7 +34,9 @@ describe("Test WfsClient",() => {
                 },
             });
 
-            expect(loadSearchOptionsFromEnv()).toEqual({
+            expect(loadMiniSearchOptionsFromEnv()).toEqual({
+                fields: ["title", "identifierTokens"],
+                combineWith: "OR",
                 fuzzy: 0.05,
                 boost: {
                     title: 4,
@@ -42,24 +46,38 @@ describe("Test WfsClient",() => {
         });
 
         it("should throw on invalid JSON", () => {
-            process.env[GPF_WFS_SEARCH_OPTIONS_ENV] = '{"fuzzy":0.1';
-            expect(() => loadSearchOptionsFromEnv()).toThrow("Invalid GPF_WFS_SEARCH_OPTIONS");
+            process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = '{"fuzzy":0.1';
+            expect(() => loadMiniSearchOptionsFromEnv()).toThrow("Invalid GPF_WFS_MINISEARCH_OPTIONS");
         });
 
         it("should throw on invalid option keys", () => {
-            process.env[GPF_WFS_SEARCH_OPTIONS_ENV] = JSON.stringify({
+            process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = JSON.stringify({
                 unsupported: 1,
             });
-            expect(() => loadSearchOptionsFromEnv()).toThrow("unexpected key 'unsupported'");
+            expect(() => loadMiniSearchOptionsFromEnv()).toThrow("unexpected key 'unsupported'");
         });
 
         it("should throw on invalid option value types", () => {
-            process.env[GPF_WFS_SEARCH_OPTIONS_ENV] = JSON.stringify({
+            process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = JSON.stringify({
                 boost: {
                     title: "4",
                 },
             });
-            expect(() => loadSearchOptionsFromEnv()).toThrow("expected 'boost.title' to be a finite number");
+            expect(() => loadMiniSearchOptionsFromEnv()).toThrow("expected 'boost.title' to be a finite number");
+        });
+
+        it("should throw on invalid fields value", () => {
+            process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = JSON.stringify({
+                fields: ["title", "not_a_field"],
+            });
+            expect(() => loadMiniSearchOptionsFromEnv()).toThrow("unexpected value 'fields.not_a_field'");
+        });
+
+        it("should throw on invalid combineWith value", () => {
+            process.env[GPF_WFS_MINISEARCH_OPTIONS_ENV] = JSON.stringify({
+                combineWith: "XOR",
+            });
+            expect(() => loadMiniSearchOptionsFromEnv()).toThrow("expected 'combineWith' to be 'AND' or 'OR'");
         });
     });
 
@@ -93,7 +111,9 @@ describe("Test WfsClient",() => {
 
         it("should allow overriding search tuning in WfsClient constructor", async () => {
             const tuned = new WfsClient(undefined, {
-                search: {
+                miniSearch: {
+                    fields: ["title", "identifierTokens"],
+                    combineWith: "OR",
                     fuzzy: 0.1,
                     boost: { title: 4.0 },
                 }


### PR DESCRIPTION
Lié à #5 

## Contexte

Cette PR améliore l’exploration des types WFS exposés par le serveur MCP `geocontext`.

L’objectif principal est de rendre `gpf_wfs_search_types` plus utile pour un agent ou un utilisateur en renvoyant davantage de contexte sur les tables trouvées, tout en clarifiant la configuration de la recherche MiniSearch et la documentation associée.

## Changements principaux

- `gpf_wfs_search_types` renvoie désormais, pour chaque résultat, un objet contenant `id`, `title` et `description`.
- `gpf_wfs_list_types` a été aligné sur le même format de sortie pour exposer aussi `id`, `title` et `description`.
- `gpf_wfs_describe_type` a été repositionné comme outil de second niveau, à utiliser après `gpf_wfs_search_types` quand on a besoin du détail des propriétés, de la géométrie et des valeurs possibles.
- La description de `gpf_wfs_describe_type` a été précisée pour indiquer que `gpf_wfs_search_types` fournit déjà le titre et la description du type.
- La gestion d’erreur de `gpf_wfs_describe_type` a été durcie avec un traitement explicite de `unknown` dans le `catch`.
- Le message d’aide retourné en cas d’erreur a été corrigé pour pointer vers le bon tool : `gpf_wfs_search_types`.

## Configuration de la recherche

- La variable d’environnement `GPF_WFS_SEARCH_OPTIONS` a été renommée en `GPF_WFS_MINISEARCH_OPTIONS`.
- Le parsing et la validation des options MiniSearch ont été étendus.
- Les options supportées incluent désormais `fields`, `combineWith`, `fuzzy` et `boost`.
- Les champs autorisés pour l’indexation et le boost incluent aussi `enums` et `identifierTokens`.
- Le client WFS utilise maintenant explicitement des options MiniSearch structurées, au lieu d’un paramétrage plus limité.
- Le `combineWith: 'AND'` forcé dans `searchFeatureTypes` a été supprimé pour laisser le comportement être piloté par la configuration MiniSearch. ('OR' par défaut)

## Documentation

- Le `README` a été mis à jour pour documenter la nouvelle variable `GPF_WFS_MINISEARCH_OPTIONS`.
- Un exemple de configuration plus complet a été ajouté.
- La documentation d’installation locale a été enrichie avec un exemple de configuration `~/.codex/config.toml` pour Codex CLI / VS Code.
- Les descriptions des tools WFS ont été ajustées pour mieux refléter leur rôle et leur complémentarité.

## Tests

- Les tests autour de `loadMiniSearchOptionsFromEnv` ont été mis à jour.
- De nouveaux cas couvrent la validation de `fields` et `combineWith`.
- Les tests de configuration du `WfsClient` ont été adaptés au nouveau contrat `miniSearch`.

## Dépendances et version

- Bump de version en `0.9.1`.
- Mise à jour de `@ignfab/gpf-schema-store` en `^0.1.1`.
- Mise à jour de `mcp-framework` en `^0.2.21`.

## Impact attendu

- Les résultats de recherche WFS sont plus lisibles et plus exploitables par un LLM.
- La sélection d’un type WFS pertinent nécessite moins d’appels supplémentaires.
- La configuration de la recherche textuelle est plus explicite, plus souple et mieux documentée.
