### PR TITLE
refactor: stabilize and document the WFS engine

### DIFF
--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -5,6 +5,8 @@ import { parseXml, XmlElement } from '@rgrove/parse-xml';
 
 import logger from "../logger.js";
 
+// --- Transport Types ---
+
 type HeadersLike = {
   get(name: string): string | null;
 };
@@ -19,157 +21,269 @@ type ResponseLike = {
 
 type RequestHeaders = Record<string, string>;
 
+type ServiceResponseErrorOptions = {
+  httpStatus?: number;
+  responseLabel?: string;
+  serviceCode?: string;
+  serviceDetail?: string;
+};
+
+// --- Shared Fetch State ---
+
 const defaultHeaders = new Headers({
   Accept: "application/json",
   "User-Agent": "geocontext",
 });
 
-
-const fetchOpts:RequestInit = {
-    headers: defaultHeaders,
+const fetchOpts: RequestInit = {
+  headers: defaultHeaders,
 };
 
 export type JsonFetcher<T> = (url: string) => Promise<T>;
 
-if ( process.env.HTTP_PROXY ){
-    fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY); 
-}
+// --- Service Errors ---
 
-function getChild(element: XmlElement | null | undefined, localName: string): XmlElement | null {
-    if (!element) {
-        return null;
-    }
+/**
+ * Structured service error enriched with HTTP and upstream service metadata.
+ */
+export class ServiceResponseError extends Error {
+  httpStatus?: number;
+  responseLabel?: string;
+  serviceCode?: string;
+  serviceDetail?: string;
 
-    const child = element.children.find(
-    (candidate): candidate is XmlElement =>
-        candidate instanceof XmlElement &&
-        candidate.name.split(":").pop() === localName
-    );
-
-    return child ?? null;
-}
-
-// Tente d'extraire un message d'erreur d'une réponse XML de type OGC WFS
-function extractXmlError(text: string): Error | null {
-    try {
-        const root = parseXml(text).children.find((child) => child instanceof XmlElement);
-        const rootName = root?.name.split(":").pop();
-        if (rootName !== "ExceptionReport" && rootName !== "ServiceExceptionReport") {
-            return null;
-        }
-
-        const exception = getChild(root, "Exception") || getChild(root, "ServiceException");
-        if (!exception) {
-            return null;
-        }
-
-        const code = exception.attributes?.exceptionCode || exception.attributes?.code;
-        const message = getChild(exception, "ExceptionText")?.text?.trim() || exception.text?.trim() || "";
-        const errorMessage = [code, message].filter(Boolean).join(": ");
-        return errorMessage ? new Error(errorMessage) : null;
-    } catch {
-        return null;
-    }
-}
-
-function previewBody(text: string): string {
-    const trimmed = text.trim();
-    if (!trimmed) {
-        return "";
-    }
-
-    return trimmed.replace(/\s+/g, " ").slice(0, 200);
-}
-
-export async function parseJsonResponse(res: ResponseLike): Promise<any> {
-    const contentType = (res.headers?.get?.("content-type") || "").toLowerCase();
-    const text = await res.text();
-    const looksLikeXml = contentType.includes("xml") || text.trim().startsWith("<");
-    const responseLabel = [res.status, res.statusText].filter(Boolean).join(" ") || "réponse HTTP";
-    const hasValidStatus = Number.isFinite(res.status);
-    const isOk = typeof res.ok === "boolean"
-        ? res.ok
-        : hasValidStatus && res.status >= 200 && res.status < 300;
-
-    if (text.trim() === "") {
-        throw new Error(`Réponse vide du service (${responseLabel})`);
-    }
-
-    if (looksLikeXml) {
-        const xmlError = extractXmlError(text);
-
-        if (xmlError) {
-            if (!isOk) {
-                throw new Error(`Erreur HTTP du service (${responseLabel}): ${xmlError.message}`);
-            }
-            throw xmlError;
-        }
-
-        const details = [`content-type=${contentType || "inconnu"}`];
-        const bodyPreview = previewBody(text);
-        if (bodyPreview) {
-            details.push(`extrait=${bodyPreview}`);
-        }
-
-        throw new Error(`Réponse XML non exploitable du service (${responseLabel}, ${details.join(", ")})`);
-    }
-
-    let json;
-    try {
-        json = JSON.parse(text);
-    } catch {
-        const details = [`content-type=${contentType || "inconnu"}`];
-        const bodyPreview = previewBody(text);
-        if (bodyPreview) {
-            details.push(`extrait=${bodyPreview}`);
-        }
-
-        throw new Error(`Réponse JSON invalide du service (${responseLabel}, ${details.join(", ")})`);
-    }
-
-    if (!isOk) {
-        const errorMessage = json?.message
-            || json?.error
-            || json?.errorMessage
-            || json?.msg
-            || json?.title
-            || json?.detail
-            || (typeof json === "string" ? json : previewBody(JSON.stringify(json)));
-        throw new Error(`Erreur HTTP du service (${responseLabel}): ${errorMessage}`);
-    }
-
-    return json;
+  constructor(message: string, options: ServiceResponseErrorOptions = {}) {
+    super(message);
+    this.name = "ServiceResponseError";
+    this.httpStatus = options.httpStatus;
+    this.responseLabel = options.responseLabel;
+    this.serviceCode = options.serviceCode;
+    this.serviceDetail = options.serviceDetail;
+  }
 }
 
 /**
- * Fetches and parses a JSON response from a URL
- * TODO : Add a timeout
- * 
- * @param {string} url 
- * @returns {Promise<any>}
+ * Checks whether an unknown error exposes the structured service-error shape.
+ *
+ * @param error Unknown error value caught by the caller.
+ * @returns `true` when the error can be treated as a `ServiceResponseError`.
+ */
+export function isServiceResponseError(error: unknown): error is ServiceResponseError {
+  return error instanceof Error && (
+    error instanceof ServiceResponseError
+    || error.name === "ServiceResponseError"
+    || "serviceCode" in error
+    || "serviceDetail" in error
+  );
+}
+
+// Reuse the standard proxy environment variable so every shared HTTP helper
+// transparently follows the same outbound network path when a proxy is required.
+if (process.env.HTTP_PROXY) {
+  fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY);
+}
+
+// --- XML Helpers ---
+
+/**
+ * Returns the first child XML element matching the requested local name.
+ *
+ * @param element Parent element to inspect.
+ * @param localName Local XML name without namespace prefix.
+ * @returns The matching child element, or `null` when none is found.
+ */
+function getChild(element: XmlElement | null | undefined, localName: string): XmlElement | null {
+  if (!element) {
+    return null;
+  }
+
+  const child = element.children.find(
+    (candidate): candidate is XmlElement =>
+      candidate instanceof XmlElement &&
+      candidate.name.split(":").pop() === localName
+  );
+
+  return child ?? null;
+}
+
+/**
+ * Tries to extract an OGC/WFS-style service error from an XML response body.
+ *
+ * @param text Raw XML response body.
+ * @returns A structured service error, or `null` when the XML payload is not a recognized error report.
+ */
+function extractXmlError(text: string): ServiceResponseError | null {
+  try {
+    const root = parseXml(text).children.find((child) => child instanceof XmlElement);
+    const rootName = root?.name.split(":").pop();
+    if (rootName !== "ExceptionReport" && rootName !== "ServiceExceptionReport") {
+      return null;
+    }
+
+    const exception = getChild(root, "Exception") || getChild(root, "ServiceException");
+    if (!exception) {
+      return null;
+    }
+
+    const code = exception.attributes?.exceptionCode || exception.attributes?.code;
+    const message = getChild(exception, "ExceptionText")?.text?.trim() || exception.text?.trim() || "";
+    const errorMessage = [code, message].filter(Boolean).join(": ");
+
+    return errorMessage
+      ? new ServiceResponseError(errorMessage, {
+        serviceCode: code,
+        serviceDetail: message || undefined,
+      })
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns a short single-line preview of a response body for diagnostics.
+ *
+ * @param text Raw response body.
+ * @returns A trimmed preview limited to 200 characters.
+ */
+function previewBody(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.replace(/\s+/g, " ").slice(0, 200);
+}
+
+// --- Response Parsing ---
+
+/**
+ * Parses an HTTP response expected to contain JSON and upgrades recognizable
+ * XML/JSON service errors to richer structured exceptions.
+ *
+ * @param res HTTP-like response object returned by `fetch`.
+ * @returns The parsed JSON payload.
+ */
+export async function parseJsonResponse(res: ResponseLike): Promise<any> {
+  const contentType = (res.headers?.get?.("content-type") || "").toLowerCase();
+  const text = await res.text();
+  const looksLikeXml = contentType.includes("xml") || text.trim().startsWith("<");
+  const responseLabel = [res.status, res.statusText].filter(Boolean).join(" ") || "réponse HTTP";
+  const hasValidStatus = Number.isFinite(res.status);
+  const isOk = typeof res.ok === "boolean"
+    ? res.ok
+    : hasValidStatus && res.status >= 200 && res.status < 300;
+
+  if (text.trim() === "") {
+    throw new Error(`Réponse vide du service (${responseLabel})`);
+  }
+
+  if (looksLikeXml) {
+    const xmlError = extractXmlError(text);
+
+    if (xmlError) {
+      if (!isOk) {
+        throw new ServiceResponseError(
+          `Erreur HTTP du service (${responseLabel}): ${xmlError.message}`,
+          {
+            httpStatus: hasValidStatus ? res.status : undefined,
+            responseLabel,
+            serviceCode: xmlError.serviceCode,
+            serviceDetail: xmlError.serviceDetail,
+          },
+        );
+      }
+
+      xmlError.httpStatus = hasValidStatus ? res.status : undefined;
+      xmlError.responseLabel = responseLabel;
+      throw xmlError;
+    }
+
+    const details = [`content-type=${contentType || "inconnu"}`];
+    const bodyPreview = previewBody(text);
+    if (bodyPreview) {
+      details.push(`extrait=${bodyPreview}`);
+    }
+
+    throw new Error(`Réponse XML non exploitable du service (${responseLabel}, ${details.join(", ")})`);
+  }
+
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    const details = [`content-type=${contentType || "inconnu"}`];
+    const bodyPreview = previewBody(text);
+    if (bodyPreview) {
+      details.push(`extrait=${bodyPreview}`);
+    }
+
+    throw new Error(`Réponse JSON invalide du service (${responseLabel}, ${details.join(", ")})`);
+  }
+
+  if (!isOk) {
+    const errorMessage = json?.message
+      || json?.error
+      || json?.errorMessage
+      || json?.msg
+      || json?.title
+      || json?.detail
+      || (typeof json === "string" ? json : previewBody(JSON.stringify(json)));
+
+    throw new ServiceResponseError(`Erreur HTTP du service (${responseLabel}): ${errorMessage}`, {
+      httpStatus: hasValidStatus ? res.status : undefined,
+      responseLabel,
+      serviceDetail: errorMessage,
+    });
+  }
+
+  return json;
+}
+
+/**
+ * Fetches and parses a JSON response from a URL.
+ *
+ * @param url Target URL.
+ * @returns The parsed JSON payload.
  */
 export async function fetchJSON(url: string): Promise<any> {
-    logger.info(`[HTTP] GET ${url} ...`);
-    const result = await fetch(url, fetchOpts).then(parseJsonResponse);
-    logger.debug(`[HTTP] GET ${url} : ${JSON.stringify(result)}`)
-    return result;
+  logger.info(`[HTTP] GET ${url} ...`);
+  const result = await fetch(url, fetchOpts).then(parseJsonResponse);
+  logger.debug(`[HTTP] GET ${url} : ${JSON.stringify(result)}`);
+  return result;
 }
 
+/**
+ * Builds the fetch options used by the shared JSON helpers.
+ *
+ * @param method HTTP method to use.
+ * @param body Optional request body.
+ * @param headers Additional request headers.
+ * @returns A `fetch` options object merged with shared defaults.
+ */
 function buildFetchOptions(method: string, body: string | undefined, headers: RequestHeaders = {}) {
-    return {
-        ...fetchOpts,
-        method,
-        headers: new Headers({
-            ...Object.fromEntries(defaultHeaders.entries()),
-            ...(headers || {})
-        }),
-        ...(body !== undefined ? { body } : {})
-    };
+  return {
+    ...fetchOpts,
+    method,
+    headers: new Headers({
+      ...Object.fromEntries(defaultHeaders.entries()),
+      ...(headers || {}),
+    }),
+    ...(body !== undefined ? { body } : {}),
+  };
 }
 
+/**
+ * Sends a POST request expected to return JSON and parses the response.
+ *
+ * @param url Target URL.
+ * @param body Optional encoded request body.
+ * @param headers Additional request headers.
+ * @returns The parsed JSON payload.
+ */
 export async function fetchJSONPost(url: string, body: string = "", headers: RequestHeaders = {}) {
-    logger.info(`[HTTP] POST ${url} ...`);
-    const result = await fetch(url, buildFetchOptions("POST", body, headers)).then(parseJsonResponse);
-    logger.debug(`[HTTP] POST ${url} : ${JSON.stringify(result)}`);
-    return result;
+  logger.info(`[HTTP] POST ${url} ...`);
+  const result = await fetch(url, buildFetchOptions("POST", body, headers)).then(parseJsonResponse);
+  logger.debug(`[HTTP] POST ${url} : ${JSON.stringify(result)}`);
+  return result;
 }

--- a/src/helpers/jsonSchema.ts
+++ b/src/helpers/jsonSchema.ts
@@ -1,14 +1,29 @@
 import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
 
+export type PublishedInputSchema = {
+  type: "object";
+  properties?: Record<string, object>;
+  required?: string[];
+  additionalProperties?: boolean;
+  $schema?: string;
+  [key: string]: unknown;
+};
+
 /**
  * Converts a Zod input schema into an MCP-compatible JSON Schema for publication.
  *
  * Uses strict union emission and, for `z.pipe(...)`, publishes the pre-transform
  * argument shape (the value callers must send), not the transformed output shape.
+ *
+ * Note: with our current Zod v3 stack, the compat converter still emits an
+ * explicit draft-07 `$schema`. MCP defaults to 2020-12 only when `$schema` is
+ * absent, so callers should not assume this helper publishes 2020-12 today.
+ * The SDK helper supports a 2020-12 target on its Zod v4 path, but that option
+ * has no effect for the Zod v3 conversion path currently used in this repo.
  */
-export function generatePublishedInputSchema(schema: any) {
+export function generatePublishedInputSchema(schema: any): PublishedInputSchema {
   return toJsonSchemaCompat(schema, {
     strictUnions: true,
     pipeStrategy: "input",
-  });
+  }) as PublishedInputSchema;
 }

--- a/src/helpers/wfs_engine/attributeFilter.ts
+++ b/src/helpers/wfs_engine/attributeFilter.ts
@@ -9,6 +9,8 @@ import type { CollectionProperty } from "@ignfab/gpf-schema-store";
 
 import type { WhereClause } from "./schema.js";
 
+// --- Normalized Clause Types ---
+
 type ScalarValue = string | number | boolean;
 
 type NormalizedWhereClause =
@@ -16,6 +18,8 @@ type NormalizedWhereClause =
   | { property: string; operator: "lt" | "lte" | "gt" | "gte"; value: number | string }
   | { property: string; operator: "in"; values: ScalarValue[] }
   | { property: string; operator: "is_null" };
+
+// --- CQL Operator Mappings ---
 
 export const SCALAR_COMPARISON_OPERATORS = {
   eq: "=",
@@ -28,6 +32,8 @@ export const NUMERIC_COMPARISON_OPERATORS = {
   gt: ">",
   gte: ">=",
 } as const;
+
+// --- Scalar Formatting ---
 
 /**
  * Escapes a string literal so it can be embedded safely in a CQL string value.
@@ -55,7 +61,9 @@ export function formatScalarValue(value: ScalarValue) {
   return String(value);
 }
 
-//TODO : this is not really robust
+// --- Property-Type Detection ---
+
+// TODO: Replace these heuristics with a more reliable mapping if catalog typing evolves.
 /**
  * Checks whether a property should be treated as boolean for value coercion.
  *
@@ -96,6 +104,8 @@ function isDateProperty(property: CollectionProperty) {
   const type = property.type.toLowerCase();
   return ["date", "datetime", "timestamp", "timestamptz"].includes(type) || property.name.startsWith("date_");
 }
+
+// --- Scalar Parsing ---
 
 /**
  * Parses a serialized numeric value and rejects non-finite numbers.
@@ -158,6 +168,8 @@ function parseBooleanString(value: string, message: string) {
   throw new Error(message);
 }
 
+// --- Clause Validation ---
+
 /**
  * Extracts the single serialized value required by operators such as `eq` or `gt`.
  *
@@ -184,6 +196,8 @@ function ensureNumericProperty(property: CollectionProperty, operator: keyof typ
     throw new Error(`L'opérateur '${operator}' n'est supporté que pour une propriété numérique ou de date. '${property.name}' est de type '${property.type}'.`);
   }
 }
+
+// --- Value Coercion ---
 
 /**
  * Coerces a serialized scalar value according to the target property metadata.
@@ -240,21 +254,33 @@ function coerceOrderedValueForProperty(property: CollectionProperty, value: stri
 export function normalizeWhereClause(property: CollectionProperty, clause: WhereClause): NormalizedWhereClause {
   switch (clause.operator) {
     case "eq":
-    case "ne":
+    case "ne": {
+      const value = getSingleStringValue(
+        clause,
+        `L'opérateur '${clause.operator}' exige exactement une propriété \`value\`.`,
+      );
+
       return {
         property: clause.property,
         operator: clause.operator,
-        value: coerceScalarValueForProperty(property, getSingleStringValue(clause, `L'opérateur '${clause.operator}' exige exactement une propriété \`value\`.`)),
+        value: coerceScalarValueForProperty(property, value),
       };
+    }
     case "lt":
     case "lte":
     case "gt":
-    case "gte":
+    case "gte": {
+      const value = getSingleStringValue(
+        clause,
+        `L'opérateur '${clause.operator}' exige exactement une propriété \`value\`.`,
+      );
+
       return {
         property: clause.property,
         operator: clause.operator,
-        value: coerceOrderedValueForProperty(property, getSingleStringValue(clause, `L'opérateur '${clause.operator}' exige exactement une propriété \`value\`.`), clause.operator),
+        value: coerceOrderedValueForProperty(property, value, clause.operator),
       };
+    }
     case "in":
       if (clause.value !== undefined || !Array.isArray(clause.values) || clause.values.length === 0 || !clause.values.every((value): value is string => typeof value === "string")) {
         throw new Error("L'opérateur 'in' exige une propriété `values` non vide.");

--- a/src/helpers/wfs_engine/byId.ts
+++ b/src/helpers/wfs_engine/byId.ts
@@ -7,48 +7,128 @@
 
 import type { Collection } from "@ignfab/gpf-schema-store";
 
-import { getFeatureType, fetchFeatureCollection } from "./execution.js";
-import { compileSelectProperty, getGeometryProperty } from "./compile.js";
+import {
+  getFeatureType,
+  fetchFeatureCollection,
+  type WfsFeatureCollectionResponse,
+  type WfsFeatureResponse,
+} from "./execution.js";
+import { validateSelectProperty, getGeometryProperty } from "./queryPreparation.js";
 import { buildGetFeatureByIdRequest } from "./request.js";
 import { attachFeatureRefs } from "./response.js";
 
+// --- Input Types ---
+
+/**
+ * Normalized execution input for the strict by-id `results` flow.
+ */
 export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
 };
 
-type BuildPropertyNameInput = {
-  result_type: "results" | "request";
+// --- Internal Types ---
+
+type PropertySelectionInput = {
+  includeGeometry?: boolean;
   select?: string[];
 };
+
+type FetchFeatureByIdInput = {
+  typename: string;
+  feature_id: string;
+  propertyName?: string;
+};
+
+// --- Property Selection ---
 
 /**
  * Builds the optional `propertyName` request parameter from `select`.
  *
  * @param featureType Feature type definition loaded from the embedded catalog.
- * @param input Normalized tool input.
+ * @param input Property selection options derived from the caller's output mode.
  * @returns A comma-separated property list, or `undefined` when all properties should be returned.
  */
 export function buildPropertyName(
-    featureType: Collection,
-    input: BuildPropertyNameInput,
+  featureType: Collection,
+  input: PropertySelectionInput,
 ) {
-    if (!input.select || input.select.length === 0) {
-        return undefined;
-    }
+  if (!input.select || input.select.length === 0) {
+    return undefined;
+  }
 
-    const geometryProperty = getGeometryProperty(featureType);
-    const selectedProperties = input.select.map((propertyName) =>
-        compileSelectProperty(featureType, geometryProperty, propertyName),
-    );
+  const geometryProperty = getGeometryProperty(featureType);
+  const selectedProperties = input.select.map((propertyName) =>
+    validateSelectProperty(featureType, geometryProperty, propertyName),
+  );
 
-    if (input.result_type === "request") {
-        return [...selectedProperties, geometryProperty.name].join(",");
-    }
+  if (input.includeGeometry) {
+    return [...selectedProperties, geometryProperty.name].join(",");
+  }
 
-    return selectedProperties.join(",");
+  return selectedProperties.join(",");
 }
+
+// --- Live Lookup ---
+
+/**
+ * Executes the live WFS lookup targeting a single `featureID`.
+ *
+ * @param input Target layer, expected feature id, and optional property selection.
+ * @returns The raw FeatureCollection returned by the WFS service.
+ */
+export async function fetchFeatureById(
+  input: FetchFeatureByIdInput,
+): Promise<WfsFeatureCollectionResponse> {
+  const request = buildGetFeatureByIdRequest(
+    input.typename,
+    input.feature_id,
+    input.propertyName,
+  );
+
+  return fetchFeatureCollection(request);
+}
+
+// --- Cardinality Enforcement ---
+
+/**
+ * Enforces the strict by-id contract on a raw WFS FeatureCollection.
+ *
+ * @param featureCollection Raw FeatureCollection returned by the WFS service.
+ * @param input Expected target layer and feature id.
+ * @returns The single matching feature.
+ */
+export function requireSingleFeatureById(
+  featureCollection: WfsFeatureCollectionResponse,
+  input: Pick<GetFeatureByIdExecutionInput, "typename" | "feature_id">,
+): WfsFeatureResponse {
+  if (!Array.isArray(featureCollection.features)) {
+    throw new Error("Le service WFS n'a pas retourné de collection d'objets exploitable.");
+  }
+
+  if (featureCollection.features.length === 0) {
+    throw new Error(`Le feature '${input.feature_id}' est introuvable dans '${input.typename}'.`);
+  }
+
+  if (featureCollection.features.length > 1) {
+    throw new Error(
+      `Le feature '${input.feature_id}' dans '${input.typename}' devrait être unique, mais ${featureCollection.features.length} objets ont été retournés.`,
+    );
+  }
+
+  const [firstFeature] = featureCollection.features;
+
+  if (firstFeature?.id !== input.feature_id) {
+    throw new Error(
+      `Le service WFS a retourné l'identifiant '${String(firstFeature?.id)}' au lieu de '${input.feature_id}'.`,
+    );
+  }
+
+  return firstFeature;
+}
+
+// --- Results Execution ---
 
 /**
  * Executes the structured WFS by-id flow for `result_type="results"`.
@@ -74,38 +154,15 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    result_type: "results",
+    includeGeometry: false,
     select: input.select,
   });
-  const request = buildGetFeatureByIdRequest(
-    input.typename,
-    input.feature_id,
+  const featureCollection = await fetchFeatureById({
+    typename: input.typename,
+    feature_id: input.feature_id,
     propertyName,
-  );
-
-  const featureCollection = await fetchFeatureCollection(request);
-
-  if (!Array.isArray(featureCollection?.features)) {
-    throw new Error("Le service WFS n'a pas retourné de collection d'objets exploitable.");
-  }
-
-  if (featureCollection.features.length === 0) {
-    throw new Error(`Le feature '${input.feature_id}' est introuvable dans '${input.typename}'.`);
-  }
-
-  if (featureCollection.features.length > 1) {
-    throw new Error(
-      `Le feature '${input.feature_id}' dans '${input.typename}' devrait être unique, mais ${featureCollection.features.length} objets ont été retournés.`
-    );
-  }
-
-  const [firstFeature] = featureCollection.features;
-
-  if (firstFeature?.id !== input.feature_id) {
-    throw new Error(
-      `Le service WFS a retourné l'identifiant '${String(firstFeature?.id)}' au lieu de '${input.feature_id}'.`
-    );
-  }
+  });
+  const firstFeature = requireSingleFeatureById(featureCollection, input);
 
   const singleFeatureCollection = {
     ...featureCollection,

--- a/src/helpers/wfs_engine/execution.ts
+++ b/src/helpers/wfs_engine/execution.ts
@@ -1,13 +1,35 @@
+/**
+ * Low-level WFS execution helpers for the structured WFS engine.
+ *
+ * This module centralizes:
+ * - feature type lookup from the embedded catalog
+ * - execution of compiled WFS requests
+ * - extraction of response-level metadata such as total hit counts
+ */
+
 import type { CompiledRequest } from "./request.js";
 import { wfsClient } from "../../gpf/wfs-schema-catalog.js";
-import { fetchJSONPost } from "../../helpers/http.js";
+import { fetchJSONPost } from "../http.js";
 
-/**
- * Shared WFS execution helpers for the structured WFS engine.
- *
- * This module centralizes catalog lookup, compiled request execution, and a few
- * low-level response helpers reused by MCP WFS tools.
- */
+// --- Response Types ---
+
+export type WfsFeatureResponse = {
+  type?: "Feature";
+  id?: string;
+  geometry?: unknown;
+  geometry_name?: string;
+  properties?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type WfsFeatureCollectionResponse = Record<string, unknown> & {
+  features?: WfsFeatureResponse[];
+  totalFeatures?: number;
+  numberMatched?: number | "unknown";
+  numberReturned?: number;
+};
+
+// --- Catalog Lookup ---
 
 /**
  * Loads a WFS feature type description from the embedded catalog.
@@ -16,8 +38,10 @@ import { fetchJSONPost } from "../../helpers/http.js";
  * @returns The matching feature type description.
  */
 export async function getFeatureType(typename: string) {
-    return wfsClient.getFeatureType(typename);
+  return wfsClient.getFeatureType(typename);
 }
+
+// --- Request Execution ---
 
 /**
  * Executes a compiled WFS request as POST and returns the JSON FeatureCollection.
@@ -25,13 +49,15 @@ export async function getFeatureType(typename: string) {
  * @param request Compiled request split into query-string parameters and POST body.
  * @returns The parsed JSON response returned by the WFS endpoint.
  */
-export async function fetchFeatureCollection(request: CompiledRequest) {
-    const url = `${request.url}?${new URLSearchParams(request.query).toString()}`;
-    return fetchJSONPost(url, request.body, {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Accept": "application/json",
-    });
+export async function fetchFeatureCollection(request: CompiledRequest): Promise<WfsFeatureCollectionResponse> {
+  const url = `${request.url}?${new URLSearchParams(request.query).toString()}`;
+  return fetchJSONPost(url, request.body, {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Accept": "application/json",
+  }) as Promise<WfsFeatureCollectionResponse>;
 }
+
+// --- Response Metadata ---
 
 /**
  * Extracts a result count from a WFS response, preferring `numberMatched`.
@@ -40,15 +66,15 @@ export async function fetchFeatureCollection(request: CompiledRequest) {
  * @param featureCollection Parsed WFS response object.
  * @returns The total number of matching features.
  */
-export function getMatchedFeatureCount(featureCollection: Record<string, unknown>) {
-    if (typeof featureCollection.numberMatched === "number") {
-        return featureCollection.numberMatched;
-    }
-    if (featureCollection.numberMatched === "unknown") {
-        throw new Error("Le service WFS a renvoyé un comptage indéterminé (numberMatched=\"unknown\").");
-    }
-    if (typeof featureCollection.totalFeatures === "number") {
-        return featureCollection.totalFeatures;
-    }
-    throw new Error("Le service WFS n'a pas retourné de comptage exploitable");
+export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionResponse) {
+  if (typeof featureCollection.numberMatched === "number") {
+    return featureCollection.numberMatched;
+  }
+  if (featureCollection.numberMatched === "unknown") {
+    throw new Error("Le service WFS a renvoyé un comptage indéterminé (numberMatched=\"unknown\").");
+  }
+  if (typeof featureCollection.totalFeatures === "number") {
+    return featureCollection.totalFeatures;
+  }
+  throw new Error("Le service WFS n'a pas retourné de comptage exploitable");
 }

--- a/src/helpers/wfs_engine/features.ts
+++ b/src/helpers/wfs_engine/features.ts
@@ -1,27 +1,3 @@
-import type { Collection } from "@ignfab/gpf-schema-store";
-
-import logger from "../../logger.js";
-import {
-  compileQueryParts,
-  geometryToEwkt,
-  getGeometryProperty,
-  getSpatialFilter,
-  type CompiledQuery,
-  type ResolvedFeatureGeometryRef,
-} from "./compile.js";
-import {
-  fetchFeatureCollection,
-  getFeatureType,
-  getMatchedFeatureCount,
-} from "./execution.js";
-import {
-  buildMainRequest,
-  buildReferenceGeometryRequest,
-  type CompiledRequest,
-} from "./request.js";
-import { attachFeatureRefs } from "./response.js";
-import type { GpfWfsGetFeaturesInput } from "./schema.js";
-
 /**
  * Shared execution helpers for structured WFS feature search.
  *
@@ -30,11 +6,46 @@ import type { GpfWfsGetFeaturesInput } from "./schema.js";
  * hit counting, and FeatureCollection post-processing.
  */
 
+import type { Collection } from "@ignfab/gpf-schema-store";
+
+import { isServiceResponseError } from "../http.js";
+import logger from "../../logger.js";
+import { fetchFeatureById, requireSingleFeatureById } from "./byId.js";
+import {
+  compileQueryParts,
+  geometryToEwkt,
+  getGeometryProperty,
+  getSpatialFilter,
+  type CompiledQuery,
+  type ResolvedFeatureGeometryRef,
+} from "./queryPreparation.js";
+import {
+  fetchFeatureCollection,
+  getFeatureType,
+  getMatchedFeatureCount,
+  type WfsFeatureCollectionResponse,
+} from "./execution.js";
+import {
+  buildMainRequest,
+  type CompiledRequest,
+} from "./request.js";
+import { attachFeatureRefs } from "./response.js";
+import type { GpfWfsGetFeaturesInput } from "./schema.js";
+
 // --- Types ---
 
+/**
+ * Prepared request context returned once the `get_features` input has been
+ * validated, compiled, and assembled into a live WFS request.
+ */
 export type PreparedGetFeaturesRequest = {
   compiled: CompiledQuery;
   request: CompiledRequest;
+};
+
+type GeometryLike = {
+  type: string;
+  coordinates: unknown;
 };
 
 // --- Validation ---
@@ -62,16 +73,28 @@ export function ensureIntersectsFeatureTargetsOtherTypename(
   }
 }
 
+/**
+ * Checks whether a raw value exposes the minimal geometry shape required by
+ * `geometryToEwkt`.
+ *
+ * @param value Unknown feature geometry value.
+ * @returns `true` when the value looks like a GeoJSON geometry object.
+ */
+function isGeometryLike(value: unknown): value is GeometryLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof value.type === "string" &&
+    "coordinates" in value
+  );
+}
+
 // --- Reference Geometry ---
 
 /**
  * Resolves the geometry of a reference feature when `intersects_feature` is used,
  * then converts it to EWKT for CQL compilation.
- *
- * This helper currently reads the first feature returned by the reference
- * lookup. It ensures that a feature exists and exposes a usable geometry, but
- * does not enforce strict uniqueness or exact `id` matching beyond what the WFS
- * request itself guarantees.
  *
  * @param input Normalized tool input.
  * @returns The resolved reference geometry, or `undefined` when no reference feature is needed.
@@ -86,30 +109,23 @@ export async function resolveIntersectsFeatureGeometry(
 
   const referenceFeatureType = await getFeatureType(spatialFilter.typename);
   const referenceGeometryProperty = getGeometryProperty(referenceFeatureType);
-  const request = buildReferenceGeometryRequest(
-    spatialFilter.typename,
-    spatialFilter.feature_id,
-    referenceGeometryProperty.name,
-  );
-  const featureCollection = await fetchFeatureCollection(request);
-  const referenceFeature = Array.isArray(featureCollection?.features)
-    ? featureCollection.features[0]
-    : undefined;
+  const featureCollection = await fetchFeatureById({
+    typename: spatialFilter.typename,
+    feature_id: spatialFilter.feature_id,
+    propertyName: referenceGeometryProperty.name,
+  });
+  const referenceFeature = requireSingleFeatureById(featureCollection, {
+    typename: spatialFilter.typename,
+    feature_id: spatialFilter.feature_id,
+  });
 
-  if (!referenceFeature) {
-    throw new Error(
-      `Le feature de référence '${spatialFilter.feature_id}' est introuvable dans '${spatialFilter.typename}'.`,
-    );
-  }
-  if (!referenceFeature?.geometry) {
+  if (!isGeometryLike(referenceFeature?.geometry)) {
     throw new Error(
       `Le feature de référence '${spatialFilter.feature_id}' n'a pas de géométrie exploitable.`,
     );
   }
 
   return {
-    typename: spatialFilter.typename,
-    feature_id: spatialFilter.feature_id,
     geometry_ewkt: geometryToEwkt(referenceFeature.geometry),
   };
 }
@@ -129,11 +145,18 @@ export async function resolveIntersectsFeatureGeometry(
 export async function prepareGetFeaturesRequest(
   input: GpfWfsGetFeaturesInput,
 ): Promise<PreparedGetFeaturesRequest> {
+  // TODO: Assess if this guard does not prevent legitimate use cases.
   ensureIntersectsFeatureTargetsOtherTypename(input);
-
+  // Get the feature type definition from the embedded catalog to access
+  // property definitions and the geometry column name.
   const featureType: Collection = await getFeatureType(input.typename);
+  // Resolve the reference geometry for `intersects_feature`, when needed by
+  // the selected spatial filter.
   const resolvedGeometryRef = await resolveIntersectsFeatureGeometry(input);
+  // Compile query fragments from the normalized input, feature type, and
+  // optional resolved reference geometry.
   const compiled = compileQueryParts(input, featureType, resolvedGeometryRef);
+  // Assemble the final WFS request from the compiled fragments.
   const request = buildMainRequest(input, compiled);
 
   return { compiled, request };
@@ -154,17 +177,21 @@ export async function prepareGetFeaturesRequest(
 export async function executeGetFeatures(input: GpfWfsGetFeaturesInput) {
   const { compiled, request } = await prepareGetFeaturesRequest(input);
 
-  let featureCollection: any;
+  let featureCollection: WfsFeatureCollectionResponse;
+
   try {
     logger.info(
       `[gpf_wfs_get_features] POST ${request.url}?${new URLSearchParams(request.query).toString()}`,
     );
     featureCollection = await fetchFeatureCollection(request);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (message.includes(`Illegal property name: ${compiled.geometryProperty.name}`)) {
+    if (
+      isServiceResponseError(error) &&
+      error.serviceCode === "InvalidParameterValue" &&
+      error.serviceDetail === `Illegal property name: ${compiled.geometryProperty.name}`
+    ) {
       throw new Error(
-        `Le champ géométrique '${compiled.geometryProperty.name}' issu du catalogue embarqué est rejeté par le WFS live pour '${input.typename}'. Le catalogue embarqué est probablement désynchronisé. Détail : ${message}`,
+        `Le champ géométrique '${compiled.geometryProperty.name}' issu du catalogue embarqué est rejeté par le WFS live pour '${input.typename}'. Le catalogue embarqué est probablement désynchronisé. Détail : ${error.message}`,
       );
     }
     throw error;

--- a/src/helpers/wfs_engine/geometry.ts
+++ b/src/helpers/wfs_engine/geometry.ts
@@ -5,6 +5,8 @@
  * in spatial CQL predicates such as `intersects_feature`.
  */
 
+// --- Coordinate Serialization ---
+
 /**
  * Serializes a single coordinate pair into a WKT position.
  *
@@ -14,6 +16,8 @@
 function positionToWkt(position: [number, number]) {
   return `${position[0]} ${position[1]}`;
 }
+
+// --- Geometry Serialization ---
 
 /**
  * Serializes a GeoJSON-like geometry object into EWKT for CQL spatial predicates.

--- a/src/helpers/wfs_engine/properties.ts
+++ b/src/helpers/wfs_engine/properties.ts
@@ -8,6 +8,9 @@
  */
 
 import type { Collection, CollectionProperty } from "@ignfab/gpf-schema-store";
+import type { GpfWfsGetFeaturesInput } from "./schema.js";
+
+// --- Property Listing ---
 
 /**
  * Lists available property names for a feature type, mainly for error reporting.
@@ -18,6 +21,8 @@ import type { Collection, CollectionProperty } from "@ignfab/gpf-schema-store";
 function getPropertyList(featureType: Collection) {
   return featureType.properties.map((property) => property.name).join(", ");
 }
+
+// --- Geometry Resolution ---
 
 /**
  * Returns every geometry-like property exposed by a feature type.
@@ -46,6 +51,8 @@ export function getGeometryProperty(featureType: Collection) {
   return geometryProperties[0];
 }
 
+// --- Generic Property Resolution ---
+
 /**
  * Loads a property by exact name and throws a descriptive error when it does not exist.
  *
@@ -56,14 +63,19 @@ export function getGeometryProperty(featureType: Collection) {
 function getPropertyOrThrow(featureType: Collection, propertyName: string) {
   const property = featureType.properties.find((candidate) => candidate.name === propertyName);
   if (!property) {
-    //throw new Error(`La propriété '${propertyName}' n'existe pas pour '${featureType.id}'. Utiliser une propriété parmi : ${getPropertyList(featureType)}.`);
-    throw new Error(`La propriété '${propertyName}' n'existe pas pour '${featureType.id}'. Appelle \`gpf_wfs_describe_type\` pour obtenir la liste des propriétés disponibles.`);
+    throw new Error(
+      `La propriété '${propertyName}' n'existe pas pour '${featureType.id}'. ` +
+      `Appelle \`gpf_wfs_describe_type\` pour obtenir la liste des propriétés disponibles.`,
+    );
   }
   return property;
 }
 
+// --- Non-Geometry Validation ---
+
 /**
- * Ensures that a property exists and is not the geometry column of the feature type.
+ * Resolves a property by exact name and ensures it is not the geometry column
+ * of the feature type.
  *
  * @param featureType Feature type definition loaded from the embedded catalog.
  * @param geometryProperty Geometry property already resolved for the feature type.
@@ -71,13 +83,15 @@ function getPropertyOrThrow(featureType: Collection, propertyName: string) {
  * @param message Error message template used when the property is geometric.
  * @returns The matching non-geometric property metadata.
  */
-export function ensureNonGeometryProperty(featureType: Collection, geometryProperty: CollectionProperty, propertyName: string, message: string) {
+export function resolveNonGeometryProperty(featureType: Collection, geometryProperty: CollectionProperty, propertyName: string, message: string) {
   const property = getPropertyOrThrow(featureType, propertyName);
   if (property.name === geometryProperty.name || property.defaultCrs) {
     throw new Error(message.replace("{property}", property.name));
   }
   return property;
 }
+
+// --- Select Validation ---
 
 /**
  * Validates a selected property name and returns the exact property name to expose.
@@ -87,11 +101,60 @@ export function ensureNonGeometryProperty(featureType: Collection, geometryPrope
  * @param propertyName Raw selected property name.
  * @returns The validated non-geometric property name.
  */
-export function compileSelectProperty(featureType: Collection, geometryProperty: CollectionProperty, propertyName: string) {
-  return ensureNonGeometryProperty(
+export function validateSelectProperty(featureType: Collection, geometryProperty: CollectionProperty, propertyName: string) {
+  return resolveNonGeometryProperty(
     featureType,
     geometryProperty,
     propertyName,
     "La propriété '{property}' est géométrique. `select` accepte uniquement des propriétés non géométriques."
   ).name;
+}
+
+// --- Property Selection ---
+
+/**
+ * Builds the list of property names to return according to `select` and `result_type`.
+ *
+ * Note that:
+ * - when `select` is omitted and `result_type` is `results`, every non-geometric property is returned
+ * - when `select` is provided, each property is validated against the embedded catalog
+ * - when `result_type` is `request`, the geometry column is appended to the requested selection
+ *
+ * @param featureType Feature type definition loaded from the embedded catalog.
+ * @param geometryProperty Geometry property already resolved for the feature type.
+ * @param input Normalized tool input.
+ * @returns The list of property names to expose in the WFS `propertyName` parameter.
+ */
+export function buildSelectList(
+  featureType: Collection,
+  geometryProperty: CollectionProperty,
+  input: GpfWfsGetFeaturesInput,
+) {
+  // If `select` is specified, only the requested properties are returned
+  // after validation against the embedded catalog.
+  if (input.select && input.select.length > 0) {
+    const selectedProperties = input.select.map((propertyName) =>
+      validateSelectProperty(featureType, geometryProperty, propertyName),
+    );
+
+    // For `result_type="request"`, also include the geometry column so the
+    // compiled request stays directly usable for mapping/debugging.
+    if (input.result_type === "request") {
+      return [...selectedProperties, geometryProperty.name];
+    }
+
+    return selectedProperties;
+  }
+
+  // If `select` is omitted and `result_type="results"`, return every
+  // non-geometric property from the feature type.
+  if (input.result_type === "results") {
+    return featureType.properties
+      .filter((property) => !property.defaultCrs)
+      .map((property) => property.name);
+  }
+
+  // If `select` is omitted and `result_type` is `hits` or `request`,
+  // do not send any `propertyName` selection.
+  return [];
 }

--- a/src/helpers/wfs_engine/queryPreparation.ts
+++ b/src/helpers/wfs_engine/queryPreparation.ts
@@ -1,11 +1,22 @@
+/**
+ * Query preparation helpers for the structured WFS engine.
+ *
+ * This module centralizes:
+ * - compilation of attribute clauses into CQL fragments
+ * - compilation of spatial filters into CQL fragments
+ * - assembly of query parts used by WFS request builders
+ * - a small façade over lower-level helpers reused elsewhere in the engine
+ */
+
 import type { Collection, CollectionProperty } from "@ignfab/gpf-schema-store";
 
 import {
-  compileSelectProperty,
-  ensureNonGeometryProperty,
+  validateSelectProperty,
+  buildSelectList,
+  resolveNonGeometryProperty,
   getGeometryProperty,
 } from "./properties.js";
-import { getSpatialFilter } from "./spatial.js";
+import { getSpatialFilter } from "./spatialFilter.js";
 
 import type {
   GpfWfsGetFeaturesInput,
@@ -18,7 +29,7 @@ import {
   normalizeWhereClause,
   SCALAR_COMPARISON_OPERATORS,
   NUMERIC_COMPARISON_OPERATORS,
-} from "./where.js";
+} from "./attributeFilter.js";
 
 import {
   compileBboxSpatialFilter,
@@ -27,18 +38,28 @@ import {
   compileIntersectsPointSpatialFilter,
 } from "./spatialCql.js";
 
+// --- Re-exports ---
+
 export { geometryToEwkt } from "./geometry.js";
-export { compileSelectProperty, getGeometryProperty } from "./properties.js";
-export { getSpatialFilter } from "./spatial.js";
+export { validateSelectProperty, getGeometryProperty } from "./properties.js";
+export { getSpatialFilter } from "./spatialFilter.js";
+
+// --- Internal Constants ---
 
 const ORDER_DIRECTION_TO_WFS = {
   asc: "A",
   desc: "D",
 } as const;
 
+// --- Internal Clause Types ---
+
+type ScalarComparisonClause = Extract<ReturnType<typeof normalizeWhereClause>, { operator: "eq" | "ne" }>;
+type OrderedComparisonClause = Extract<ReturnType<typeof normalizeWhereClause>, { operator: "lt" | "lte" | "gt" | "gte" }>;
+type InClause = Extract<ReturnType<typeof normalizeWhereClause>, { operator: "in" }>;
+
+// --- Public Types ---
+
 export type ResolvedFeatureGeometryRef = {
-  typename: string;
-  feature_id: string;
   geometry_ewkt: string;
 };
 
@@ -52,6 +73,55 @@ export type CompiledQuery = {
 // --- Attribute Compilation ---
 
 /**
+ * Compiles a normalized scalar comparison (`eq` / `ne`) into a CQL fragment.
+ *
+ * @param property Non-geometric property targeted by the clause.
+ * @param clause Normalized scalar comparison clause.
+ * @returns A CQL predicate fragment.
+ */
+function compileScalarComparisonClause(
+  property: CollectionProperty,
+  clause: ScalarComparisonClause,
+) {
+  return `${property.name} ${SCALAR_COMPARISON_OPERATORS[clause.operator]} ${formatScalarValue(clause.value)}`;
+}
+
+/**
+ * Compiles a normalized ordered comparison (`lt` / `lte` / `gt` / `gte`) into a CQL fragment.
+ *
+ * @param property Non-geometric property targeted by the clause.
+ * @param clause Normalized ordered comparison clause.
+ * @returns A CQL predicate fragment.
+ */
+function compileOrderedComparisonClause(
+  property: CollectionProperty,
+  clause: OrderedComparisonClause,
+) {
+  return `${property.name} ${NUMERIC_COMPARISON_OPERATORS[clause.operator]} ${formatScalarValue(clause.value)}`;
+}
+
+/**
+ * Compiles a normalized `in` clause into a CQL fragment.
+ *
+ * @param property Non-geometric property targeted by the clause.
+ * @param clause Normalized `in` clause.
+ * @returns A CQL predicate fragment.
+ */
+function compileInClause(property: CollectionProperty, clause: InClause) {
+  return `${property.name} IN (${clause.values.map(formatScalarValue).join(", ")})`;
+}
+
+/**
+ * Compiles a normalized `is_null` clause into a CQL fragment.
+ *
+ * @param property Non-geometric property targeted by the clause.
+ * @returns A CQL predicate fragment.
+ */
+function compileIsNullClause(property: CollectionProperty) {
+  return `${property.name} IS NULL`;
+}
+
+/**
  * Compiles a structured where clause into a CQL fragment.
  *
  * @param featureType Feature type definition loaded from the embedded catalog.
@@ -60,7 +130,7 @@ export type CompiledQuery = {
  * @returns A CQL predicate fragment.
  */
 function compileWhereClause(featureType: Collection, geometryProperty: CollectionProperty, clause: WhereClause) {
-  const property = ensureNonGeometryProperty(
+  const property = resolveNonGeometryProperty(
     featureType,
     geometryProperty,
     clause.property,
@@ -71,16 +141,16 @@ function compileWhereClause(featureType: Collection, geometryProperty: Collectio
   switch (normalized.operator) {
     case "eq":
     case "ne":
-      return `${property.name} ${SCALAR_COMPARISON_OPERATORS[normalized.operator]} ${formatScalarValue(normalized.value)}`;
+      return compileScalarComparisonClause(property, normalized);
     case "lt":
     case "lte":
     case "gt":
     case "gte":
-      return `${property.name} ${NUMERIC_COMPARISON_OPERATORS[normalized.operator]} ${formatScalarValue(normalized.value)}`;
+      return compileOrderedComparisonClause(property, normalized);
     case "in":
-      return `${property.name} IN (${normalized.values.map(formatScalarValue).join(", ")})`;
+      return compileInClause(property, normalized);
     case "is_null":
-      return `${property.name} IS NULL`;
+      return compileIsNullClause(property);
   }
 }
 
@@ -93,50 +163,13 @@ function compileWhereClause(featureType: Collection, geometryProperty: Collectio
  * @returns A WFS `sortBy` fragment.
  */
 function compileOrderByClause(featureType: Collection, geometryProperty: CollectionProperty, clause: OrderByClause) {
-  const property = ensureNonGeometryProperty(
+  const property = resolveNonGeometryProperty(
     featureType,
     geometryProperty,
     clause.property,
     "La propriété '{property}' est géométrique. Utiliser une propriété non géométrique pour `order_by`."
   );
   return `${property.name} ${ORDER_DIRECTION_TO_WFS[clause.direction]}`;
-}
-
-/**
- * Build the list of property names to return in the WFS response according to the `select` and `result_type` input parameters.
- *
- * Note that :
- * - When `select` is omitted and `result_type` is `results`, all non-geometric properties are returned.
- * - When `select` is provided, the specified properties are validated according to the featureType from the Catalog.
- * - When `result_type` is `request` and `select` is provided, the geometry column is automatically appended.
- *  
- * @param featureType Feature type definition loaded from the embedded catalog.
- * @param geometryProperty Geometry property already resolved for the feature type.
- * @param input Normalized tool input.
- * @returns The list of non-geometric property names to include in the WFS `propertyName` parameter, or an empty list to include all properties.
-*
- */
-function buildSelectList(featureType: Collection, geometryProperty: CollectionProperty, input: GpfWfsGetFeaturesInput) {
-  // if `select` is specified, we only return the requested properties (after validation)
-  if (input.select && input.select.length > 0) {
-    const selectedProperties = input.select.map((propertyName) => compileSelectProperty(featureType, geometryProperty, propertyName));
-    if (input.result_type === "request") {
-      return [...selectedProperties, geometryProperty.name];
-    }
-    return selectedProperties;
-  }
-
-  // if `select` is omitted and result_type is `results`,
-  // we return every non-geometric property 
-  if (input.result_type === "results") {
-    return featureType.properties
-      .filter((property) => !property.defaultCrs)
-      .map((property) => property.name);
-  }
-
-  // if `select` is omitted and result_type is `hits` or `request`
-  // we don't specify any propertyName
-  return [];
 }
 
 // --- Query Compilation ---
@@ -152,7 +185,7 @@ function buildSelectList(featureType: Collection, geometryProperty: CollectionPr
 export function compileQueryParts(
   input: GpfWfsGetFeaturesInput,
   featureType: Collection,
-  resolvedGeometryRef?: ResolvedFeatureGeometryRef
+  resolvedGeometryRef?: ResolvedFeatureGeometryRef,
 ): CompiledQuery {
   const geometryProperty = getGeometryProperty(featureType);
   const spatialFilter = getSpatialFilter(input);

--- a/src/helpers/wfs_engine/request.ts
+++ b/src/helpers/wfs_engine/request.ts
@@ -1,14 +1,54 @@
+/**
+ * WFS request builders used by the structured WFS engine.
+ *
+ * This module centralizes:
+ * - the transport shape shared by compiled requests
+ * - GET/POST request assembly helpers
+ * - the compact request payload exposed by MCP `result_type="request"`
+ */
+
 import { GPF_WFS_URL } from "../../gpf/wfs-schema-catalog.js";
 import type { GpfWfsGetFeaturesInput } from "./schema.js";
 import { REQUEST_GET_URL_MAX_LENGTH } from "./schema.js";
 
-export type CompiledRequest = {
+// --- Transport Types ---
+
+type WfsRequestTransport = {
   method: "POST";
   url: string;
   query: Record<string, string>;
   body: string;
+};
+
+export type CompiledRequest = WfsRequestTransport & {
   get_url?: string | null;
 };
+
+export type WfsRequestPayload = WfsRequestTransport & {
+  result_type: "request";
+  get_url: string | null;
+};
+
+// --- Request Payload Mapping ---
+
+/**
+ * Maps a compiled WFS request to the compact MCP request payload.
+ *
+ * @param request Compiled request ready to be executed against the WFS service.
+ * @returns A normalized request payload exposed by MCP tools.
+ */
+export function toWfsRequestPayload(request: CompiledRequest): WfsRequestPayload {
+  return {
+    result_type: "request",
+    method: request.method,
+    url: request.url,
+    query: request.query,
+    body: request.body,
+    get_url: request.get_url ?? null,
+  };
+}
+
+// --- Request Assembly Helpers ---
 
 /**
  * Encodes the optional CQL filter as an `application/x-www-form-urlencoded` POST body.
@@ -25,6 +65,9 @@ function buildBody(cqlFilter?: string) {
 
 /**
  * Builds a portable GET URL variant of the request when it stays below the configured limit.
+ *
+ * This helper is mainly used to populate `get_url` in request payloads
+ * returned by `result_type="request"`.
  *
  * @param url Base WFS endpoint URL.
  * @param query Query-string parameters sent with the request.
@@ -43,6 +86,8 @@ export function buildGetUrl(url: string, query: Record<string, string>, cqlFilte
   return getUrl;
 }
 
+// --- Public Builders ---
+
 /**
  * Builds the main WFS GetFeature request from normalized tool input and compiled query parts.
  *
@@ -52,7 +97,7 @@ export function buildGetUrl(url: string, query: Record<string, string>, cqlFilte
  */
 export function buildMainRequest(
   input: GpfWfsGetFeaturesInput,
-  compiled: { cqlFilter?: string; propertyName?: string; sortBy?: string }
+  compiled: { cqlFilter?: string; propertyName?: string; sortBy?: string },
 ): CompiledRequest {
   const query: Record<string, string> = {
     service: "WFS",

--- a/src/helpers/wfs_engine/response.ts
+++ b/src/helpers/wfs_engine/response.ts
@@ -6,6 +6,8 @@
  * and applies targeted transformations needed by the generic WFS toolchain.
  */
 
+// --- Response Types ---
+
 type GenericFeature = {
   id?: string;
   geometry?: unknown;
@@ -17,6 +19,8 @@ type GenericFeatureCollection = {
   features?: GenericFeature[];
   [key: string]: unknown;
 };
+
+// --- Response Transformation ---
 
 /**
  * Removes raw geometry payloads from a FeatureCollection, keeps GeoJSON validity by forcing
@@ -51,6 +55,8 @@ export function transformFeatureCollectionResponse(featureCollection: GenericFea
   const { crs: _crs, ...restCollection } = featureCollection;
   return { ...restCollection, features: transformedFeatures };
 }
+
+// --- Feature References ---
 
 /**
  * Transforms a FeatureCollection and injects the exact queried typename into each `feature_ref`.

--- a/src/helpers/wfs_engine/schema.ts
+++ b/src/helpers/wfs_engine/schema.ts
@@ -1,7 +1,18 @@
+/**
+ * Zod schemas and published MCP input schemas for the structured WFS engine.
+ *
+ * This module centralizes:
+ * - shared schema fragments reused by WFS tools
+ * - public tool input schemas and inferred input types
+ * - compact output schemas used for `hits` and `request` responses
+ */
+
 import { z } from "zod";
 
 import { generatePublishedInputSchema } from "../jsonSchema.js";
 import { lonSchema, latSchema } from "../schemas.js";
+
+// --- Shared Constants ---
 
 export const DEFAULT_LIMIT = 100;
 export const MAX_LIMIT = 5000;
@@ -9,6 +20,8 @@ export const REQUEST_GET_URL_MAX_LENGTH = 6000;
 export const WHERE_OPERATORS = ["eq", "ne", "lt", "lte", "gt", "gte", "in", "is_null"] as const;
 export const SPATIAL_OPERATORS = ["bbox", "intersects_point", "dwithin_point", "intersects_feature"] as const;
 export const ORDER_DIRECTIONS = ["asc", "desc"] as const;
+
+// --- Shared Clauses ---
 
 const whereClauseSchema = z.object({
   property: z.string().trim().min(1).describe("Nom exact d'une propriété non géométrique du type WFS. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles."),
@@ -21,6 +34,30 @@ const orderBySchema = z.object({
   property: z.string().trim().min(1).describe("Nom exact d'une propriété non géométrique à utiliser pour le tri. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles."),
   direction: z.enum(ORDER_DIRECTIONS).default("asc").describe("Direction de tri : `asc` ou `desc`."),
 }).strict().describe("Critère de tri structuré. Exemple : `{ property: \"population\", direction: \"desc\" }`.");
+
+// --- Shared Types ---
+
+export type SpatialFilter =
+  | { operator: "bbox"; west: number; south: number; east: number; north: number }
+  | { operator: "intersects_point"; lon: number; lat: number }
+  | { operator: "dwithin_point"; lon: number; lat: number; distance_m: number }
+  | { operator: "intersects_feature"; typename: string; feature_id: string };
+
+// --- Shared Compact Outputs ---
+
+const wfsRequestOutputSchema = z.object({
+  result_type: z.literal("request").describe("Indique que la réponse contient la requête WFS compilée (équivalent enrichi géométrie pour `create_map` et le débogage)."),
+  method: z.literal("POST").describe("Méthode HTTP réellement utilisée pour exécuter la requête."),
+  url: z.string().describe("URL de base appelée pour la requête POST."),
+  query: z.record(z.string()).describe("Paramètres WFS envoyés dans la query string."),
+  body: z.string().describe("Corps de la requête POST, encodé en `application/x-www-form-urlencoded`."),
+  get_url: z.string().nullable().optional().describe("URL GET dérivée quand la requête reste raisonnablement portable en GET."),
+});
+
+export const gpfWfsGetFeaturesRequestOutputSchema = wfsRequestOutputSchema;
+export const gpfWfsGetFeatureByIdRequestOutputSchema = wfsRequestOutputSchema;
+
+// --- `gpf_wfs_get_features` ---
 
 export const gpfWfsGetFeaturesInputSchema = z.object({
   typename: z
@@ -71,34 +108,51 @@ export const gpfWfsGetFeaturesInputSchema = z.object({
   intersects_feature_id: z.string().trim().min(1).optional().describe("Identifiant du feature de référence, utilisé avec `spatial_operator = \"intersects_feature\"`."),
 }).strict();
 
+// --- `gpf_wfs_get_features` Types ---
+
 export type GpfWfsGetFeaturesInput = z.infer<typeof gpfWfsGetFeaturesInputSchema>;
 export type WhereClause = NonNullable<GpfWfsGetFeaturesInput["where"]>[number];
 export type OrderByClause = NonNullable<GpfWfsGetFeaturesInput["order_by"]>[number];
 
-export type SpatialFilter =
-  | { operator: "bbox"; west: number; south: number; east: number; north: number }
-  | { operator: "intersects_point"; lon: number; lat: number }
-  | { operator: "dwithin_point"; lon: number; lat: number; distance_m: number }
-  | { operator: "intersects_feature"; typename: string; feature_id: string };
+// --- `gpf_wfs_get_features` Outputs ---
 
 export const gpfWfsGetFeaturesHitsOutputSchema = z.object({
   result_type: z.literal("hits").describe("Indique que la réponse contient uniquement un comptage."),
   totalFeatures: z.number().describe("Le nombre total d'objets correspondant à la requête."),
 });
 
-export const gpfWfsGetFeaturesRequestOutputSchema = z.object({
-  result_type: z.literal("request").describe("Indique que la réponse contient la requête WFS compilée (équivalent enrichi géométrie pour `create_map` et le débogage)."),
-  method: z.literal("POST").describe("Méthode HTTP réellement utilisée pour exécuter la requête."),
-  url: z.string().describe("URL de base appelée pour la requête POST."),
-  query: z.record(z.string()).describe("Paramètres WFS envoyés dans la query string."),
-  body: z.string().describe("Corps de la requête POST, encodé en `application/x-www-form-urlencoded`."),
-  get_url: z.string().nullable().optional().describe("URL GET dérivée quand la requête reste raisonnablement portable en GET."),
-});
+// --- `gpf_wfs_get_features` Published Schema ---
 
-type PublishedInputSchema = {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-};
+export const gpfWfsGetFeaturesPublishedInputSchema = generatePublishedInputSchema(gpfWfsGetFeaturesInputSchema);
 
-export const gpfWfsGetFeaturesPublishedInputSchema = generatePublishedInputSchema(gpfWfsGetFeaturesInputSchema) as PublishedInputSchema;
+// --- `gpf_wfs_get_feature_by_id` ---
+
+export const gpfWfsGetFeatureByIdInputSchema = z.object({
+  typename: z
+    .string()
+    .trim()
+    .min(1, "le nom du type ne doit pas être vide")
+    .describe("Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`."),
+  feature_id: z
+    .string()
+    .trim()
+    .min(1, "le feature_id ne doit pas être vide")
+    .describe("Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`."),
+  result_type: z
+    .enum(["results", "request"])
+    .default("results")
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer."),
+  select: z
+    .array(z.string().trim().min(1))
+    .min(1)
+    .optional()
+    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée."),
+}).strict();
+
+// --- `gpf_wfs_get_feature_by_id` Types ---
+
+export type GpfWfsGetFeatureByIdInput = z.infer<typeof gpfWfsGetFeatureByIdInputSchema>;
+
+// --- `gpf_wfs_get_feature_by_id` Published Schema ---
+
+export const gpfWfsGetFeatureByIdPublishedInputSchema = generatePublishedInputSchema(gpfWfsGetFeatureByIdInputSchema);

--- a/src/helpers/wfs_engine/spatialCql.ts
+++ b/src/helpers/wfs_engine/spatialCql.ts
@@ -9,6 +9,8 @@ import type { CollectionProperty } from "@ignfab/gpf-schema-store";
 
 import type { SpatialFilter } from "./schema.js";
 
+// --- Spatial Predicate Compilation ---
+
 /**
  * Compiles a bbox spatial filter into a CQL predicate.
  *

--- a/src/helpers/wfs_engine/spatialFilter.ts
+++ b/src/helpers/wfs_engine/spatialFilter.ts
@@ -10,10 +10,14 @@ import type {
   SpatialFilter,
 } from "./schema.js";
 
+// --- Parameter Groups ---
+
 const BBOX_PARAM_NAMES = ["bbox_west", "bbox_south", "bbox_east", "bbox_north"] as const;
 const INTERSECTS_POINT_PARAM_NAMES = ["intersects_lon", "intersects_lat"] as const;
 const DWITHIN_PARAM_NAMES = ["dwithin_lon", "dwithin_lat", "dwithin_distance_m"] as const;
 const INTERSECTS_FEATURE_PARAM_NAMES = ["intersects_feature_typename", "intersects_feature_id"] as const;
+
+// --- Parameter Detection ---
 
 /**
  * Checks whether any property in a named group is defined on the raw input object.
@@ -25,6 +29,85 @@ const INTERSECTS_FEATURE_PARAM_NAMES = ["intersects_feature_typename", "intersec
 function hasAny(input: GpfWfsGetFeaturesInput, keys: readonly string[]) {
   return keys.some((name) => input[name as keyof GpfWfsGetFeaturesInput] !== undefined);
 }
+
+// --- Per-Mode Readers ---
+
+/**
+ * Reads and validates the `bbox` spatial filter parameters.
+ *
+ * @param input Normalized tool input.
+ * @returns A normalized `bbox` spatial filter.
+ */
+function readBboxFilter(input: GpfWfsGetFeaturesInput): SpatialFilter {
+  if (input.bbox_west === undefined || input.bbox_south === undefined || input.bbox_east === undefined || input.bbox_north === undefined) {
+    throw new Error("Le filtre spatial `bbox` exige `bbox_west`, `bbox_south`, `bbox_east` et `bbox_north`.");
+  }
+
+  return {
+    operator: "bbox",
+    west: input.bbox_west,
+    south: input.bbox_south,
+    east: input.bbox_east,
+    north: input.bbox_north,
+  };
+}
+
+/**
+ * Reads and validates the `intersects_point` spatial filter parameters.
+ *
+ * @param input Normalized tool input.
+ * @returns A normalized `intersects_point` spatial filter.
+ */
+function readIntersectsPointFilter(input: GpfWfsGetFeaturesInput): SpatialFilter {
+  if (input.intersects_lon === undefined || input.intersects_lat === undefined) {
+    throw new Error("Le filtre spatial `intersects_point` exige `intersects_lon` et `intersects_lat`.");
+  }
+
+  return {
+    operator: "intersects_point",
+    lon: input.intersects_lon,
+    lat: input.intersects_lat,
+  };
+}
+
+/**
+ * Reads and validates the `dwithin_point` spatial filter parameters.
+ *
+ * @param input Normalized tool input.
+ * @returns A normalized `dwithin_point` spatial filter.
+ */
+function readDwithinPointFilter(input: GpfWfsGetFeaturesInput): SpatialFilter {
+  if (input.dwithin_lon === undefined || input.dwithin_lat === undefined || input.dwithin_distance_m === undefined) {
+    throw new Error("Le filtre spatial `dwithin_point` exige `dwithin_lon`, `dwithin_lat` et `dwithin_distance_m`.");
+  }
+
+  return {
+    operator: "dwithin_point",
+    lon: input.dwithin_lon,
+    lat: input.dwithin_lat,
+    distance_m: input.dwithin_distance_m,
+  };
+}
+
+/**
+ * Reads and validates the `intersects_feature` spatial filter parameters.
+ *
+ * @param input Normalized tool input.
+ * @returns A normalized `intersects_feature` spatial filter.
+ */
+function readIntersectsFeatureFilter(input: GpfWfsGetFeaturesInput): SpatialFilter {
+  if (!input.intersects_feature_typename || !input.intersects_feature_id) {
+    throw new Error("Le filtre spatial `intersects_feature` exige `intersects_feature_typename` et `intersects_feature_id`.");
+  }
+
+  return {
+    operator: "intersects_feature",
+    typename: input.intersects_feature_typename,
+    feature_id: input.intersects_feature_id,
+  };
+}
+
+// --- Public Normalization ---
 
 /**
  * Normalizes the raw spatial input into a discriminated spatial filter object.
@@ -48,33 +131,21 @@ export function getSpatialFilter(input: GpfWfsGetFeaturesInput): SpatialFilter |
       if (hasIntersectsPointParams || hasDwithinParams || hasIntersectsFeatureParams) {
         throw new Error("Le filtre spatial `bbox` n'accepte pas les paramètres d'un autre mode spatial.");
       }
-      if (input.bbox_west === undefined || input.bbox_south === undefined || input.bbox_east === undefined || input.bbox_north === undefined) {
-        throw new Error("Le filtre spatial `bbox` exige `bbox_west`, `bbox_south`, `bbox_east` et `bbox_north`.");
-      }
-      return { operator: "bbox", west: input.bbox_west, south: input.bbox_south, east: input.bbox_east, north: input.bbox_north };
+      return readBboxFilter(input);
     case "intersects_point":
       if (hasBboxParams || hasDwithinParams || hasIntersectsFeatureParams) {
         throw new Error("Le filtre spatial `intersects_point` n'accepte pas les paramètres d'un autre mode spatial.");
       }
-      if (input.intersects_lon === undefined || input.intersects_lat === undefined) {
-        throw new Error("Le filtre spatial `intersects_point` exige `intersects_lon` et `intersects_lat`.");
-      }
-      return { operator: "intersects_point", lon: input.intersects_lon, lat: input.intersects_lat };
+      return readIntersectsPointFilter(input);
     case "dwithin_point":
       if (hasBboxParams || hasIntersectsPointParams || hasIntersectsFeatureParams) {
         throw new Error("Le filtre spatial `dwithin_point` n'accepte pas les paramètres d'un autre mode spatial.");
       }
-      if (input.dwithin_lon === undefined || input.dwithin_lat === undefined || input.dwithin_distance_m === undefined) {
-        throw new Error("Le filtre spatial `dwithin_point` exige `dwithin_lon`, `dwithin_lat` et `dwithin_distance_m`.");
-      }
-      return { operator: "dwithin_point", lon: input.dwithin_lon, lat: input.dwithin_lat, distance_m: input.dwithin_distance_m };
+      return readDwithinPointFilter(input);
     case "intersects_feature":
       if (hasBboxParams || hasIntersectsPointParams || hasDwithinParams) {
         throw new Error("Le filtre spatial `intersects_feature` n'accepte pas les paramètres d'un autre mode spatial.");
       }
-      if (!input.intersects_feature_typename || !input.intersects_feature_id) {
-        throw new Error("Le filtre spatial `intersects_feature` exige `intersects_feature_typename` et `intersects_feature_id`.");
-      }
-      return { operator: "intersects_feature", typename: input.intersects_feature_typename, feature_id: input.intersects_feature_id };
+      return readIntersectsFeatureFilter(input);
   }
 }

--- a/src/tools/AdminexpressTool.ts
+++ b/src/tools/AdminexpressTool.ts
@@ -1,3 +1,7 @@
+/**
+ * MCP tool exposing administrative units that cover a given point.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
@@ -5,10 +9,14 @@ import { getAdminUnits, ADMINEXPRESS_TYPES, ADMINEXPRESS_SOURCE } from "../gpf/a
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
 
+// --- Schema ---
+
 const adminexpressInputSchema = z.object({
   lon: lonSchema,
   lat: latSchema,
 }).strict();
+
+// --- Types ---
 
 type AdminexpressInput = z.infer<typeof adminexpressInputSchema>;
 
@@ -25,6 +33,8 @@ const adminexpressOutputSchema = z.object({
   results: z.array(adminexpressResultSchema).describe("La liste des unités administratives couvrant le point demandé."),
 });
 
+// --- Tool ---
+
 class AdminexpressTool extends MCPTool<AdminexpressInput> {
   name = "adminexpress";
   title = "Unités administratives";
@@ -40,6 +50,12 @@ class AdminexpressTool extends MCPTool<AdminexpressInput> {
 
   schema = adminexpressInputSchema;
 
+  /**
+   * Looks up the administrative units covering the requested point.
+   *
+   * @param input Normalized tool input.
+   * @returns The matching administrative units enriched with reusable `feature_ref` metadata.
+   */
   async execute(input: AdminexpressInput) {
     return {
       results: await getAdminUnits(input.lon, input.lat),

--- a/src/tools/AltitudeTool.ts
+++ b/src/tools/AltitudeTool.ts
@@ -1,3 +1,7 @@
+/**
+ * MCP tool exposing altitude lookup for a single geographic position.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
@@ -5,10 +9,14 @@ import { ALTITUDE_SOURCE, getAltitudeByLocation } from "../gpf/altitude.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { lonSchema, latSchema } from "../helpers/schemas.js";
 
+// --- Schema ---
+
 const altitudeInputSchema = z.object({
   lon: lonSchema,
   lat: latSchema,
 }).strict();
+
+// --- Types ---
 
 type AltitudeInput = z.infer<typeof altitudeInputSchema>;
 
@@ -23,6 +31,8 @@ const altitudeOutputSchema = z.object({
   result: altitudeResultSchema.describe("Le résultat altimétrique pour la position demandée."),
 });
 
+// --- Tool ---
+
 class AltitudeTool extends MCPTool<AltitudeInput> {
   name = "altitude";
   title = "Altitude d’une position";
@@ -32,6 +42,12 @@ class AltitudeTool extends MCPTool<AltitudeInput> {
 
   schema = altitudeInputSchema;
 
+  /**
+   * Resolves the altitude information for the requested position.
+   *
+   * @param input Normalized tool input.
+   * @returns The altitude payload returned by the upstream service.
+   */
   async execute(input: AltitudeInput) {
     return {
       result: await getAltitudeByLocation(input.lon, input.lat),

--- a/src/tools/AssietteSupTool.ts
+++ b/src/tools/AssietteSupTool.ts
@@ -1,3 +1,7 @@
+/**
+ * MCP tool exposing nearby servitudes d'utilité publique for a given point.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
@@ -5,10 +9,14 @@ import { getAssiettesServitudes, URBANISME_SOURCE } from "../gpf/urbanisme.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
 
+// --- Schema ---
+
 const assietteSupInputSchema = z.object({
   lon: lonSchema,
   lat: latSchema,
 }).strict();
+
+// --- Types ---
 
 type AssietteSupInput = z.infer<typeof assietteSupInputSchema>;
 
@@ -26,6 +34,8 @@ const assietteSupOutputSchema = z.object({
   results: z.array(assietteSupResultSchema).describe("La liste des assiettes de servitudes d'utilité publique pertinentes pour le point demandé."),
 });
 
+// --- Tool ---
+
 class AssietteSupTool extends MCPTool<AssietteSupInput> {
   name = "assiette_sup";
   title = "Servitudes d’utilité publique";
@@ -41,6 +51,12 @@ class AssietteSupTool extends MCPTool<AssietteSupInput> {
 
   schema = assietteSupInputSchema;
 
+  /**
+   * Looks up nearby SUP footprints relevant to the requested point.
+   *
+   * @param input Normalized tool input.
+   * @returns The list of nearby assiettes with optional reusable `feature_ref` metadata.
+   */
   async execute(input: AssietteSupInput) {
     return {
       results: await getAssiettesServitudes(input.lon, input.lat),

--- a/src/tools/CadastreTool.ts
+++ b/src/tools/CadastreTool.ts
@@ -1,3 +1,7 @@
+/**
+ * MCP tool exposing nearby cadastral objects for a given point.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
@@ -5,10 +9,14 @@ import { getParcellaireExpress, PARCELLAIRE_EXPRESS_TYPES, PARCELLAIRE_EXPRESS_S
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
 
+// --- Schema ---
+
 const cadastreInputSchema = z.object({
   lon: lonSchema,
   lat: latSchema,
 }).strict();
+
+// --- Types ---
 
 type CadastreInput = z.infer<typeof cadastreInputSchema>;
 
@@ -27,6 +35,7 @@ const cadastreOutputSchema = z.object({
   results: z.array(cadastreResultSchema).describe("La liste des objets cadastraux les plus proches du point demandé."),
 });
 
+// --- Tool ---
 
 class CadastreTool extends MCPTool<CadastreInput> {
   name = "cadastre";
@@ -44,6 +53,12 @@ class CadastreTool extends MCPTool<CadastreInput> {
 
   schema = cadastreInputSchema;
 
+  /**
+   * Returns the nearest cadastral objects around the requested point.
+   *
+   * @param input Normalized tool input.
+   * @returns The nearest cadastral objects, at most one per cadastral type.
+   */
   async execute(input: CadastreInput) {
     return {
       results: await getParcellaireExpress(input.lon, input.lat),

--- a/src/tools/GeocodeTool.ts
+++ b/src/tools/GeocodeTool.ts
@@ -1,8 +1,14 @@
+/**
+ * MCP tool exposing free-text geocoding and autocomplete.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
 import { geocode, GEOCODE_SOURCE } from "../gpf/geocode.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
+
+// --- Schema ---
 
 const geocodeInputSchema = z.object({
   text: z
@@ -19,6 +25,8 @@ const geocodeInputSchema = z.object({
     .describe("Le nombre maximum de résultats à retourner (entre 1 et 10). Défaut : 3."),
 }).strict();
 
+// --- Types ---
+
 type GeocodeInput = z.infer<typeof geocodeInputSchema>;
 
 const geocodeResultSchema = z.object({
@@ -34,6 +42,8 @@ const geocodeOutputSchema = z.object({
   results: z.array(geocodeResultSchema).describe("La liste ordonnée des résultats géocodés."),
 });
 
+// --- Tool ---
+
 class GeocodeTool extends MCPTool<GeocodeInput> {
   name = "geocode";
   title = "Géocodage de lieux et d’adresses";
@@ -47,6 +57,12 @@ class GeocodeTool extends MCPTool<GeocodeInput> {
 
   schema = geocodeInputSchema;
 
+  /**
+   * Geocodes a free-text query and returns the ordered candidate list.
+   *
+   * @param input Normalized tool input.
+   * @returns The ordered list of geocoded candidates.
+   */
   async execute(input: GeocodeInput) {
     return {
       results: await geocode(input.text, input.maximumResponses),

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -1,9 +1,15 @@
+/**
+ * MCP tool exposing detailed schema inspection for a single WFS type.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 import type { Collection } from "@ignfab/gpf-schema-store";
 
 import { wfsClient } from "../gpf/wfs-schema-catalog.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
+
+// --- Schema ---
 
 const gpfWfsDescribeTypeInputSchema = z.object({
   typename: z
@@ -12,6 +18,8 @@ const gpfWfsDescribeTypeInputSchema = z.object({
     .min(1, "le nom du type ne doit pas être vide")
     .describe("Le nom du type (ex : BDTOPO_V3:batiment)"),
 }).strict();
+
+// --- Types ---
 
 type GpfWfsDescribeTypeInput = z.infer<typeof gpfWfsDescribeTypeInputSchema>;
 
@@ -35,6 +43,8 @@ const gpfWfsDescribeTypeOutputSchema = z.object({
   }).describe("La description détaillée du type WFS."),
 });
 
+// --- Tool ---
+
 class GpfWfsDescribeTypeTool extends MCPTool<GpfWfsDescribeTypeInput> {
   name = "gpf_wfs_describe_type";
   title = "Description d’un type WFS";
@@ -49,6 +59,12 @@ class GpfWfsDescribeTypeTool extends MCPTool<GpfWfsDescribeTypeInput> {
 
   schema = gpfWfsDescribeTypeInputSchema;
 
+  /**
+   * Loads the detailed schema description for one WFS typename.
+   *
+   * @param input Normalized tool input.
+   * @returns The detailed feature type description from the embedded catalog.
+   */
   async execute(input: GpfWfsDescribeTypeInput) {
     try {
       const featureType: Collection = await wfsClient.getFeatureType(input.typename);

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -7,51 +7,20 @@
  */
 
 import { MCPTool } from "mcp-framework";
-import type { Collection } from "@ignfab/gpf-schema-store";
-import { z } from "zod";
 
-import { wfsClient } from "../gpf/wfs-schema-catalog.js";
-import { generatePublishedInputSchema } from "../helpers/jsonSchema.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { buildPropertyName, executeGetFeatureById } from "../helpers/wfs_engine/byId.js";
-import { buildGetFeatureByIdRequest } from "../helpers/wfs_engine/request.js";
-import { gpfWfsGetFeaturesRequestOutputSchema } from "../helpers/wfs_engine/schema.js";
-
-// --- Schema ---
-
-const gpfWfsGetFeatureByIdInputSchema = z.object({
-  typename: z
-    .string()
-    .trim()
-    .min(1, "le nom du type ne doit pas être vide")
-    .describe("Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`."),
-  feature_id: z
-    .string()
-    .trim()
-    .min(1, "le feature_id ne doit pas être vide")
-    .describe("Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`."),
-  result_type: z
-    .enum(["results", "request"])
-    .default("results")
-    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer."),
-  select: z
-    .array(z.string().trim().min(1))
-    .min(1)
-    .optional()
-    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée."),
-}).strict();
-
-// --- Types ---
-
-type GpfWfsGetFeatureByIdInput = z.infer<typeof gpfWfsGetFeatureByIdInputSchema>;
-
-type PublishedInputSchema = {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-};
-
-const gpfWfsGetFeatureByIdPublishedInputSchema = generatePublishedInputSchema(gpfWfsGetFeatureByIdInputSchema) as PublishedInputSchema;
+import { getFeatureType } from "../helpers/wfs_engine/execution.js";
+import {
+  buildGetFeatureByIdRequest,
+  toWfsRequestPayload,
+} from "../helpers/wfs_engine/request.js";
+import {
+  gpfWfsGetFeatureByIdInputSchema,
+  type GpfWfsGetFeatureByIdInput,
+  gpfWfsGetFeatureByIdPublishedInputSchema,
+  gpfWfsGetFeatureByIdRequestOutputSchema,
+} from "../helpers/wfs_engine/schema.js";
 
 // --- Tool ---
 
@@ -66,6 +35,8 @@ class GpfWfsGetFeatureByIdTool extends MCPTool<GpfWfsGetFeatureByIdInput> {
     "Utiliser `result_type=\"request\"` pour récupérer la requête WFS compilée (avec `get_url`) et l'utiliser ou la visualiser ailleurs."
   ].join("\n");
 
+  // `schema` remains the runtime validation source, while `inputSchema`
+  // publishes the MCP-facing variant expected by clients.
   schema = gpfWfsGetFeatureByIdInputSchema;
 
   /**
@@ -80,6 +51,11 @@ class GpfWfsGetFeatureByIdTool extends MCPTool<GpfWfsGetFeatureByIdInput> {
   /**
    * Formats compact responses (`request`) into `structuredContent`.
    *
+   * We intentionally do not expose a single `outputSchemaShape` for the tool as
+   * a whole: the `results` path returns a generic FeatureCollection whose
+   * feature properties depend on the queried WFS layer, while `request` has a
+   * compact, closed shape that is worth validating explicitly.
+   *
    * @param data Raw execution result returned by the tool implementation.
    * @returns An MCP success response, optionally enriched with structured content.
    */
@@ -92,7 +68,7 @@ class GpfWfsGetFeatureByIdTool extends MCPTool<GpfWfsGetFeatureByIdInput> {
     ) {
       return {
         content: [{ type: "text" as const, text: JSON.stringify(data) }],
-        structuredContent: gpfWfsGetFeaturesRequestOutputSchema.parse(data),
+        structuredContent: gpfWfsGetFeatureByIdRequestOutputSchema.parse(data),
       };
     }
 
@@ -108,23 +84,15 @@ class GpfWfsGetFeatureByIdTool extends MCPTool<GpfWfsGetFeatureByIdInput> {
    */
   async execute(input: GpfWfsGetFeatureByIdInput) {
     if (input.result_type === "request") {
-      // Keep request preview assembly local to the tool: this branch exposes
-      // MCP-facing debug output rather than executing the by-id results flow.
-      const featureType: Collection = await wfsClient.getFeatureType(input.typename);
+      // The `request` mode is handled here because it returns a preview payload,
+      // not the actual by-id WFS result.
+      const featureType = await getFeatureType(input.typename);
       const propertyName = buildPropertyName(featureType, {
-        result_type: input.result_type,
+        includeGeometry: true,
         select: input.select,
       });
       const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);
-
-      return {
-        result_type: "request" as const,
-        method: request.method,
-        url: request.url,
-        query: request.query,
-        body: request.body,
-        get_url: request.get_url ?? null,
-      };
+      return toWfsRequestPayload(request);
     }
 
     return executeGetFeatureById({

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -5,6 +5,7 @@ import {
   executeGetFeatures,
   prepareGetFeaturesRequest,
 } from "../helpers/wfs_engine/features.js";
+import { toWfsRequestPayload } from "../helpers/wfs_engine/request.js";
 import {
   gpfWfsGetFeaturesHitsOutputSchema,
   gpfWfsGetFeaturesInputSchema,
@@ -31,6 +32,7 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
     "Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et `spatial_operator` avec ses paramètres dédiés pour le spatial. Avec `result_type=\"request\"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.",
     "Exemple attributaire : `where=[{ property: \"code_insee\", operator: \"eq\", value: \"75056\" }]`.",
     "Exemple bbox : `spatial_operator=\"bbox\"` avec `bbox_west`, `bbox_south`, `bbox_east`, `bbox_north` en `lon/lat`.",
+    "Exemple point dans géométrie : `spatial_operator=\"intersects_point\"` avec `intersects_lon` et `intersects_lat`.",
     "Exemple distance : `spatial_operator=\"dwithin_point\"` avec `dwithin_lon`, `dwithin_lat`, `dwithin_distance_m`.",
     "Exemple réutilisation : `spatial_operator=\"intersects_feature\"` avec `intersects_feature_typename` et `intersects_feature_id` issus d'une `feature_ref`.",
     "⚠️ Quand `typename` et `intersects_feature_typename` sont identiques, utiliser `gpf_wfs_get_feature_by_id` pour récupérer exactement l'objet ciblé.",
@@ -38,6 +40,8 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
     "Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiques à chaque typename et diffèrent systématiquement des conventions habituelles (ex : pas de nom_officiel, navigabilite sans accent, etc.). Toute tentative sans appel préalable à `gpf_wfs_describe_type` **provoquera une erreur.**",
   ].join("\n");
 
+  // `schema` remains the runtime validation source, while `inputSchema`
+  // publishes the MCP-facing variant expected by clients.
   schema = gpfWfsGetFeaturesInputSchema;
 
   /**
@@ -87,25 +91,6 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
   }
 
   /**
-   * Formats the request-preview response returned by `result_type="request"`.
-   *
-   * @param input Normalized tool input.
-   * @returns An MCP-compatible request preview payload.
-   */
-  protected async buildRequestPreview(input: GpfWfsGetFeaturesInput) {
-    const { request } = await prepareGetFeaturesRequest(input);
-
-    return {
-      result_type: "request" as const,
-      method: request.method,
-      url: request.url,
-      query: request.query,
-      body: request.body,
-      get_url: request.get_url ?? null,
-    };
-  }
-
-  /**
    * Orchestrates the MCP-facing execution flow.
    *
    * Request previews stay in the tool because they are a tool-specific output
@@ -116,7 +101,8 @@ class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
    */
   async execute(input: GpfWfsGetFeaturesInput) {
     if (input.result_type === "request") {
-      return this.buildRequestPreview(input);
+      const { request } = await prepareGetFeaturesRequest(input);
+      return toWfsRequestPayload(request);
     }
 
     return executeGetFeatures(input);

--- a/src/tools/GpfWfsSearchTypesTool.ts
+++ b/src/tools/GpfWfsSearchTypesTool.ts
@@ -1,8 +1,14 @@
+/**
+ * MCP tool exposing keyword-based search over the embedded WFS type catalog.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { wfsClient } from "../gpf/wfs-schema-catalog.js";
+
+// --- Schema ---
 
 const gpfWfsSearchTypesInputSchema = z.object({
   query: z
@@ -19,6 +25,8 @@ const gpfWfsSearchTypesInputSchema = z.object({
     .describe("Le nombre maximum de résultats à retourner (entre 1 et 50). Défaut : 10."),
 }).strict();
 
+// --- Types ---
+
 type GpfWfsSearchTypesInput = z.infer<typeof gpfWfsSearchTypesInputSchema>;
 
 const gpfWfsSearchTypeResultSchema = z.object({
@@ -31,6 +39,8 @@ const gpfWfsSearchTypeResultSchema = z.object({
 const gpfWfsSearchTypesOutputSchema = z.object({
   results: z.array(gpfWfsSearchTypeResultSchema).describe("La liste ordonnée des types WFS trouvés."),
 });
+
+// --- Tool ---
 
 class GpfWfsSearchTypesTool extends MCPTool<GpfWfsSearchTypesInput> {
   name = "gpf_wfs_search_types";
@@ -47,6 +57,12 @@ class GpfWfsSearchTypesTool extends MCPTool<GpfWfsSearchTypesInput> {
 
   schema = gpfWfsSearchTypesInputSchema;
 
+  /**
+   * Searches the embedded WFS type catalog from a free-text query.
+   *
+   * @param input Normalized tool input.
+   * @returns The ordered search results, optionally enriched with relevance scores.
+   */
   async execute(input: GpfWfsSearchTypesInput) {
     const maxResults = input.max_results || 10;
     const featureTypes = await wfsClient.searchFeatureTypesWithScores(input.query, maxResults);

--- a/src/tools/UrbanismeTool.ts
+++ b/src/tools/UrbanismeTool.ts
@@ -1,3 +1,7 @@
+/**
+ * MCP tool exposing urban planning information around a given point.
+ */
+
 import { MCPTool } from "mcp-framework";
 import { z } from "zod";
 
@@ -5,10 +9,14 @@ import { getUrbanisme, URBANISME_SOURCE } from "../gpf/urbanisme.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
 
+// --- Schema ---
+
 const urbanismeInputSchema = z.object({
   lon: lonSchema,
   lat: latSchema,
 }).strict();
+
+// --- Types ---
 
 type UrbanismeInput = z.infer<typeof urbanismeInputSchema>;
 
@@ -38,6 +46,7 @@ const URBANISME_TOOL_DESCRIPTION = [
   "- fichier: https://www.geoportail-urbanisme.gouv.fr/api/document/{gpu_doc_id}/files/{nomfic}",
 ].join("\n");
 
+// --- Tool ---
 
 class UrbanismeTool extends MCPTool<UrbanismeInput> {
   name = "urbanisme";
@@ -48,6 +57,12 @@ class UrbanismeTool extends MCPTool<UrbanismeInput> {
 
   schema = urbanismeInputSchema;
 
+  /**
+   * Returns the urban planning objects relevant to the requested point.
+   *
+   * @param input Normalized tool input.
+   * @returns The relevant urban planning objects, including reusable `feature_ref` metadata when available.
+   */
   async execute(input: UrbanismeInput) {
     return {
       results: await getUrbanisme(input.lon, input.lat),

--- a/test/helpers/http.test.ts
+++ b/test/helpers/http.test.ts
@@ -43,6 +43,21 @@ describe("Test HTTP helpers", () => {
         );
     });
 
+    it("should expose structured details for extracted OGC XML errors", async () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1">
+  <ows:Exception exceptionCode="InvalidParameterValue">
+    <ows:ExceptionText>Illegal property name: geom</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>`;
+
+        await expect(parseJsonResponse(createResponse(xml, "application/xml"))).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceCode: "InvalidParameterValue",
+            serviceDetail: "Illegal property name: geom",
+        });
+    });
+
     it("should fail explicitly on empty responses", async () => {
         await expect(parseJsonResponse(createResponse(""))).rejects.toThrow(
             "Réponse vide du service (200 OK)"
@@ -104,5 +119,43 @@ describe("Test HTTP helpers", () => {
         ).rejects.toThrow(
             "Erreur HTTP du service (400 Bad Request): InvalidParameterValue: Illegal property name: geom"
         );
+    });
+
+    it("should keep structured XML error details on HTTP failures", async () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1">
+  <ows:Exception exceptionCode="InvalidParameterValue">
+    <ows:ExceptionText>Illegal property name: geom</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>`;
+
+        await expect(
+            parseJsonResponse(
+                createResponse(xml, "application/xml", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceCode: "InvalidParameterValue",
+            serviceDetail: "Illegal property name: geom",
+            responseLabel: "400 Bad Request",
+        });
+    });
+
+    it("should expose structured details for non-2xx JSON responses", async () => {
+        await expect(
+            parseJsonResponse(
+                createResponse('{"message":"bad filter"}', "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceDetail: "bad filter",
+            responseLabel: "400 Bad Request",
+        });
     });
 });

--- a/test/helpers/wfs_engine/queryPreparation.test.ts
+++ b/test/helpers/wfs_engine/queryPreparation.test.ts
@@ -1,9 +1,9 @@
 import type { Collection } from "@ignfab/gpf-schema-store";
 
-import { compileQueryParts, geometryToEwkt } from "../../../src/helpers/wfs_engine/compile";
+import { compileQueryParts, geometryToEwkt } from "../../../src/helpers/wfs_engine/queryPreparation";
 import type { GpfWfsGetFeaturesInput } from "../../../src/helpers/wfs_engine/schema";
 
-describe("gpfWfsGetFeatures/compile", () => {
+describe("gpfWfsGetFeatures/queryPreparation", () => {
   const featureType: Collection = {
     id: "ADMINEXPRESS-COG.LATEST:commune",
     namespace: "ADMINEXPRESS-COG.LATEST",
@@ -80,8 +80,6 @@ describe("gpfWfsGetFeatures/compile", () => {
       intersects_feature_typename: "ADMINEXPRESS-COG.LATEST:commune",
       intersects_feature_id: "commune.1",
     }, featureType, {
-      typename: "ADMINEXPRESS-COG.LATEST:commune",
-      feature_id: "commune.1",
       geometry_ewkt: "SRID=4326;MULTIPOLYGON(((2 48,2.2 48,2.2 48.2,2 48,2 48)))",
     });
 

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -44,13 +44,38 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
   it("should expose an MCP definition with `results|request` result_type only", () => {
     const tool = new GpfWfsGetFeatureByIdTool();
     expect(tool.toolDefinition.title).toEqual("Lecture d’un objet WFS par identifiant");
-    expect(tool.toolDefinition.inputSchema.properties?.feature_id).toMatchObject({
-      type: "string",
-      minLength: 1,
-    });
-    expect(tool.toolDefinition.inputSchema.properties?.result_type).toMatchObject({
-      type: "string",
-      enum: ["results", "request"],
+    expect(tool.toolDefinition.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        typename: {
+          type: "string",
+          minLength: 1,
+          description: "Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`.",
+        },
+        feature_id: {
+          type: "string",
+          minLength: 1,
+          description: "Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`.",
+        },
+        result_type: {
+          type: "string",
+          enum: ["results", "request"],
+          default: "results",
+          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer.",
+        },
+        select: {
+          type: "array",
+          items: {
+            type: "string",
+            minLength: 1,
+          },
+          minItems: 1,
+          description: "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée.",
+        },
+      },
+      required: ["typename", "feature_id"],
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#",
     });
   });
 

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -7,6 +7,14 @@ const mockFetchJSONPost = jest.fn<(
   body?: string,
   headers?: Record<string, string>,
 ) => Promise<unknown>>();
+const mockIsServiceResponseError = (
+  error: unknown,
+): error is Error & { serviceCode?: string; serviceDetail?: string } =>
+  error instanceof Error && (
+    error.name === "ServiceResponseError" ||
+    "serviceCode" in error ||
+    "serviceDetail" in error
+  );
 
 jest.unstable_mockModule("../../../src/gpf/wfs-schema-catalog.js", () => ({
   GPF_WFS_URL: "https://data.geopf.fr/wfs",
@@ -17,6 +25,7 @@ jest.unstable_mockModule("../../../src/gpf/wfs-schema-catalog.js", () => ({
 
 jest.unstable_mockModule("../../../src/helpers/http.js", () => ({
   fetchJSONPost: mockFetchJSONPost,
+  isServiceResponseError: mockIsServiceResponseError,
 }));
 
 const { default: GpfWfsGetFeaturesTool } = await import(
@@ -305,6 +314,38 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     expect(requests[0].query.propertyName).toEqual("code_insee,population");
     expect(requests[0].query.sortBy).toEqual("population D");
     expect(requests[0].body).toContain("cql_filter=");
+  });
+
+  it("should report live geometry property mismatches with a catalog desync hint", async () => {
+    const tool = new GpfWfsGetFeaturesTool();
+    mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
+    mockFetchJSONPost.mockRejectedValue(
+      Object.assign(
+        new Error("Erreur HTTP du service (400 Bad Request): InvalidParameterValue: Illegal property name: geometrie"),
+        {
+          name: "ServiceResponseError",
+          serviceCode: "InvalidParameterValue",
+          serviceDetail: "Illegal property name: geometrie",
+        },
+      ),
+    );
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("catalogue embarqué est rejeté");
+    expect(textContent.text).toContain("géométrique 'geometrie'");
   });
 
   it("should keep hits independent from limit and omit propertyName", async () => {


### PR DESCRIPTION
Closes #64

This PR is a focused stabilization pass on the recent WFS engine extraction.

It keeps tool behavior unchanged overall, but makes the WFS layer cleaner, stricter, and easier to maintain:
- aligns the `by_id` and `get_features` flows around shared by-id lookup primitives
- tightens internal response typing and removes a few overly loose `any`-style paths
- improves consistency in request payload shaping and shared entry points
- restructures and documents the `wfs_engine` modules with clearer boundaries, naming, sections, and JSDoc
- renames a few internal modules to better reflect their actual role (`queryPreparation`, `attributeFilter`, `spatialFilter`)

It also includes a small amount of follow-up cleanup around WFS request/output schemas and HTTP error handling, with the goal of making the refactor more robust without changing the public contract of the tools.

Validated with:
- `npm run build`
- `npm test -- --runInBand`