### PR TITLE
Describe Feature is skipped

### DIFF
--- a/src/helpers/wfs_internal/compile.ts
+++ b/src/helpers/wfs_internal/compile.ts
@@ -233,7 +233,8 @@ export function getGeometryProperty(featureType: Collection) {
 function getPropertyOrThrow(featureType: Collection, propertyName: string) {
   const property = featureType.properties.find((candidate) => candidate.name === propertyName);
   if (!property) {
-    throw new Error(`La propriété '${propertyName}' n'existe pas pour '${featureType.id}'. Utiliser une propriété parmi : ${getPropertyList(featureType)}.`);
+    //throw new Error(`La propriété '${propertyName}' n'existe pas pour '${featureType.id}'. Utiliser une propriété parmi : ${getPropertyList(featureType)}.`);
+    throw new Error(`La propriété '${propertyName}' n'existe pas pour '${featureType.id}'. Appelle \`gpf_wfs_describe_type\` pour obtenir la liste des propriétés disponibles.`);
   }
   return property;
 }

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -43,7 +43,7 @@ class GpfWfsDescribeTypeTool extends MCPTool<GpfWfsDescribeTypeInput> {
     "Renvoie le schéma détaillé d'un type WFS à partir de son identifiant (`typename`) : identifiants, description et liste des propriétés.",
     "Utiliser ce tool après `gpf_wfs_search_types` pour inspecter les propriétés disponibles avant d'appeler `gpf_wfs_get_features`.",
     "La sortie inclut notamment le type des propriétés, leur description, leurs valeurs possibles (`enum`) lorsqu'elles existent",
-    "**Appel fortement recommandé si les noms exacts des propriétés ne sont pas connus : un nom de propriété incorrect provoque une erreur**."
+    "**IMPORTANT: Appel fortement recommandé si les noms exacts des propriétés ne sont pas connus : un nom de propriété incorrect provoque une erreur**."
   ].join("\n");
   protected outputSchemaShape = gpfWfsDescribeTypeOutputSchema;
 

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -27,6 +27,8 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
     "Exemple bbox : `spatial_operator=\"bbox\"` avec `bbox_west`, `bbox_south`, `bbox_east`, `bbox_north` en `lon/lat`.",
     "Exemple distance : `spatial_operator=\"dwithin_point\"` avec `dwithin_lon`, `dwithin_lat`, `dwithin_distance_m`.",
     "Exemple réutilisation : `spatial_operator=\"intersects_feature\"` avec `intersects_feature_typename` et `intersects_feature_id` issus d'une `feature_ref`.",
+    "**OBLIGATOIRE : toujours appeler `gpf_wfs_describe_type` avant ce tool, sauf si `gpf_wfs_describe_type` a déjà été appelé pour ce même typename dans la conversation en cours.**",
+    "Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiques à chaque typename et diffèrent systématiquement des conventions habituelles (ex : pas de nom_officiel, navigabilite sans accent, etc.). Toute tentative sans appel préalable à `gpf_wfs_describe_type` **provoquera une erreur.**"
   ].join("\n");
 
   schema = gpfWfsGetFeaturesInputSchema;


### PR DESCRIPTION
closes #49 

This pull request clarifies and strengthens the guidance and error messages related to property name usage in WFS tools. It emphasizes the importance of calling `gpf_wfs_describe_type` before attempting to access feature properties, and updates error messages and documentation to prevent common mistakes.

**Error handling improvements:**

* Updated the error message in `getPropertyOrThrow` (in `compile.ts`) to explicitly instruct users to call `gpf_wfs_describe_type` for available property names, making troubleshooting clearer.

**Documentation and usage guidance:**

* In `GpfWfsGetFeaturesTool`, added a mandatory warning to always call `gpf_wfs_describe_type` before using the tool (unless already called for the same typename in the current conversation), and clarified that property names are not guessable and must be retrieved explicitly.
* In `GpfWfsDescribeTypeTool`, made the documentation more prominent by adding "**IMPORTANT:**" to the recommendation about calling the tool when property names are unknown.