### PR TITLE
gpf_wfs_get_feature_by_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Remarque :
 
 - Les outils `gpf_wfs_search_types` et `gpf_wfs_describe_type` s'appuient sur un catalogue de schémas embarqué fourni par `@ignfab/gpf-schema-store`.
 - L'outil `gpf_wfs_get_features` interroge toujours le service WFS de la Géoplateforme en direct.
+- L'outil `gpf_wfs_get_feature_by_id` interroge aussi le service WFS de la Géoplateforme en direct.
 - Le catalogue embarqué améliore la description des featureTypes mais il peut être légèrement décalé par rapport à l'état courant du WFS.
 
 ## Fonctionnalités
@@ -177,7 +178,7 @@ L'idée est ici de répondre à des précises en traitant côté serveur les app
 
 * [assiette_sup(lon,lat)](src/tools/AssietteSupTool.ts) permet de **récupérer les Servitude d'Utilité Publiques (SUP)**
 
-Les tools WFS orientés "objet" (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`) exposent un `feature_ref { typename, feature_id }` quand l'objet source est réutilisable tel quel dans un appel ultérieur à `gpf_wfs_get_features`, notamment avec `spatial_operator="intersects_feature"`.
+Les tools WFS orientés "objet" (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`) exposent un `feature_ref { typename, feature_id }` quand l'objet source est réutilisable tel quel dans un appel ultérieur à `gpf_wfs_get_feature_by_id` (exact match) ou `gpf_wfs_get_features` (par exemple avec `spatial_operator="intersects_feature"`).
 
 ### Explorer les données vecteurs
 
@@ -197,6 +198,18 @@ Les tools WFS orientés "objet" (`adminexpress`, `cadastre`, `urbanisme`, `assie
 > - Compare le modèle des communes entre ADMINEXPRESS-COG:2024 et ADMINEXPRESS-COG.LATEST
 
 #### Explorer les données des tables
+
+* [gpf_wfs_get_feature_by_id(typename,feature_id,...)](src/tools/GpfWfsGetFeatureByIdTool.ts) pour **récupérer exactement un objet WFS identifié par son `feature_id`**.
+
+Le tool accepte un contrat structuré :
+
+- `select` pour choisir les propriétés à renvoyer
+- `result_type="request"` pour récupérer la requête compilée en `POST` avec `get_url`
+- `result_type="results"` pour renvoyer une FeatureCollection normalisée contenant exactement un seul objet
+
+Exemple :
+
+- `typename="ADMINEXPRESS-COG.LATEST:commune", feature_id="commune.8952"`
 
 * [gpf_wfs_get_features(typename,...)](src/tools/GpfWfsGetFeaturesTool.ts) pour **récupérer les données d'une table** depuis le service WFS de la Géoplateforme sans écrire de CQL à la main.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1717,6 +1717,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,6 +1734,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1745,6 +1751,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,6 +1768,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1773,6 +1785,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1787,6 +1802,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1801,6 +1819,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1815,6 +1836,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/helpers/jsonSchema.ts
+++ b/src/helpers/jsonSchema.ts
@@ -1,5 +1,11 @@
 import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
 
+/**
+ * Converts a Zod input schema into an MCP-compatible JSON Schema for publication.
+ *
+ * Uses strict union emission and, for `z.pipe(...)`, publishes the pre-transform
+ * argument shape (the value callers must send), not the transformed output shape.
+ */
 export function generatePublishedInputSchema(schema: any) {
   return toJsonSchemaCompat(schema, {
     strictUnions: true,

--- a/src/helpers/wfs_internal/compile.ts
+++ b/src/helpers/wfs_internal/compile.ts
@@ -436,7 +436,7 @@ function compileOrderByClause(featureType: Collection, geometryProperty: Collect
  * @param propertyName Raw selected property name.
  * @returns The validated non-geometric property name.
  */
-function compileSelectProperty(featureType: Collection, geometryProperty: CollectionProperty, propertyName: string) {
+export function compileSelectProperty(featureType: Collection, geometryProperty: CollectionProperty, propertyName: string) {
   return ensureNonGeometryProperty(
     featureType,
     geometryProperty,

--- a/src/helpers/wfs_internal/request.ts
+++ b/src/helpers/wfs_internal/request.ts
@@ -108,3 +108,39 @@ export function buildReferenceGeometryRequest(typename: string, featureId: strin
     get_url: buildGetUrl(GPF_WFS_URL, query),
   };
 }
+
+/**
+ * Builds a GetFeature request targeting exactly one feature by its WFS `featureID`.
+ *
+ * @param typename Typename of the target layer.
+ * @param featureId Identifier of the target feature.
+ * @param propertyName Optional comma-separated property list.
+ * @returns A POST request split into base URL, query-string parameters, empty body, and optional GET variant.
+ */
+export function buildGetFeatureByIdRequest(
+  typename: string,
+  featureId: string,
+  propertyName?: string,
+): CompiledRequest {
+  const query: Record<string, string> = {
+    service: "WFS",
+    version: "2.0.0",
+    request: "GetFeature",
+    typeNames: typename,
+    outputFormat: "application/json",
+    featureID: featureId,
+    count: "2",
+  };
+
+  if (propertyName) {
+    query.propertyName = propertyName;
+  }
+
+  return {
+    method: "POST",
+    url: GPF_WFS_URL,
+    query,
+    body: "",
+    get_url: buildGetUrl(GPF_WFS_URL, query),
+  };
+}

--- a/src/helpers/wfs_internal/response.ts
+++ b/src/helpers/wfs_internal/response.ts
@@ -43,3 +43,36 @@ export function transformFeatureCollectionResponse(featureCollection: GenericFea
   const { crs: _crs, ...restCollection } = featureCollection;
   return { ...restCollection, features: transformedFeatures };
 }
+
+/**
+ * Transforms a FeatureCollection and injects the exact queried typename into each `feature_ref`.
+ *
+ * @param featureCollection Raw FeatureCollection returned by the WFS endpoint.
+ * @param typename Typename of the queried layer.
+ * @returns A transformed FeatureCollection whose `feature_ref` objects carry the exact typename.
+ */
+export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string) {
+  const transformed = transformFeatureCollectionResponse(featureCollection) as Record<string, unknown>;
+  if (!Array.isArray(transformed.features)) {
+    return transformed;
+  }
+
+  transformed.features = transformed.features.map((feature) => {
+    if (typeof feature !== "object" || feature === null || !("feature_ref" in feature)) {
+      return feature;
+    }
+    const featureRef = feature.feature_ref;
+    if (typeof featureRef !== "object" || featureRef === null) {
+      return feature;
+    }
+    return {
+      ...feature,
+      feature_ref: {
+        ...featureRef,
+        typename,
+      },
+    };
+  });
+
+  return transformed;
+}

--- a/src/tools/AdminexpressTool.ts
+++ b/src/tools/AdminexpressTool.ts
@@ -32,7 +32,8 @@ class AdminexpressTool extends MCPTool<AdminexpressInput> {
   description = [
     `Renvoie, pour un point donné par sa \`longitude\` et sa \`latitude\`, la liste des unités administratives (${ADMINEXPRESS_TYPES.join(", ")}) qui le couvrent, sous forme d'objets typés contenant leurs propriétés administratives.`,
     "Les résultats incluent un `feature_ref` WFS réutilisable. Les propriétés incluent notamment le code INSEE.",
-    "Le `feature_ref` de chaque unité administrative est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator=\"intersects_feature\"` pour interroger des données sur cette emprise.",
+    "Le `feature_ref` de chaque unité administrative est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator=\"intersects_feature\"` pour interroger d'autres données sur cette emprise.",
+    "Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.",
     `(source : ${ADMINEXPRESS_SOURCE}).`
   ].join("\n");
   protected outputSchemaShape = adminexpressOutputSchema;

--- a/src/tools/AssietteSupTool.ts
+++ b/src/tools/AssietteSupTool.ts
@@ -34,6 +34,7 @@ class AssietteSupTool extends MCPTool<AssietteSupInput> {
     "Renvoie, pour un point donné par sa longitude et sa latitude, la liste des assiettes de servitudes d'utilité publique (SUP) pertinentes à proximité, avec leurs propriétés associées.",
     "Une SUP est une contrainte légale sur l'usage du sol liée à un équipement ou une infrastructure publique (ex : AC pour patrimoine, EL pour voirie, PT pour télécoms, I pour installations classées...).",
     "Les résultats peuvent inclure des assiettes ponctuelles, linéaires ou surfaciques et exposent un `feature_ref` WFS réutilisable quand il est disponible.",
+    "Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.",
     `(source : ${URBANISME_SOURCE}).`
   ].join("\n");
   protected outputSchemaShape = assietteSupOutputSchema;

--- a/src/tools/CadastreTool.ts
+++ b/src/tools/CadastreTool.ts
@@ -37,6 +37,7 @@ class CadastreTool extends MCPTool<CadastreInput> {
     "Les résultats sont retournés au plus une fois par type lorsqu'ils sont disponibles et incluent un `feature_ref` WFS réutilisable.",
     "Le `feature_ref` est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator=\"intersects_feature\"`.",
     "La distance de recherche est fixée à 10 mètres.  Si aucun objet n'est trouvé dans les 10 mètres, le résultat est vide.",
+    "Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.",
     `(source : ${PARCELLAIRE_EXPRESS_SOURCE}).`
   ].join("\n");
   protected outputSchemaShape = cadastreOutputSchema;

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -1,0 +1,189 @@
+import { MCPTool } from "mcp-framework";
+import type { Collection } from "@ignfab/gpf-schema-store";
+import { z } from "zod";
+
+import { wfsClient } from "../gpf/wfs.js";
+import { fetchJSONPost } from "../helpers/http.js";
+import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
+import { generatePublishedInputSchema } from "../helpers/jsonSchema.js";
+import { compileSelectProperty, getGeometryProperty } from "../helpers/wfs_internal/compile.js";
+import { buildGetFeatureByIdRequest, type CompiledRequest } from "../helpers/wfs_internal/request.js";
+import { attachFeatureRefs } from "../helpers/wfs_internal/response.js";
+import { gpfWfsGetFeaturesRequestOutputSchema } from "../helpers/wfs_internal/schema.js";
+
+const gpfWfsGetFeatureByIdInputSchema = z.object({
+  typename: z
+    .string()
+    .trim()
+    .min(1, "le nom du type ne doit pas être vide")
+    .describe("Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`."),
+  feature_id: z
+    .string()
+    .trim()
+    .min(1, "le feature_id ne doit pas être vide")
+    .describe("Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`."),
+  result_type: z
+    .enum(["results", "request"])
+    .default("results")
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer."),
+  select: z
+    .array(z.string().trim().min(1))
+    .min(1)
+    .optional()
+    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée."),
+}).strict();
+
+type GpfWfsGetFeatureByIdInput = z.infer<typeof gpfWfsGetFeatureByIdInputSchema>;
+
+type PublishedInputSchema = {
+  type: "object";
+  properties?: Record<string, object>;
+  required?: string[];
+};
+
+const gpfWfsGetFeatureByIdPublishedInputSchema = generatePublishedInputSchema(gpfWfsGetFeatureByIdInputSchema) as PublishedInputSchema;
+
+class GpfWfsGetFeatureByIdTool extends MCPTool<GpfWfsGetFeatureByIdInput> {
+  name = "gpf_wfs_get_feature_by_id";
+  title = "Lecture d’un objet WFS par identifiant";
+  annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;
+  description = [
+    "Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.",
+    "Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).",
+    "Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.",
+    "Utiliser `result_type=\"request\"` pour récupérer la requête WFS compilée (avec `get_url`) et l'utiliser ou la visualiser ailleurs."
+  ].join("\n");
+
+  schema = gpfWfsGetFeatureByIdInputSchema;
+
+  /**
+   * Exposes an input schema variant that stays compatible with most MCP integrations.
+   *
+   * @returns The published input schema exposed through the MCP tool definition.
+   */
+  get inputSchema() {
+    return gpfWfsGetFeatureByIdPublishedInputSchema;
+  }
+
+  /**
+   * Formats compact responses (`request`) into `structuredContent`.
+   *
+   * @param data Raw execution result returned by the tool implementation.
+   * @returns An MCP success response, optionally enriched with structured content.
+   */
+  protected createSuccessResponse(data: unknown) {
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "result_type" in data &&
+      data.result_type === "request"
+    ) {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(data) }],
+        structuredContent: gpfWfsGetFeaturesRequestOutputSchema.parse(data),
+      };
+    }
+
+    return super.createSuccessResponse(data);
+  }
+
+  /**
+   * Loads a WFS feature type description from the embedded catalog.
+   *
+   * @param typename Exact WFS typename to load from the embedded schema store.
+   * @returns The matching feature type description.
+   */
+  protected async getFeatureType(typename: string) {
+    return wfsClient.getFeatureType(typename);
+  }
+
+  /**
+   * Executes a compiled WFS request as POST and returns the JSON FeatureCollection.
+   *
+   * @param request Compiled request split into query-string parameters and POST body.
+   * @returns The parsed JSON response returned by the WFS endpoint.
+   */
+  protected async fetchFeatureCollection(request: CompiledRequest) {
+    const url = `${request.url}?${new URLSearchParams(request.query).toString()}`;
+    return fetchJSONPost(url, request.body, {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
+    });
+  }
+
+  /**
+   * Builds the optional `propertyName` request parameter from `select`.
+   *
+   * @param featureType Feature type definition loaded from the embedded catalog.
+   * @param input Normalized tool input.
+   * @returns A comma-separated property list, or `undefined` when all properties should be returned.
+   */
+  protected buildPropertyName(featureType: Collection, input: GpfWfsGetFeatureByIdInput) {
+    if (!input.select || input.select.length === 0) {
+      return undefined;
+    }
+
+    const geometryProperty = getGeometryProperty(featureType);
+    const selectedProperties = input.select.map((propertyName) => compileSelectProperty(featureType, geometryProperty, propertyName));
+
+    if (input.result_type === "request") {
+      return [...selectedProperties, geometryProperty.name].join(",");
+    }
+
+    return selectedProperties.join(",");
+  }
+
+  /**
+   * Orchestrates the by-id execution flow:
+   * schema lookup -> request compilation -> optional request output -> WFS execution -> cardinality validation.
+   *
+   * @param input Normalized tool input.
+   * @returns Either a compiled request or a transformed FeatureCollection containing one feature.
+   */
+  async execute(input: GpfWfsGetFeatureByIdInput) {
+    const featureType: Collection = await this.getFeatureType(input.typename);
+    const propertyName = this.buildPropertyName(featureType, input);
+    const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);
+
+    if (input.result_type === "request") {
+      return {
+        result_type: "request" as const,
+        method: request.method,
+        url: request.url,
+        query: request.query,
+        body: request.body,
+        get_url: request.get_url ?? null,
+      };
+    }
+
+    const featureCollection = await this.fetchFeatureCollection(request);
+    if (!Array.isArray(featureCollection?.features)) {
+      throw new Error("Le service WFS n'a pas retourné de collection d'objets exploitable.");
+    }
+
+    if (featureCollection.features.length === 0) {
+      throw new Error(`Le feature '${input.feature_id}' est introuvable dans '${input.typename}'.`);
+    }
+
+    if (featureCollection.features.length > 1) {
+      throw new Error(`Le feature '${input.feature_id}' dans '${input.typename}' devrait être unique, mais ${featureCollection.features.length} objets ont été retournés.`);
+    }
+
+    const [firstFeature] = featureCollection.features;
+    if (firstFeature?.id !== input.feature_id) {
+      throw new Error(`Le service WFS a retourné l'identifiant '${String(firstFeature?.id)}' au lieu de '${input.feature_id}'.`);
+    }
+
+    const singleFeatureCollection = {
+      ...featureCollection,
+      features: [firstFeature],
+      totalFeatures: 1,
+      numberReturned: 1,
+      numberMatched: 1,
+    };
+
+    return attachFeatureRefs(singleFeatureCollection, input.typename);
+  }
+}
+
+export default GpfWfsGetFeatureByIdTool;

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -7,7 +7,7 @@ import logger from "../logger.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { compileQueryParts, geometryToEwkt, getGeometryProperty, getSpatialFilter } from "../helpers/wfs_internal/compile.js";
 import { buildMainRequest, buildReferenceGeometryRequest, type CompiledRequest } from "../helpers/wfs_internal/request.js";
-import { transformFeatureCollectionResponse } from "../helpers/wfs_internal/response.js";
+import { attachFeatureRefs } from "../helpers/wfs_internal/response.js";
 import {
   gpfWfsGetFeaturesHitsOutputSchema,
   gpfWfsGetFeaturesInputSchema,
@@ -27,6 +27,7 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
     "Exemple bbox : `spatial_operator=\"bbox\"` avec `bbox_west`, `bbox_south`, `bbox_east`, `bbox_north` en `lon/lat`.",
     "Exemple distance : `spatial_operator=\"dwithin_point\"` avec `dwithin_lon`, `dwithin_lat`, `dwithin_distance_m`.",
     "Exemple réutilisation : `spatial_operator=\"intersects_feature\"` avec `intersects_feature_typename` et `intersects_feature_id` issus d'une `feature_ref`.",
+    "⚠️ Quand `typename` et `intersects_feature_typename` sont identiques, utiliser `gpf_wfs_get_feature_by_id` pour récupérer exactement l'objet ciblé.",
     "**OBLIGATOIRE : toujours appeler `gpf_wfs_describe_type` avant ce tool, sauf si `gpf_wfs_describe_type` a déjà été appelé pour ce même typename dans la conversation en cours.**",
     "Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiques à chaque typename et diffèrent systématiquement des conventions habituelles (ex : pas de nom_officiel, navigabilite sans accent, etc.). Toute tentative sans appel préalable à `gpf_wfs_describe_type` **provoquera une erreur.**"
   ].join("\n");
@@ -124,41 +125,6 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
   }
 
   /**
-   * Enriches transformed features with a complete `feature_ref`, reusable
-   * in particular by `intersects_feature`.
-   *
-   * @param featureCollection Raw WFS FeatureCollection response.
-   * @param typename Typename of the main queried layer.
-   * @returns The transformed FeatureCollection with fully populated feature references.
-   */
-  protected attachFeatureRefs(featureCollection: Record<string, unknown>, typename: string) {
-    const transformed = transformFeatureCollectionResponse(featureCollection) as Record<string, unknown>;
-
-    if (!Array.isArray(transformed.features)) {
-      return transformed;
-    }
-
-    transformed.features = transformed.features.map((feature) => {
-      if (typeof feature !== "object" || feature === null || !("feature_ref" in feature)) {
-        return feature;
-      }
-      const featureRef = feature.feature_ref;
-      if (typeof featureRef !== "object" || featureRef === null) {
-        return feature;
-      }
-      return {
-        ...feature,
-        feature_ref: {
-          ...featureRef,
-          typename,
-        },
-      };
-    });
-
-    return transformed;
-  }
-
-  /**
    * Resolves the geometry of a reference feature when `intersects_feature` is used,
    * then converts it to EWKT for CQL compilation.
    *
@@ -202,6 +168,17 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
    * @returns Either a compiled request, a hit count, or a transformed FeatureCollection.
    */
   async execute(input: GpfWfsGetFeaturesInput) {
+    if (
+      input.spatial_operator === "intersects_feature" &&
+      input.intersects_feature_typename !== undefined &&
+      input.typename === input.intersects_feature_typename
+    ) {
+      throw new Error(
+        "Le filtre `intersects_feature` sur le même `typename` retourne potentiellement plusieurs objets. " +
+        "Utiliser `gpf_wfs_get_feature_by_id` avec `{ typename, feature_id: intersects_feature_id }` pour cibler exactement un objet."
+      );
+    }
+
     const featureType: Collection = await this.getFeatureType(input.typename);
     const resolvedGeometryRef = await this.resolveIntersectsFeatureGeometry(input);
     const compiled = compileQueryParts(input, featureType, resolvedGeometryRef);
@@ -237,7 +214,7 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
       };
     }
 
-    return this.attachFeatureRefs(featureCollection, input.typename);
+    return attachFeatureRefs(featureCollection, input.typename);
   }
 }
 

--- a/src/tools/UrbanismeTool.ts
+++ b/src/tools/UrbanismeTool.ts
@@ -31,6 +31,7 @@ const URBANISME_TOOL_DESCRIPTION = [
   "Les résultats peuvent notamment inclure le document d'urbanisme applicable ainsi que des éléments réglementaires associés à proximité du point.",
   "Quand un objet correspond à une couche WFS réutilisable, il expose aussi un `feature_ref` compatible avec `gpf_wfs_get_features` et `spatial_operator=\"intersects_feature\"`.",
   "Le zonage PLU (zone U, AU, A, N...) est inclus dans les zones retournées et constitue souvent l'information principale recherchée.",
+  "Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.",
   "Modèles d'URL Géoportail de l'Urbanisme :",
   "- fiche document: https://www.geoportail-urbanisme.gouv.fr/document/by-id/{gpu_doc_id}",
   "- carte: https://www.geoportail-urbanisme.gouv.fr/map/?documentId={gpu_doc_id}",

--- a/test/tools/strict-input.test.ts
+++ b/test/tools/strict-input.test.ts
@@ -4,6 +4,7 @@ import AssietteSupTool from "../../src/tools/AssietteSupTool";
 import CadastreTool from "../../src/tools/CadastreTool";
 import GeocodeTool from "../../src/tools/GeocodeTool";
 import GpfWfsDescribeTypeTool from "../../src/tools/GpfWfsDescribeTypeTool";
+import GpfWfsGetFeatureByIdTool from "../../src/tools/GpfWfsGetFeatureByIdTool";
 import GpfWfsGetFeaturesTool from "../../src/tools/GpfWfsGetFeaturesTool";
 import GpfWfsSearchTypesTool from "../../src/tools/GpfWfsSearchTypesTool";
 import UrbanismeTool from "../../src/tools/UrbanismeTool";
@@ -38,6 +39,14 @@ const strictInputCases = [
     label: "GpfWfsDescribeTypeTool",
     tool: new GpfWfsDescribeTypeTool(),
     validArguments: { typename: "BDTOPO_V3:batiment" },
+  },
+  {
+    label: "GpfWfsGetFeatureByIdTool",
+    tool: new GpfWfsGetFeatureByIdTool(),
+    validArguments: {
+      typename: "BDTOPO_V3:batiment",
+      feature_id: "batiment.1",
+    },
   },
   {
     label: "GpfWfsGetFeaturesTool",

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -1,0 +1,236 @@
+import type { Collection } from "@ignfab/gpf-schema-store";
+
+import GpfWfsGetFeatureByIdTool from "../../../src/tools/GpfWfsGetFeatureByIdTool";
+
+describe("Test GpfWfsGetFeatureByIdTool", () => {
+  class TestableGpfWfsGetFeatureByIdTool extends GpfWfsGetFeatureByIdTool {
+    public featureTypes: Record<string, Collection> = {};
+    public requests: Array<{ url: string; query: Record<string, string>; body: string }> = [];
+    public nextResponse: unknown = null;
+
+    protected async getFeatureType(typename: string) {
+      const featureType = this.featureTypes[typename];
+      if (!featureType) {
+        throw new Error(`unexpected typename ${typename}`);
+      }
+      return featureType;
+    }
+
+    protected async fetchFeatureCollection(request: { url: string; query: Record<string, string>; body: string }) {
+      this.requests.push(request);
+      return this.nextResponse;
+    }
+  }
+
+  const polygonFeatureType: Collection = {
+    id: "ADMINEXPRESS-COG.LATEST:commune",
+    namespace: "ADMINEXPRESS-COG.LATEST",
+    name: "commune",
+    title: "Commune",
+    description: "Description de test",
+    properties: [
+      { name: "code_insee", type: "string" },
+      { name: "nom_officiel", type: "string" },
+      { name: "geometrie", type: "multipolygon", defaultCrs: "EPSG:4326" },
+    ],
+  };
+
+  it("should expose an MCP definition with `results|request` result_type only", () => {
+    const tool = new GpfWfsGetFeatureByIdTool();
+    expect(tool.toolDefinition.title).toEqual("Lecture d’un objet WFS par identifiant");
+    expect(tool.toolDefinition.inputSchema.properties?.feature_id).toMatchObject({
+      type: "string",
+      minLength: 1,
+    });
+    expect(tool.toolDefinition.inputSchema.properties?.result_type).toMatchObject({
+      type: "string",
+      enum: ["results", "request"],
+    });
+  });
+
+  it("should return text content and structuredContent for request", async () => {
+    const tool = new TestableGpfWfsGetFeatureByIdTool();
+    tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          result_type: "request",
+          select: ["code_insee"],
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const request = JSON.parse(textContent.text);
+    expect(request.method).toEqual("POST");
+    expect(request.query.featureID).toEqual("commune.1");
+    expect(request.query.typeNames).toEqual("ADMINEXPRESS-COG.LATEST:commune");
+    expect(request.query.propertyName).toEqual("code_insee,geometrie");
+    expect(request.query.count).toEqual("2");
+    expect(response.structuredContent).toMatchObject({
+      result_type: "request",
+      method: "POST",
+    });
+  });
+
+  it("should return exactly one transformed feature for results", async () => {
+    const tool = new TestableGpfWfsGetFeatureByIdTool();
+    tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
+    tool.nextResponse = {
+      type: "FeatureCollection",
+      totalFeatures: 1,
+      features: [
+        {
+          type: "Feature",
+          id: "commune.1",
+          geometry: { type: "MultiPolygon", coordinates: [] },
+          geometry_name: "geometrie",
+          properties: {
+            code_insee: "01001",
+            nom_officiel: "L'Abergement-Clémenciat",
+          },
+        },
+      ],
+    };
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(tool.requests).toHaveLength(1);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const results = JSON.parse(textContent.text);
+    expect(results.totalFeatures).toEqual(1);
+    expect(results.numberMatched).toEqual(1);
+    expect(results.features).toHaveLength(1);
+    expect(results.features[0].geometry).toBeNull();
+    expect(results.features[0].feature_ref).toEqual({
+      typename: "ADMINEXPRESS-COG.LATEST:commune",
+      feature_id: "commune.1",
+    });
+    expect(results.features[0].geometry_name).toBeUndefined();
+  });
+
+  it("should fail clearly when the feature is missing", async () => {
+    const tool = new TestableGpfWfsGetFeatureByIdTool();
+    tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
+    tool.nextResponse = { type: "FeatureCollection", features: [], totalFeatures: 0 };
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.404",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("est introuvable");
+    expect(textContent.text).toContain("commune.404");
+  });
+
+  it("should fail clearly when multiple features are returned", async () => {
+    const tool = new TestableGpfWfsGetFeatureByIdTool();
+    tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
+    tool.nextResponse = {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", id: "commune.1", geometry: null, properties: {} },
+        { type: "Feature", id: "commune.2", geometry: null, properties: {} },
+      ],
+      totalFeatures: 2,
+    };
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("devrait être unique");
+  });
+
+  it("should fail clearly when the returned feature id mismatches", async () => {
+    const tool = new TestableGpfWfsGetFeatureByIdTool();
+    tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
+    tool.nextResponse = {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", id: "commune.2", geometry: null, properties: {} },
+      ],
+      totalFeatures: 1,
+    };
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("au lieu de");
+  });
+
+  it("should reject invalid result_type values such as hits", async () => {
+    const tool = new GpfWfsGetFeatureByIdTool();
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          result_type: "hits",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("results");
+    expect(textContent.text).toContain("request");
+  });
+});

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -424,6 +424,7 @@ describe("Test GpfWfsGetFeaturesTool",() => {
 
     it("should resolve intersects_feature from MultiPoint references", async () => {
         const tool = new TestableGpfWfsGetFeaturesTool();
+        tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
         tool.featureTypes[multipointFeatureType.id] = multipointFeatureType;
         tool.nextResponse = {
             type: "FeatureCollection",
@@ -442,7 +443,7 @@ describe("Test GpfWfsGetFeaturesTool",() => {
             params: {
                 name: "gpf_wfs_get_features",
                 arguments: {
-                    typename: "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:localisant",
+                    typename: "ADMINEXPRESS-COG.LATEST:commune",
                     spatial_operator: "intersects_feature",
                     intersects_feature_typename: "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:localisant",
                     intersects_feature_id: "localisant.1",
@@ -464,6 +465,7 @@ describe("Test GpfWfsGetFeaturesTool",() => {
     it("should report missing reference features clearly for intersects_feature", async () => {
         const tool = new TestableGpfWfsGetFeaturesTool();
         tool.featureTypes[polygonFeatureType.id] = polygonFeatureType;
+        tool.featureTypes[multipointFeatureType.id] = multipointFeatureType;
         tool.nextResponse = {
             type: "FeatureCollection",
             features: [],
@@ -476,8 +478,8 @@ describe("Test GpfWfsGetFeaturesTool",() => {
                 arguments: {
                     typename: "ADMINEXPRESS-COG.LATEST:commune",
                     spatial_operator: "intersects_feature",
-                    intersects_feature_typename: "ADMINEXPRESS-COG.LATEST:commune",
-                    intersects_feature_id: "commune.404",
+                    intersects_feature_typename: "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:localisant",
+                    intersects_feature_id: "localisant.404",
                 },
             },
         });
@@ -488,6 +490,31 @@ describe("Test GpfWfsGetFeaturesTool",() => {
             throw new Error("expected text content");
         }
         expect(textContent.text).toContain("est introuvable");
-        expect(textContent.text).toContain("commune.404");
+        expect(textContent.text).toContain("localisant.404");
+    });
+
+    it("should reject intersects_feature on the same typename and guide to by-id tool", async () => {
+        const tool = new TestableGpfWfsGetFeaturesTool();
+
+        const response = await tool.toolCall({
+            params: {
+                name: "gpf_wfs_get_features",
+                arguments: {
+                    typename: "ADMINEXPRESS-COG.LATEST:commune",
+                    spatial_operator: "intersects_feature",
+                    intersects_feature_typename: "ADMINEXPRESS-COG.LATEST:commune",
+                    intersects_feature_id: "commune.1",
+                },
+            },
+        });
+
+        expect(response.isError).toBe(true);
+        const textContent = response.content[0];
+        if (textContent.type !== "text") {
+            throw new Error("expected text content");
+        }
+        expect(textContent.text).toContain("gpf_wfs_get_feature_by_id");
+        expect(textContent.text).toContain("intersects_feature");
+        expect(tool.requests).toHaveLength(0);
     });
 });


### PR DESCRIPTION
closes #48 

### Summary
This PR introduces a new MCP tool, `gpf_wfs_get_feature_by_id`, to reliably fetch a single WFS feature by its exact identifier and avoid ambiguous same-layer spatial intersections.

### What changed
- Added `gpf_wfs_get_feature_by_id`:
  - Input: `typename`, `feature_id`, optional `select`, `result_type: results | request` (`hits` intentionally not supported).
  - Strict cardinality checks:
    - 0 result => explicit error
    - \>1 result => explicit error
    - returned ID mismatch => explicit error
- Added WFS request builder for by-id calls in `wfs_internal/request.ts`.
- Refactored shared response handling:
  - introduced `attachFeatureRefs(...)` in `wfs_internal/response.ts`.
- Reused existing property validation logic by exporting `compileSelectProperty(...)` from `wfs_internal/compile.ts`.
- Updated `gpf_wfs_get_features`:
  - rejects `intersects_feature` when `typename === intersects_feature_typename`
  - returns a guided error pointing to `gpf_wfs_get_feature_by_id`.
- Updated tool descriptions (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`) to strongly direct exact `feature_ref` reuse to `gpf_wfs_get_feature_by_id`.
- Updated README documentation for the new workflow.

### Tests
- Added dedicated test suite for `gpf_wfs_get_feature_by_id`.
- Extended strict input tests to include the new tool.
- Updated `gpf_wfs_get_features` tests to cover the new same-layer intersection guard and guidance behavior.

### Validation
- `npm run build` passes (tool definitions validated).
- `npm test` passes (all suites green).