### PR TITLE
Migrate remaining runtime source files from JavaScript to TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2376,9 +2376,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
         {
@@ -2902,9 +2902,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.341",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.341.tgz",
-      "integrity": "sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw==",
+      "version": "1.5.343",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
+      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5486,9 +5486,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ignfab/geocontext",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ignfab/geocontext",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "@ignfab/gpf-schema-store": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignfab/geocontext",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "An experimental MCP server providing access to the services and data of the french Geoplateform",
   "type": "module",
   "bin": {

--- a/src/gpf/adminexpress.ts
+++ b/src/gpf/adminexpress.ts
@@ -1,6 +1,10 @@
 import { fetchWfsFeatures, mapWfsFeature } from '../helpers/wfs.js';
 import logger from '../logger.js';
 
+type JsonFetcher = (url: string) => Promise<any>;
+
+type AdminUnit = Record<string, unknown>;
+
 /**
  * ADMINEXPRESS-COG.LATEST:{type}
  * 
@@ -25,9 +29,9 @@ export const ADMINEXPRESS_TYPES = [
  * @param {number} lon 
  * @param {number} lat 
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns {object[]}
+ * @returns {Promise<AdminUnit[]>}
  */
-export async function getAdminUnits(lon, lat, fetcher) {
+export async function getAdminUnits(lon: number, lat: number, fetcher?: JsonFetcher): Promise<AdminUnit[]>{
     logger.info(`[adminexpress] getAdminUnits(${lon},${lat})...`);
 
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order

--- a/src/gpf/altitude.ts
+++ b/src/gpf/altitude.ts
@@ -3,6 +3,26 @@ import logger from "../logger.js";
 
 export const ALTITUDE_SOURCE = "Géoplateforme (altimétrie)";
 
+type JsonFetcher = (url: string) => Promise<any>;
+
+type RawElevation = {
+  lon: number;
+  lat: number;
+  z: number;
+  acc: string;
+};
+
+type RawAltitudeResponse = {
+  elevations?: RawElevation[];
+};
+
+type AltitudeResult = {
+  lon: number;
+  lat: number;
+  altitude: number;
+  accuracy: string;
+};
+
 /**
  * Get altitude for a given location.
  * 
@@ -11,14 +31,14 @@ export const ALTITUDE_SOURCE = "Géoplateforme (altimétrie)";
  * @param {number} lon 
  * @param {number} lat 
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns 
+ * @returns {Promise<AltitudeResult>}
  */
-export async function getAltitudeByLocation(lon, lat, fetcher = fetchJSON) {
+export async function getAltitudeByLocation(lon: number, lat: number, fetcher: JsonFetcher = fetchJSON): Promise<AltitudeResult> {
     logger.info(`getAltitudeByLocation(${lon},${lat})...`);
     
     const url = `https://data.geopf.fr/altimetrie/1.0/calcul/alti/rest/elevation.json?lon=${lon}&lat=${lat}&resource=ign_rge_alti_wld`;
 
-    const json = await fetcher(url);
+    const json: RawAltitudeResponse = await fetcher(url);
     const elevation = json?.elevations?.[0];
 
     if (!elevation) {

--- a/src/gpf/geocode.ts
+++ b/src/gpf/geocode.ts
@@ -3,6 +3,30 @@ import logger from "../logger.js";
 
 export const GEOCODE_SOURCE = "Géoplateforme (service d'autocomplétion)";
 
+type RawGeocodeResult = {
+  x: number;
+  y: number;
+  fulltext: string;
+  kind: string;
+  city: string;
+  zipcode: string;
+};
+
+type GeocodeResult = {
+  lon: number;
+  lat: number;
+  fulltext: string;
+  kind: string;
+  city: string;
+  zipcode: string;
+};
+
+type RawGeocodeResponse = {
+  results?: RawGeocodeResult[];
+};
+
+type JsonFetcher = (url: string) => Promise<any>;
+
 // https://data.geopf.fr/geocodage/completion/openapi does not provide all the necessary information yet
 
 /**
@@ -13,9 +37,9 @@ export const GEOCODE_SOURCE = "Géoplateforme (service d'autocomplétion)";
  * @param {string} text
  * @param {number} [maximumResponses=3]
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns 
+ * @returns {Promise<GeocodeResult[]>}
  */
-export async function geocode(text, maximumResponses = 3, fetcher = fetchJSON) {
+export async function geocode(text: string, maximumResponses = 3, fetcher: JsonFetcher = fetchJSON): Promise<GeocodeResult[]> {
     const normalizedText = typeof text === "string" ? text.trim() : "";
 
     if (!normalizedText) {
@@ -29,7 +53,7 @@ export async function geocode(text, maximumResponses = 3, fetcher = fetchJSON) {
       maximumResponses: String(maximumResponses)
     }).toString();
 
-    const json = await fetcher(url);
+    const json: RawGeocodeResponse = await fetcher(url);
     const results = Array.isArray(json?.results) ? json.results : [];
     return results.map((item)=>{return {
       lon: item.x,

--- a/src/gpf/parcellaire-express.ts
+++ b/src/gpf/parcellaire-express.ts
@@ -4,6 +4,14 @@ import distance from '../helpers/distance.js';
 import { fetchWfsFeatures, mapWfsFeature, toGeoJsonPoint } from '../helpers/wfs.js';
 import logger from '../logger.js';
 
+type JsonFetcher = (url: string) => Promise<any>;
+
+type ParcellaireExpressItem = Record<string, unknown> & {
+  type: unknown;
+  distance: number;
+  source: string;
+};
+
 // CADASTRALPARCELS.PARCELLAIRE_EXPRESS:
 // https://data.geopf.fr/wfs/ows?service=WFS&version=2.0.0&request=GetCapabilities
 
@@ -21,9 +29,9 @@ export const PARCELLAIRE_EXPRESS_TYPES = [
  * Filter items by distance keeping the nearest for each type.
  *
  * @param {array<object>} items 
- * @returns {array<object>}
+ * @returns {array<ParcellaireExpressItem>}
  */
-function filterByDistance(items){
+function filterByDistance(items: ParcellaireExpressItem[]): ParcellaireExpressItem[] {
     const sortedItems = _.orderBy(items, ['type', 'distance'], ['asc', 'asc']);
 
     const result = [];
@@ -47,9 +55,9 @@ function filterByDistance(items){
  * @param {number} lon 
  * @param {number} lat 
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns 
+ * @returns {Promise<ParcellaireExpressItem[]>}
  */
-export async function getParcellaireExpress(lon, lat, fetcher) {
+export async function getParcellaireExpress(lon: number, lat:number, fetcher?: JsonFetcher): Promise<ParcellaireExpressItem[]> {
     logger.info(`getParcellaireExpress(${lon},${lat}) ...`);
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order
     const cql_filter = `DWITHIN(geom,SRID=4326;POINT(${lon} ${lat}),10,meters)`;

--- a/src/gpf/urbanisme.ts
+++ b/src/gpf/urbanisme.ts
@@ -1,6 +1,13 @@
 import distance from "../helpers/distance.js";
 import { fetchWfsFeatures, mapWfsFeature, toGeoJsonPoint } from "../helpers/wfs.js";
 import logger from "../logger.js";
+import type { FlatWfsFeature } from "../helpers/wfs.js";
+
+type JsonFetcher = (url: string) => Promise<any>;
+
+type UrbanismeItem = FlatWfsFeature & {
+  distance: number;
+};
 
 // https://data.geopf.fr/wfs/ows?service=WFS&version=2.0.0&request=GetCapabilities
 export const URBANISME_TYPES = [
@@ -23,8 +30,8 @@ const URBANISME_EXCLUDED_PROPERTIES = new Set([
     'urlfic'
 ]);
 
-function sanitizeUrbanismeItem(item) {
-    const sanitized = {};
+function sanitizeUrbanismeItem(item: UrbanismeItem): Record<string, unknown> {
+    const sanitized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(item)) {
         if (URBANISME_EXCLUDED_PROPERTIES.has(key)) {
             continue;
@@ -44,9 +51,9 @@ function sanitizeUrbanismeItem(item) {
  * @param {number} lon 
  * @param {number} lat 
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns 
+ * @returns {Promise<Record<string, unknown>[]>}
  */
-export async function getUrbanisme(lon, lat, fetcher) {
+export async function getUrbanisme(lon: number, lat: number, fetcher?: JsonFetcher): Promise<Record<string, unknown>[]> {
     logger.info(`getUrbanisme(${lon},${lat})...`);
 
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order
@@ -76,9 +83,9 @@ const ASSIETTES_SUP_TYPES = [
  * @param {number} lon 
  * @param {number} lat 
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns 
+ * @returns {Promise<UrbanismeItem[]>}
  */
-export async function getAssiettesServitudes(lon, lat, fetcher) {
+export async function getAssiettesServitudes(lon: number, lat: number, fetcher?: JsonFetcher): Promise<UrbanismeItem[]> {
     logger.info(`getAssiettesServitudes(${lon},${lat})...`);
 
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order

--- a/src/helpers/distance.ts
+++ b/src/helpers/distance.ts
@@ -1,8 +1,10 @@
 import GeoJSONReader from 'jsts/org/locationtech/jts/io/GeoJSONReader.js'
 import { DistanceOp } from 'jsts/org/locationtech/jts/operation/distance.js'
+import GeometryFactory from 'jsts/org/locationtech/jts/geom/GeometryFactory.js'
 
 import turfDistance from '@turf/distance'
 import {point as turfPoint} from '@turf/helpers'
+import type { Geometry } from "geojson";
 
 /**
  * Compute approximative distance in meters between gA and gB.
@@ -12,8 +14,8 @@ import {point as turfPoint} from '@turf/helpers'
  * @param {object} gA GeoJSON Geometry
  * @param {object} gB GeoJSON Geometry
  */
-export default function distance(gA, gB) {
-    const geojsonReader = new GeoJSONReader()
+export default function distance(gA: Geometry, gB: Geometry): number {
+    const geojsonReader = new GeoJSONReader(new GeometryFactory())
     const a = geojsonReader.read(gA);
     const b = geojsonReader.read(gB);
 

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,27 +1,56 @@
 import fetch from 'node-fetch';
+import type { RequestInit } from "node-fetch";
+
 import { parseXml, XmlElement } from '@rgrove/parse-xml';
 
 import logger from "../logger.js";
 
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
-const fetchOpts = {
-    headers: new Headers({
-        "Accept": "application/json",
-        "User-Agent": "geocontext"
-    })
+type HeadersLike = {
+  get(name: string): string | null;
+};
+
+type ResponseLike = {
+  status: number;
+  statusText: string;
+  ok?: boolean;
+  headers?: HeadersLike;
+  text(): Promise<string>;
+};
+
+type RequestHeaders = Record<string, string>;
+
+const defaultHeaders = new Headers({
+  Accept: "application/json",
+  "User-Agent": "geocontext",
+});
+
+
+const fetchOpts:RequestInit = {
+    headers: defaultHeaders,
 };
 
 if ( process.env.HTTP_PROXY ){
     fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY); 
 }
 
-function getChild(element, localName) {
-    return element.children.find((child) => child instanceof XmlElement && child.name.split(":").pop() === localName) || null;
+function getChild(element: XmlElement | null | undefined, localName: string): XmlElement | null {
+    if (!element) {
+        return null;
+    }
+
+    const child = element.children.find(
+    (candidate): candidate is XmlElement =>
+        candidate instanceof XmlElement &&
+        candidate.name.split(":").pop() === localName
+    );
+
+    return child ?? null;
 }
 
 // Tente d'extraire un message d'erreur d'une réponse XML de type OGC WFS
-function extractXmlError(text) {
+function extractXmlError(text: string): Error | null {
     try {
         const root = parseXml(text).children.find((child) => child instanceof XmlElement);
         const rootName = root?.name.split(":").pop();
@@ -43,7 +72,7 @@ function extractXmlError(text) {
     }
 }
 
-function previewBody(text) {
+function previewBody(text: string): string {
     const trimmed = text.trim();
     if (!trimmed) {
         return "";
@@ -52,7 +81,7 @@ function previewBody(text) {
     return trimmed.replace(/\s+/g, " ").slice(0, 200);
 }
 
-export async function parseJsonResponse(res) {
+export async function parseJsonResponse(res: ResponseLike): Promise<any> {
     const contentType = (res.headers?.get?.("content-type") || "").toLowerCase();
     const text = await res.text();
     const looksLikeXml = contentType.includes("xml") || text.trim().startsWith("<");
@@ -119,26 +148,26 @@ export async function parseJsonResponse(res) {
  * @param {string} url 
  * @returns {Promise<any>}
  */
-export async function fetchJSON(url) {
+export async function fetchJSON(url: string): Promise<any> {
     logger.info(`[HTTP] GET ${url} ...`);
     const result = await fetch(url, fetchOpts).then(parseJsonResponse);
     logger.debug(`[HTTP] GET ${url} : ${JSON.stringify(result)}`)
     return result;
 }
 
-function buildFetchOptions(method, body, headers) {
+function buildFetchOptions(method: string, body: string | undefined, headers: RequestHeaders = {}) {
     return {
         ...fetchOpts,
         method,
         headers: new Headers({
-            ...Object.fromEntries(fetchOpts.headers.entries()),
+            ...Object.fromEntries(defaultHeaders.entries()),
             ...(headers || {})
         }),
         ...(body !== undefined ? { body } : {})
     };
 }
 
-export async function fetchJSONPost(url, body = "", headers = {}) {
+export async function fetchJSONPost(url: string, body: string = "", headers: RequestHeaders = {}) {
     logger.info(`[HTTP] POST ${url} ...`);
     const result = await fetch(url, buildFetchOptions("POST", body, headers)).then(parseJsonResponse);
     logger.debug(`[HTTP] POST ${url} : ${JSON.stringify(result)}`);

--- a/src/helpers/wfs.ts
+++ b/src/helpers/wfs.ts
@@ -1,6 +1,31 @@
 import { fetchJSON } from './http.js';
-
+import type { Point, BBox, Geometry } from 'geojson';
 const GPF_WFS_BASE_URL = process.env.GPF_WFS_BASE_URL || 'https://data.geopf.fr/wfs';
+
+type JsonFetcher = (url: string) => Promise<any>;
+
+type WfsFeature = {
+  id: string;
+  properties: Record<string, unknown>;
+  geometry: Geometry;
+  bbox?: BBox;
+};
+
+type WfsFeatureCollection = {
+  features?: WfsFeature[];
+};
+
+export type FeatureRef = {
+  typename: string;
+  feature_id: string;
+};
+
+export type FlatWfsFeature = Record<string, unknown> & {
+  type: string;
+  id: string;
+  bbox?: BBox;
+  feature_ref?: FeatureRef;
+};
 
 /**
  * Fetch features from a GPF WFS endpoint.
@@ -9,9 +34,9 @@ const GPF_WFS_BASE_URL = process.env.GPF_WFS_BASE_URL || 'https://data.geopf.fr/
  * @param {string} cqlFilter - CQL_FILTER value
  * @param {string} errorLabel - service label used in the error message
  * @param {(url: string) => Promise<any>} [fetcher]
- * @returns {Promise<any[]>} raw GeoJSON features array
+ * @returns {Promise<WfsFeature[]>} raw GeoJSON features array
  */
-export async function fetchWfsFeatures(typeNames, cqlFilter, errorLabel, fetcher = fetchJSON) {
+export async function fetchWfsFeatures(typeNames: string[], cqlFilter: string, errorLabel: string, fetcher: JsonFetcher = fetchJSON) : Promise<WfsFeature[]> {
     const url = GPF_WFS_BASE_URL + '?' + new URLSearchParams({
         service: 'WFS',
         request: 'GetFeature',
@@ -34,7 +59,7 @@ export async function fetchWfsFeatures(typeNames, cqlFilter, errorLabel, fetcher
  * @param {number} lat
  * @returns {object} GeoJSON Point
  */
-export function toGeoJsonPoint(lon, lat) {
+export function toGeoJsonPoint(lon: number, lat:number): Point {
     return { type: "Point", coordinates: [lon, lat] };
 }
 
@@ -44,9 +69,9 @@ export function toGeoJsonPoint(lon, lat) {
  *
  * @param {object}  feature        - Raw GeoJSON feature from WFS
  * @param {string[]} knownTypeNames - Fully qualified WFS type names used for feature_ref resolution
- * @returns {object} Flat result with type, id, bbox, optional feature_ref, and spread properties
+ * @returns {FlatWfsFeature} Flat result with type, id, bbox, optional feature_ref, and spread properties
  */
-export function mapWfsFeature(feature, knownTypeNames) {
+export function mapWfsFeature(feature: WfsFeature, knownTypeNames: string[]): FlatWfsFeature {
     const type = feature.id.split('.')[0];
     const typename = knownTypeNames.find((t) => t.endsWith(`:${type}`));
     return {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,8 +7,15 @@ const formats = {
     simple: format.simple()
 };
 
+type LogFormat = keyof typeof formats;
+
+function isLogFormat(value: string): value is LogFormat {
+    return Object.keys(formats).includes(value);
+}
+
 const LOG_FORMAT = process.env.LOG_FORMAT ? process.env.LOG_FORMAT : 'simple';
-if ( ! Object.keys(formats).includes(LOG_FORMAT) ){
+
+if (!isLogFormat(LOG_FORMAT)) {
     throw new Error(`LOG_FORMAT=${LOG_FORMAT} not found!`);
 }
 

--- a/test/helpers/distance.test.ts
+++ b/test/helpers/distance.test.ts
@@ -1,5 +1,5 @@
 import distance from "../../src/helpers/distance.js";
-
+import type { Polygon } from "geojson";
 import {paris, marseille, besancon, parisMarseille} from '../samples';
 
 describe("Test distance",() => {
@@ -18,7 +18,7 @@ describe("Test distance",() => {
 
     describe("Test distance(Point,Polygon)", () => {
         it("should return 0m from Paris point to a polygon containing Paris",() => {
-            const polygonContainingParis = {
+            const polygonContainingParis: Polygon = {
                 "type": "Polygon",
                 "coordinates": [
                     [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "lib": [ "es2015" ],
         "allowSyntheticDefaultImports": true,
         "skipLibCheck": true,
-        "allowJs": true,
+        "allowJs": false,
         "esModuleInterop": true
     },
     "include": [


### PR DESCRIPTION
closes #37 

This PR performs a minimal migration of the remaining runtime source files in `src/` from JavaScript to TypeScript.

The goal is deliberately narrow: port the existing implementation to TypeScript without changing behavior or reorganizing the codebase.

**Included**
- rename migrated `src/**/*.js` files to `*.ts`
- add the minimal TypeScript annotations required for compilation
- keep the existing runtime behavior and module structure
- update the small test change needed for GeoJSON typing
- disable `allowJs` in `tsconfig.json`

**Notes**
- some functions keep an optional `fetcher?: JsonFetcher` parameter to preserve the existing JavaScript call pattern
- when omitted, the downstream helper still falls back to its default fetch implementation
- this keeps the migration behavior-preserving without refactoring the fetcher call chain in this PR

**Not included**
- no intended functional changes
- no architectural refactor
- no directory reorganization
- no testing stack migration

**Validation**
- `tsc --noEmit`
- `npm test -- --runInBand`