### PR TITLE
HTTP error handling improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@ignfab/geocontext",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ignfab/geocontext",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",
-        "@ignfab/gpf-schema-store": "^0.1.1",
+        "@ignfab/gpf-schema-store": "^0.1.2",
+        "@rgrove/parse-xml": "^4.2.0",
         "https-proxy-agent": "^7.0.6",
         "jsts": "^2.12.1",
         "lodash": "^4.17.21",
@@ -649,9 +650,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -662,9 +663,9 @@
       }
     },
     "node_modules/@ignfab/gpf-schema-store": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@ignfab/gpf-schema-store/-/gpf-schema-store-0.1.1.tgz",
-      "integrity": "sha512-Q2Do3nEzyVuMk+5jCvfXV2vrCYGCZl/8wZeTKEDFVpaX8rg/4yMuhyIStkOkpHOGBGbrbrq22qNjaybUrIbdkQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ignfab/gpf-schema-store/-/gpf-schema-store-0.1.2.tgz",
+      "integrity": "sha512-kbtgvKJ8EurpXkTxZ6EnZqCmAAdvc2edhAr7LCgWMn7kFI7wqovN39X3HPKMoDVWBGvOTvW/vr2OrmOsrowffg==",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",
@@ -2122,9 +2123,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
-      "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
+      "version": "2.10.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2298,9 +2299,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001785",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
-      "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
+      "version": "1.0.30001786",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
+      "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
       "dev": true,
       "funding": [
         {
@@ -2775,9 +2776,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-      "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2824,9 +2825,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.332",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
+      "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3600,9 +3601,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignfab/geocontext",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "An experimental MCP server providing access to the services and data of the french Geoplateform",
   "type": "module",
   "bin": {
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "@camptocamp/ogc-client": "^1.3.0",
-    "@ignfab/gpf-schema-store": "^0.1.1",
+    "@ignfab/gpf-schema-store": "^0.1.2",
+    "@rgrove/parse-xml": "^4.2.0",
     "https-proxy-agent": "^7.0.6",
     "jsts": "^2.12.1",
     "lodash": "^4.17.21",

--- a/src/helpers/http.js
+++ b/src/helpers/http.js
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import { parseXml, XmlElement } from '@rgrove/parse-xml';
 
 import logger from "../logger.js";
 
@@ -15,14 +16,116 @@ if ( process.env.HTTP_PROXY ){
     fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY); 
 }
 
+function getChild(element, localName) {
+    return element.children.find((child) => child instanceof XmlElement && child.name.split(":").pop() === localName) || null;
+}
+
+// Tente d'extraire un message d'erreur d'une réponse XML de type OGC WFS
+function extractXmlError(text) {
+    try {
+        const root = parseXml(text).children.find((child) => child instanceof XmlElement);
+        if (!root) {
+            return null;
+        }
+
+        const rootName = root.name.split(":").pop();
+        if (rootName !== "ExceptionReport" && rootName !== "ServiceExceptionReport") {
+            return null;
+        }
+
+        const exception = getChild(root, "Exception") || getChild(root, "ServiceException");
+        if (!exception) {
+            return null;
+        }
+
+        const code = exception.attributes?.exceptionCode || exception.attributes?.code;
+        const message = getChild(exception, "ExceptionText")?.text?.trim() || exception.text?.trim() || "";
+        const errorMessage = [code, message].filter(Boolean).join(": ");
+        return errorMessage ? new Error(errorMessage) : null;
+    } catch {
+        return null;
+    }
+}
+
+function previewBody(text) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+        return "";
+    }
+
+    return trimmed.replace(/\s+/g, " ").slice(0, 200);
+}
+
+export async function parseJsonResponse(res) {
+    const contentType = (res.headers?.get?.("content-type") || "").toLowerCase();
+    const text = await res.text();
+    const looksLikeXml = contentType.includes("xml") || text.trim().startsWith("<");
+    const responseLabel = [res.status, res.statusText].filter(Boolean).join(" ") || "réponse HTTP";
+    const hasValidStatus = Number.isFinite(res.status);
+    const isOk = typeof res.ok === "boolean"
+        ? res.ok
+        : hasValidStatus && res.status >= 200 && res.status < 300;
+
+    if (text.trim() === "") {
+        throw new Error(`Réponse vide du service (${responseLabel})`);
+    }
+
+    if (looksLikeXml) {
+        const xmlError = extractXmlError(text);
+
+        if (xmlError) {
+            if (!isOk) {
+                throw new Error(`Erreur HTTP du service (${responseLabel}): ${xmlError.message}`);
+            }
+            throw xmlError;
+        }
+
+        const details = [`content-type=${contentType || "inconnu"}`];
+        const bodyPreview = previewBody(text);
+        if (bodyPreview) {
+            details.push(`extrait=${bodyPreview}`);
+        }
+
+        throw new Error(`Réponse XML non exploitable du service (${responseLabel}, ${details.join(", ")})`);
+    }
+
+    let json;
+    try {
+        json = JSON.parse(text);
+    } catch {
+        const details = [`content-type=${contentType || "inconnu"}`];
+        const bodyPreview = previewBody(text);
+        if (bodyPreview) {
+            details.push(`extrait=${bodyPreview}`);
+        }
+
+        throw new Error(`Réponse JSON invalide du service (${responseLabel}, ${details.join(", ")})`);
+    }
+
+    if (!isOk) {
+        const errorMessage = json?.message
+            || json?.error
+            || json?.errorMessage
+            || json?.msg
+            || json?.title
+            || json?.detail
+            || (typeof json === "string" ? json : previewBody(JSON.stringify(json)));
+        throw new Error(`Erreur HTTP du service (${responseLabel}): ${errorMessage}`);
+    }
+
+    return json;
+}
+
 /**
+ * Fetches and parses a JSON response from a URL
+ * TODO : Add a timeout
  * 
  * @param {string} url 
  * @returns {Promise<any>}
  */
 export async function fetchJSON(url) {
     logger.info(`[HTTP] GET ${url} ...`);
-    const result = await fetch(url, fetchOpts).then(res => res.json());
+    const result = await fetch(url, fetchOpts).then(parseJsonResponse);
     logger.debug(`[HTTP] GET ${url} : ${JSON.stringify(result)}`)
     return result;
 }

--- a/test/helpers/http.test.ts
+++ b/test/helpers/http.test.ts
@@ -1,0 +1,108 @@
+import { parseJsonResponse } from "../../src/helpers/http.js";
+
+function createResponse(
+    body: string,
+    contentType = "application/json",
+    {
+        status = 200,
+        statusText = "OK",
+        ok,
+        includeOk = true,
+    }: { status?: number; statusText?: string; ok?: boolean; includeOk?: boolean } = {}
+) {
+    return {
+        status,
+        statusText,
+        ...(includeOk ? { ok: ok ?? (status >= 200 && status < 300) } : {}),
+        headers: {
+            get(name: string) {
+                return name.toLowerCase() === "content-type" ? contentType : null;
+            },
+        },
+        async text() {
+            return body;
+        },
+    };
+}
+
+describe("Test HTTP helpers", () => {
+    it("should parse JSON responses", async () => {
+        await expect(parseJsonResponse(createResponse('{"ok":true}'))).resolves.toEqual({ ok: true });
+    });
+
+    it("should extract OGC XML errors", async () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1">
+  <ows:Exception exceptionCode="InvalidParameterValue">
+    <ows:ExceptionText>Illegal property name: geom</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>`;
+
+        await expect(parseJsonResponse(createResponse(xml, "application/xml"))).rejects.toThrow(
+            "InvalidParameterValue: Illegal property name: geom"
+        );
+    });
+
+    it("should fail explicitly on empty responses", async () => {
+        await expect(parseJsonResponse(createResponse(""))).rejects.toThrow(
+            "Réponse vide du service (200 OK)"
+        );
+    });
+
+    it("should fail explicitly on non exploitable XML responses", async () => {
+        const xml = `<FeatureCollection><feature /></FeatureCollection>`;
+
+        await expect(parseJsonResponse(createResponse(xml, "application/xml"))).rejects.toThrow(
+            "Réponse XML non exploitable du service (200 OK, content-type=application/xml, extrait=<FeatureCollection><feature /></FeatureCollection>)"
+        );
+    });
+
+    it("should fail explicitly on invalid JSON responses", async () => {
+        await expect(parseJsonResponse(createResponse("not-json", "text/plain"))).rejects.toThrow(
+            "Réponse JSON invalide du service (200 OK, content-type=text/plain, extrait=not-json)"
+        );
+    });
+
+    it("should reject non-2xx JSON responses with their message", async () => {
+        await expect(
+            parseJsonResponse(
+                createResponse('{"message":"bad filter"}', "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toThrow("Erreur HTTP du service (400 Bad Request): bad filter");
+    });
+
+    it("should reject responses with invalid status when ok is absent", async () => {
+        await expect(
+            parseJsonResponse(
+                createResponse('{"message":"bad filter"}', "application/json", {
+                    status: Number.NaN,
+                    statusText: "Bad Request",
+                    includeOk: false,
+                })
+            )
+        ).rejects.toThrow("Erreur HTTP du service (Bad Request): bad filter");
+    });
+
+    it("should reject non-2xx XML responses with extracted OGC errors", async () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1">
+  <ows:Exception exceptionCode="InvalidParameterValue">
+    <ows:ExceptionText>Illegal property name: geom</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>`;
+
+        await expect(
+            parseJsonResponse(
+                createResponse(xml, "application/xml", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toThrow(
+            "Erreur HTTP du service (400 Bad Request): InvalidParameterValue: Illegal property name: geom"
+        );
+    });
+});


### PR DESCRIPTION
closes #29 

Improve HTTP/WFS error handling in `fetchJSON`

## Context

Some WFS requests can return XML error payloads while the code expects JSON. In those cases, the error surfaced to the caller was either unclear or misleading.

## Changes

- improve the HTTP helper to better inspect non-JSON responses
- detect and extract OGC/WFS XML errors (`ExceptionReport`, `ServiceExceptionReport`)
- return clearer error messages when the service responds with:
  - a non-usable XML response
  - invalid JSON
  - an empty response
  - an HTTP error with a JSON payload
- fix the fallback logic around `res.ok` / `res.status`
- add unit tests covering the main error cases

## Impact

- clearer error messages for the MCP / LLM client
- fewer cases where an HTTP error response could be treated as a success
- more robust handling of unexpected WFS responses

## Tests

- added unit tests for `parseJsonResponse`
- targeted and full test suites both pass