### PR TITLE
Enforce strict input schemas

### DIFF
--- a/src/tools/AdminexpressTool.ts
+++ b/src/tools/AdminexpressTool.ts
@@ -16,7 +16,7 @@ const adminexpressInputSchema = z.object({
     .min(-90)
     .max(90)
     .describe("La latitude du point."),
-});
+}).strict();
 
 type AdminexpressInput = z.infer<typeof adminexpressInputSchema>;
 

--- a/src/tools/AltitudeTool.ts
+++ b/src/tools/AltitudeTool.ts
@@ -16,7 +16,7 @@ const altitudeInputSchema = z.object({
     .min(-90)
     .max(90)
     .describe("La latitude du point."),
-});
+}).strict();
 
 type AltitudeInput = z.infer<typeof altitudeInputSchema>;
 

--- a/src/tools/AssietteSupTool.ts
+++ b/src/tools/AssietteSupTool.ts
@@ -16,7 +16,7 @@ const assietteSupInputSchema = z.object({
     .min(-90)
     .max(90)
     .describe("La latitude du point."),
-});
+}).strict();
 
 type AssietteSupInput = z.infer<typeof assietteSupInputSchema>;
 

--- a/src/tools/CadastreTool.ts
+++ b/src/tools/CadastreTool.ts
@@ -16,7 +16,7 @@ const cadastreInputSchema = z.object({
     .min(-90)
     .max(90)
     .describe("La latitude du point."),
-});
+}).strict();
 
 type CadastreInput = z.infer<typeof cadastreInputSchema>;
 

--- a/src/tools/GeocodeTool.ts
+++ b/src/tools/GeocodeTool.ts
@@ -18,7 +18,7 @@ const geocodeInputSchema = z.object({
     .max(10)
     .optional()
     .describe("Le nombre maximum de résultats à retourner (entre 1 et 10). Défaut : 3."),
-});
+}).strict();
 
 type GeocodeInput = z.infer<typeof geocodeInputSchema>;
 

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -11,7 +11,7 @@ const gpfWfsDescribeTypeInputSchema = z.object({
     .trim()
     .min(1, "le nom du type ne doit pas être vide")
     .describe("Le nom du type (ex : BDTOPO_V3:batiment)"),
-});
+}).strict();
 
 type GpfWfsDescribeTypeInput = z.infer<typeof gpfWfsDescribeTypeInputSchema>;
 

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -53,7 +53,7 @@ const gpfWfsGetFeaturesInputSchema = z.object({
       "- `hits` : retourne uniquement le nombre total d'objets correspondant à la requête",
       "- `url` : retourne uniquement l'URL WFS construite pour la requête, utile pour inspection, débogage ou réutilisation côté client",
     ].join("\r\n"))
-});
+}).strict();
 
 type GpfWfsGetFeaturesInput = z.infer<typeof gpfWfsGetFeaturesInputSchema>;
 

--- a/src/tools/GpfWfsListTypesTool.ts
+++ b/src/tools/GpfWfsListTypesTool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { wfsClient } from "../gpf/wfs.js";
 
-const gpfWfsListTypesInputSchema = z.object({});
+const gpfWfsListTypesInputSchema = z.object({}).strict();
 
 type GpfWfsListTypesInput = z.infer<typeof gpfWfsListTypesInputSchema>;
 

--- a/src/tools/GpfWfsSearchTypesTool.ts
+++ b/src/tools/GpfWfsSearchTypesTool.ts
@@ -17,7 +17,7 @@ const gpfWfsSearchTypesInputSchema = z.object({
     .max(50)
     .optional()
     .describe("Le nombre maximum de résultats à retourner (entre 1 et 50). Défaut : 10."),
-});
+}).strict();
 
 type GpfWfsSearchTypesInput = z.infer<typeof gpfWfsSearchTypesInputSchema>;
 

--- a/src/tools/UrbanismeTool.ts
+++ b/src/tools/UrbanismeTool.ts
@@ -16,7 +16,7 @@ const urbanismeInputSchema = z.object({
     .min(-90)
     .max(90)
     .describe("La latitude du point."),
-});
+}).strict();
 
 type UrbanismeInput = z.infer<typeof urbanismeInputSchema>;
 

--- a/test/tools/strict-input.test.ts
+++ b/test/tools/strict-input.test.ts
@@ -1,0 +1,88 @@
+import AdminexpressTool from "../../src/tools/AdminexpressTool";
+import AltitudeTool from "../../src/tools/AltitudeTool";
+import AssietteSupTool from "../../src/tools/AssietteSupTool";
+import CadastreTool from "../../src/tools/CadastreTool";
+import GeocodeTool from "../../src/tools/GeocodeTool";
+import GpfWfsDescribeTypeTool from "../../src/tools/GpfWfsDescribeTypeTool";
+import GpfWfsGetFeaturesTool from "../../src/tools/GpfWfsGetFeaturesTool";
+import GpfWfsListTypesTool from "../../src/tools/GpfWfsListTypesTool";
+import GpfWfsSearchTypesTool from "../../src/tools/GpfWfsSearchTypesTool";
+import UrbanismeTool from "../../src/tools/UrbanismeTool";
+
+const strictInputCases = [
+  {
+    label: "AdminexpressTool",
+    tool: new AdminexpressTool(),
+    validArguments: { lon: 2.3522, lat: 48.8566 },
+  },
+  {
+    label: "AltitudeTool",
+    tool: new AltitudeTool(),
+    validArguments: { lon: 2.3522, lat: 48.8566 },
+  },
+  {
+    label: "AssietteSupTool",
+    tool: new AssietteSupTool(),
+    validArguments: { lon: 2.3522, lat: 48.8566 },
+  },
+  {
+    label: "CadastreTool",
+    tool: new CadastreTool(),
+    validArguments: { lon: 2.3522, lat: 48.8566 },
+  },
+  {
+    label: "GeocodeTool",
+    tool: new GeocodeTool(),
+    validArguments: { text: "10 rue de la Paix Paris" },
+  },
+  {
+    label: "GpfWfsDescribeTypeTool",
+    tool: new GpfWfsDescribeTypeTool(),
+    validArguments: { typename: "BDTOPO_V3:batiment" },
+  },
+  {
+    label: "GpfWfsGetFeaturesTool",
+    tool: new GpfWfsGetFeaturesTool(),
+    validArguments: { typename: "BDTOPO_V3:batiment" },
+  },
+  {
+    label: "GpfWfsListTypesTool",
+    tool: new GpfWfsListTypesTool(),
+    validArguments: {},
+  },
+  {
+    label: "GpfWfsSearchTypesTool",
+    tool: new GpfWfsSearchTypesTool(),
+    validArguments: { query: "batiment" },
+  },
+  {
+    label: "UrbanismeTool",
+    tool: new UrbanismeTool(),
+    validArguments: { lon: 2.3522, lat: 48.8566 },
+  },
+] as const;
+
+describe("Strict tool input schemas", () => {
+  it.each(strictInputCases)("should reject unexpected arguments for $label", async ({ tool, validArguments }) => {
+    const response = await tool.toolCall({
+      params: {
+        name: tool.name,
+        arguments: {
+          ...validArguments,
+          unexpected: "unexpected",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+    });
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toMatch(/unrecognized/i);
+    expect(textContent.text).toContain("unexpected");
+  });
+});


### PR DESCRIPTION
closes #31 

This pull request enforces strict input validation on all tool input schemas by using Zod's `.strict()` method, ensuring that any unexpected arguments are rejected. Additionally, a new test suite is added to verify that each tool properly rejects inputs containing unexpected fields.

**Input Schema Strictness:**

* Added `.strict()` to all tool input schemas in `src/tools`, so any unexpected properties in the input will now cause validation to fail. This change affects the following tools: `AdminexpressTool`, `AltitudeTool`, `AssietteSupTool`, `CadastreTool`, `GeocodeTool`, `GpfWfsDescribeTypeTool`, `GpfWfsGetFeaturesTool`, `GpfWfsListTypesTool`, `GpfWfsSearchTypesTool`, and `UrbanismeTool`.
**Testing:**

* Added a new test file `test/tools/strict-input.test.ts` that systematically checks each tool to ensure it rejects any input containing unexpected arguments, improving reliability and preventing silent acceptance of invalid data.