### PR TITLE
tighten shared runtime types after the TypeScript migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "clean:dist": "node scripts/dist-clean.js",
     "build": "npm run clean:dist && tsc && npx mcp-build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "test": "node --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js",

--- a/src/gpf/adminexpress.ts
+++ b/src/gpf/adminexpress.ts
@@ -1,9 +1,9 @@
 import { fetchWfsFeatures, mapWfsFeature } from '../helpers/wfs.js';
 import logger from '../logger.js';
+import type { JsonFetcher } from '../helpers/http.js';
+import type { WfsFeatureCollection, FlatWfsFeature } from '../helpers/wfs.js';
 
-type JsonFetcher = (url: string) => Promise<any>;
-
-type AdminUnit = Record<string, unknown>;
+type AdminUnit = FlatWfsFeature;
 
 /**
  * ADMINEXPRESS-COG.LATEST:{type}
@@ -28,10 +28,10 @@ export const ADMINEXPRESS_TYPES = [
  *
  * @param {number} lon 
  * @param {number} lat 
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<WfsFeatureCollection>} [fetcher] - optional custom fetcher function
  * @returns {Promise<AdminUnit[]>}
  */
-export async function getAdminUnits(lon: number, lat: number, fetcher?: JsonFetcher): Promise<AdminUnit[]>{
+export async function getAdminUnits(lon: number, lat: number, fetcher?: JsonFetcher<WfsFeatureCollection>): Promise<AdminUnit[]>{
     logger.info(`[adminexpress] getAdminUnits(${lon},${lat})...`);
 
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order

--- a/src/gpf/altitude.ts
+++ b/src/gpf/altitude.ts
@@ -1,9 +1,7 @@
 import { fetchJSON } from "../helpers/http.js";
 import logger from "../logger.js";
-
+import type { JsonFetcher } from "../helpers/http.js";
 export const ALTITUDE_SOURCE = "Géoplateforme (altimétrie)";
-
-type JsonFetcher = (url: string) => Promise<any>;
 
 type RawElevation = {
   lon: number;
@@ -30,10 +28,10 @@ type AltitudeResult = {
  * 
  * @param {number} lon 
  * @param {number} lat 
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<RawAltitudeResponse>} [fetcher] - optional custom fetcher function
  * @returns {Promise<AltitudeResult>}
  */
-export async function getAltitudeByLocation(lon: number, lat: number, fetcher: JsonFetcher = fetchJSON): Promise<AltitudeResult> {
+export async function getAltitudeByLocation(lon: number, lat: number, fetcher: JsonFetcher<RawAltitudeResponse> = fetchJSON): Promise<AltitudeResult> {
     logger.info(`getAltitudeByLocation(${lon},${lat})...`);
     
     const url = `https://data.geopf.fr/altimetrie/1.0/calcul/alti/rest/elevation.json?lon=${lon}&lat=${lat}&resource=ign_rge_alti_wld`;

--- a/src/gpf/geocode.ts
+++ b/src/gpf/geocode.ts
@@ -1,6 +1,6 @@
 import { fetchJSON } from "../helpers/http.js";
 import logger from "../logger.js";
-
+import type { JsonFetcher } from "../helpers/http.js";
 export const GEOCODE_SOURCE = "Géoplateforme (service d'autocomplétion)";
 
 type RawGeocodeResult = {
@@ -25,8 +25,6 @@ type RawGeocodeResponse = {
   results?: RawGeocodeResult[];
 };
 
-type JsonFetcher = (url: string) => Promise<any>;
-
 // https://data.geopf.fr/geocodage/completion/openapi does not provide all the necessary information yet
 
 /**
@@ -36,10 +34,10 @@ type JsonFetcher = (url: string) => Promise<any>;
  * 
  * @param {string} text
  * @param {number} [maximumResponses=3]
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<RawGeocodeResponse>} [fetcher] - optional custom fetcher function
  * @returns {Promise<GeocodeResult[]>}
  */
-export async function geocode(text: string, maximumResponses = 3, fetcher: JsonFetcher = fetchJSON): Promise<GeocodeResult[]> {
+export async function geocode(text: string, maximumResponses = 3, fetcher: JsonFetcher<RawGeocodeResponse> = fetchJSON): Promise<GeocodeResult[]> {
     const normalizedText = typeof text === "string" ? text.trim() : "";
 
     if (!normalizedText) {

--- a/src/gpf/parcellaire-express.ts
+++ b/src/gpf/parcellaire-express.ts
@@ -4,10 +4,10 @@ import distance from '../helpers/distance.js';
 import { fetchWfsFeatures, mapWfsFeature, toGeoJsonPoint } from '../helpers/wfs.js';
 import logger from '../logger.js';
 
-type JsonFetcher = (url: string) => Promise<any>;
+import type { JsonFetcher } from '../helpers/http.js';
+import type { WfsFeatureCollection, FlatWfsFeature, WfsFeatureWithGeometry } from '../helpers/wfs.js';
 
-type ParcellaireExpressItem = Record<string, unknown> & {
-  type: unknown;
+type ParcellaireExpressItem = FlatWfsFeature & {
   distance: number;
   source: string;
 };
@@ -54,10 +54,10 @@ function filterByDistance(items: ParcellaireExpressItem[]): ParcellaireExpressIt
  * 
  * @param {number} lon 
  * @param {number} lat 
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<WfsFeatureCollection>} [fetcher] - optional custom fetcher function
  * @returns {Promise<ParcellaireExpressItem[]>}
  */
-export async function getParcellaireExpress(lon: number, lat:number, fetcher?: JsonFetcher): Promise<ParcellaireExpressItem[]> {
+export async function getParcellaireExpress(lon: number, lat:number, fetcher?: JsonFetcher<WfsFeatureCollection<WfsFeatureWithGeometry>>): Promise<ParcellaireExpressItem[]> {
     logger.info(`getParcellaireExpress(${lon},${lat}) ...`);
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order
     const cql_filter = `DWITHIN(geom,SRID=4326;POINT(${lon} ${lat}),10,meters)`;

--- a/src/gpf/urbanisme.ts
+++ b/src/gpf/urbanisme.ts
@@ -1,9 +1,8 @@
 import distance from "../helpers/distance.js";
 import { fetchWfsFeatures, mapWfsFeature, toGeoJsonPoint } from "../helpers/wfs.js";
 import logger from "../logger.js";
-import type { FlatWfsFeature } from "../helpers/wfs.js";
-
-type JsonFetcher = (url: string) => Promise<any>;
+import type { FlatWfsFeature, WfsFeatureCollection, WfsFeatureWithGeometry } from "../helpers/wfs.js";
+import type { JsonFetcher } from '../helpers/http.js';
 
 type UrbanismeItem = FlatWfsFeature & {
   distance: number;
@@ -50,10 +49,10 @@ function sanitizeUrbanismeItem(item: UrbanismeItem): Record<string, unknown> {
  *
  * @param {number} lon 
  * @param {number} lat 
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<WfsFeatureCollection>} [fetcher] - optional custom fetcher function
  * @returns {Promise<Record<string, unknown>[]>}
  */
-export async function getUrbanisme(lon: number, lat: number, fetcher?: JsonFetcher): Promise<Record<string, unknown>[]> {
+export async function getUrbanisme(lon: number, lat: number, fetcher?: JsonFetcher<WfsFeatureCollection<WfsFeatureWithGeometry>>): Promise<Record<string, unknown>[]> {
     logger.info(`getUrbanisme(${lon},${lat})...`);
 
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order
@@ -82,10 +81,10 @@ const ASSIETTES_SUP_TYPES = [
  *
  * @param {number} lon 
  * @param {number} lat 
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<WfsFeatureCollection>} [fetcher] - optional custom fetcher function
  * @returns {Promise<UrbanismeItem[]>}
  */
-export async function getAssiettesServitudes(lon: number, lat: number, fetcher?: JsonFetcher): Promise<UrbanismeItem[]> {
+export async function getAssiettesServitudes(lon: number, lat: number, fetcher?: JsonFetcher<WfsFeatureCollection<WfsFeatureWithGeometry>>): Promise<UrbanismeItem[]> {
     logger.info(`getAssiettesServitudes(${lon},${lat})...`);
 
     // Using EWKT format with SRID=4326 prefix for standard lon,lat order

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,11 +1,9 @@
 import fetch from 'node-fetch';
 import type { RequestInit } from "node-fetch";
-
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { parseXml, XmlElement } from '@rgrove/parse-xml';
 
 import logger from "../logger.js";
-
-import { HttpsProxyAgent } from 'https-proxy-agent';
 
 type HeadersLike = {
   get(name: string): string | null;
@@ -30,6 +28,8 @@ const defaultHeaders = new Headers({
 const fetchOpts:RequestInit = {
     headers: defaultHeaders,
 };
+
+export type JsonFetcher<T> = (url: string) => Promise<T>;
 
 if ( process.env.HTTP_PROXY ){
     fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY); 

--- a/src/helpers/wfs.ts
+++ b/src/helpers/wfs.ts
@@ -1,18 +1,20 @@
 import { fetchJSON } from './http.js';
-import type { Point, BBox, Geometry } from 'geojson';
+import type { Point, Geometry } from 'geojson';
 const GPF_WFS_BASE_URL = process.env.GPF_WFS_BASE_URL || 'https://data.geopf.fr/wfs';
+import type { JsonFetcher } from './http.js';
 
-type JsonFetcher = (url: string) => Promise<any>;
-
-type WfsFeature = {
+export type WfsFeatureBase = {
   id: string;
   properties: Record<string, unknown>;
-  geometry: Geometry;
-  bbox?: BBox;
+  bbox?: number[];
 };
 
-type WfsFeatureCollection = {
-  features?: WfsFeature[];
+export type WfsFeatureWithGeometry = WfsFeatureBase & {
+  geometry: Geometry;
+};
+
+export type WfsFeatureCollection<TFeature extends WfsFeatureBase = WfsFeatureBase> = {
+  features?: TFeature[];
 };
 
 export type FeatureRef = {
@@ -23,7 +25,7 @@ export type FeatureRef = {
 export type FlatWfsFeature = Record<string, unknown> & {
   type: string;
   id: string;
-  bbox?: BBox;
+  bbox?: number[];
   feature_ref?: FeatureRef;
 };
 
@@ -33,10 +35,10 @@ export type FlatWfsFeature = Record<string, unknown> & {
  * @param {string[]} typeNames - fully qualified WFS type names
  * @param {string} cqlFilter - CQL_FILTER value
  * @param {string} errorLabel - service label used in the error message
- * @param {(url: string) => Promise<any>} [fetcher]
+ * @param {JsonFetcher<WfsFeatureCollection>} [fetcher] - optional custom fetcher function
  * @returns {Promise<WfsFeature[]>} raw GeoJSON features array
  */
-export async function fetchWfsFeatures(typeNames: string[], cqlFilter: string, errorLabel: string, fetcher: JsonFetcher = fetchJSON) : Promise<WfsFeature[]> {
+export async function fetchWfsFeatures<TFeature extends WfsFeatureBase = WfsFeatureBase>(typeNames: string[], cqlFilter: string, errorLabel: string, fetcher: JsonFetcher<WfsFeatureCollection<TFeature>> = fetchJSON) : Promise<TFeature[]> {
     const url = GPF_WFS_BASE_URL + '?' + new URLSearchParams({
         service: 'WFS',
         request: 'GetFeature',
@@ -57,7 +59,7 @@ export async function fetchWfsFeatures(typeNames: string[], cqlFilter: string, e
  *
  * @param {number} lon
  * @param {number} lat
- * @returns {object} GeoJSON Point
+ * @returns {Point} GeoJSON Point
  */
 export function toGeoJsonPoint(lon: number, lat:number): Point {
     return { type: "Point", coordinates: [lon, lat] };
@@ -71,7 +73,7 @@ export function toGeoJsonPoint(lon: number, lat:number): Point {
  * @param {string[]} knownTypeNames - Fully qualified WFS type names used for feature_ref resolution
  * @returns {FlatWfsFeature} Flat result with type, id, bbox, optional feature_ref, and spread properties
  */
-export function mapWfsFeature(feature: WfsFeature, knownTypeNames: string[]): FlatWfsFeature {
+export function mapWfsFeature(feature: WfsFeatureBase, knownTypeNames: string[]): FlatWfsFeature {
     const type = feature.id.split('.')[0];
     const typename = knownTypeNames.find((t) => t.endsWith(`:${type}`));
     return {

--- a/test/gpf/parcellaire-express.test.ts
+++ b/test/gpf/parcellaire-express.test.ts
@@ -1,7 +1,9 @@
 import {getParcellaireExpress} from "../../src/gpf/parcellaire-express.js";
 import { mairieLoray } from "../samples";
+import type { Point } from "geojson";
+import type { WfsFeatureCollection, WfsFeatureWithGeometry } from "../../src/helpers/wfs.js";
 
-const parcellaireExpressFeatureCollection = {
+const parcellaireExpressFeatureCollection: WfsFeatureCollection<WfsFeatureWithGeometry>  = {
     features: [
         {
             id: "commune.1",

--- a/test/gpf/urbanisme.test.ts
+++ b/test/gpf/urbanisme.test.ts
@@ -1,14 +1,12 @@
 import {getUrbanisme, getAssiettesServitudes} from "../../src/gpf/urbanisme.js";
 import { chamonix, mairieLoray } from "../samples";
+import type { Point } from "geojson";
 
 const urbanismeFeatureCollection: {
     features: Array<{
         id: string;
         bbox: number[];
-        geometry: {
-            type: string;
-            coordinates: number[];
-        };
+        geometry: Point;
         properties: Record<string, string | null>;
     }>;
 } = {
@@ -47,10 +45,7 @@ const assiettesFeatureCollection: {
     features: Array<{
         id: string;
         bbox: number[];
-        geometry: {
-            type: string;
-            coordinates: number[];
-        };
+        geometry: Point;
         properties: Record<string, string>;
     }>;
 } = {


### PR DESCRIPTION
Closes #56

This PR follows up on #56 and tightens shared runtime types introduced during the JavaScript-to-TypeScript migration.

**Included**
- centralize `JsonFetcher` as a shared generic type
- replace duplicated local fetcher aliases in `src/gpf/*` and `src/helpers/*`
- clarify shared WFS structural types by separating base features from geometry-bearing features
- make WFS feature collections generic to better match caller expectations
- improve reuse of shared WFS result types across helpers and GPF modules
- align test fixtures with the updated GeoJSON/WFS type contracts

**Scope**
- no intended runtime behavior changes
- no architectural reorganization
- no testing stack migration

**Validation**
- `npm run typecheck`
- `npm test -- --runInBand`