### PR TITLE
Harmonize MCP Error Handling Across Tools and HTTP Parsing

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,6 +2,47 @@
 
 Generated from runtime `toolDefinition` metadata for `@ignfab/geocontext` v0.9.7.
 
+## Contrat d’erreur MCP
+
+- En cas d'échec, chaque tool renvoie `isError: true`.
+- `content.text` contient le message de détail en français (aligné avec `structuredContent.detail`).
+- `structuredContent` contient l'objet canonique exploitable par un client.
+
+Exemple complet généré automatiquement à partir d'un appel de tool invalide (contrainte de validation) :
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "adminexpress:invalid-input-example",
+  "result": {
+    "isError": true,
+    "content": [
+      {
+        "type": "text",
+        "text": "Paramètres invalides : Le paramètre 'lon' est requis. Le paramètre 'lat' est requis."
+      }
+    ],
+    "structuredContent": {
+      "type": "urn:geocontext:problem:invalid-tool-params",
+      "title": "Paramètres d’outil invalides",
+      "detail": "Paramètres invalides : Le paramètre 'lon' est requis. Le paramètre 'lat' est requis.",
+      "errors": [
+        {
+          "code": "invalid_type",
+          "detail": "Le paramètre 'lon' est requis.",
+          "name": "lon"
+        },
+        {
+          "code": "invalid_type",
+          "detail": "Le paramètre 'lat' est requis.",
+          "name": "lat"
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Index
 
 - [`adminexpress`](#adminexpress)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1509,9 +1509,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
-      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2733,9 +2733,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "clean:dist": "node scripts/dist-clean.js",
     "build": "npm run clean:dist && npx mcp-build",
-    "docs:mcp": "node --no-warnings scripts/generate-mcp-docs.mjs",
+    "docs:mcp": "npm run build && node --no-warnings scripts/generate-mcp-docs.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "watch": "tsc --watch",
     "start": "node dist/index.js",

--- a/scripts/generate-mcp-docs.mjs
+++ b/scripts/generate-mcp-docs.mjs
@@ -33,6 +33,10 @@ const miniSearchOptionsEnv = "GPF_WFS_MINISEARCH_OPTIONS";
  * @property {JsonSchema=} outputSchema
  */
 
+/**
+ * @typedef {ToolDefinition & {source: string, _instance: import("mcp-framework").MCPTool}} LoadedTool
+ */
+
 function formatInline(value) {
   return typeof value === "string" ? value : JSON.stringify(value);
 }
@@ -247,12 +251,14 @@ async function loadToolDefinitions() {
 
   const filenames = (await readdir(compiledToolsDir))
     .filter((filename) => filename.endsWith("Tool.js"))
+    .filter((filename) => filename !== "BaseTool.js")
     .sort((left, right) => left.localeCompare(right));
 
   if (filenames.length === 0) {
     throw new Error(`No tool modules found in ${compiledToolsDir}. Run \`npm run build\` first.`);
   }
 
+  /** @type {LoadedTool[]} */
   const definitions = [];
 
   for (const filename of filenames) {
@@ -268,6 +274,7 @@ async function loadToolDefinitions() {
     assertToolDefinition(instance.toolDefinition, filename);
     definitions.push({
       source: sourcePathForCompiledTool(filename),
+      _instance: instance,
       ...instance.toolDefinition,
     });
   }
@@ -285,11 +292,86 @@ async function loadToolDefinitions() {
   return definitions.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function buildDocumentLines(pkg, tools) {
+function normalizeErrorResponse(response) {
+  if (!response || typeof response !== "object") {
+    return undefined;
+  }
+
+  const source = /** @type {Record<string, unknown>} */ (response);
+  if (source.isError !== true || !Array.isArray(source.content)) {
+    return undefined;
+  }
+
+  return {
+    isError: true,
+    content: source.content,
+    ...(source.structuredContent !== undefined ? { structuredContent: source.structuredContent } : {}),
+  };
+}
+
+async function buildErrorExample(tools) {
+  for (const tool of tools) {
+    try {
+      const response = await tool._instance.toolCall({
+        params: {
+          name: tool.name,
+          arguments: {},
+        },
+      });
+
+      if (response?.isError !== true) {
+        continue;
+      }
+
+      const normalized = normalizeErrorResponse(response);
+      if (normalized) {
+        return {
+          toolName: tool.name,
+          response: normalized,
+        };
+      }
+    } catch {
+      // Try next tool if this one does not produce a clean validation error sample.
+    }
+  }
+
+  return undefined;
+}
+
+async function buildErrorContractSection(tools) {
+  const errorExample = await buildErrorExample(tools);
+  if (!errorExample) {
+    return [];
+  }
+
+  const errorExampleWithJsonRpcEnvelope = {
+    jsonrpc: "2.0",
+    id: `${errorExample.toolName}:invalid-input-example`,
+    result: errorExample.response,
+  };
+
+  return [
+    "## Contrat d’erreur MCP",
+    "",
+    "- En cas d'échec, chaque tool renvoie `isError: true`.",
+    "- `content.text` contient le message de détail en français (aligné avec `structuredContent.detail`).",
+    "- `structuredContent` contient l'objet canonique exploitable par un client.",
+    "",
+    "Exemple complet généré automatiquement à partir d'un appel de tool invalide (contrainte de validation) :",
+    "",
+    "```json",
+    JSON.stringify(errorExampleWithJsonRpcEnvelope, null, 2),
+    "```",
+  ];
+}
+
+async function buildDocumentLines(pkg, tools) {
+  const errorContractSection = await buildErrorContractSection(tools);
   const lines = [
     "# MCP Tool Reference",
     "",
     `Generated from runtime \`toolDefinition\` metadata for \`${pkg.name}\` v${pkg.version}.`,
+    ...(errorContractSection.length > 0 ? ["", ...errorContractSection] : []),
     "",
     "## Index",
     "",
@@ -330,7 +412,7 @@ function buildDocumentLines(pkg, tools) {
 export async function main() {
   const pkg = await loadPackageMetadata();
   const tools = await loadToolDefinitions();
-  const content = `${buildDocumentLines(pkg, tools).join("\n")}\n`;
+  const content = `${(await buildDocumentLines(pkg, tools)).join("\n")}\n`;
 
   await mkdir(dirname(outputPath), { recursive: true });
 

--- a/src/gpf/altitude.ts
+++ b/src/gpf/altitude.ts
@@ -1,4 +1,4 @@
-import { fetchJSON } from "../helpers/http.js";
+import { fetchJSONGet } from "../helpers/http.js";
 import logger from "../logger.js";
 import type { JsonFetcher } from "../helpers/http.js";
 export const ALTITUDE_SOURCE = "Géoplateforme (altimétrie)";
@@ -31,7 +31,7 @@ type AltitudeResult = {
  * @param {JsonFetcher<RawAltitudeResponse>} [fetcher] - optional custom fetcher function
  * @returns {Promise<AltitudeResult>}
  */
-export async function getAltitudeByLocation(lon: number, lat: number, fetcher: JsonFetcher<RawAltitudeResponse> = fetchJSON): Promise<AltitudeResult> {
+export async function getAltitudeByLocation(lon: number, lat: number, fetcher: JsonFetcher<RawAltitudeResponse> = fetchJSONGet): Promise<AltitudeResult> {
     logger.info(`getAltitudeByLocation(${lon},${lat})...`);
     
     const url = `https://data.geopf.fr/altimetrie/1.0/calcul/alti/rest/elevation.json?lon=${lon}&lat=${lat}&resource=ign_rge_alti_wld`;

--- a/src/gpf/geocode.ts
+++ b/src/gpf/geocode.ts
@@ -1,4 +1,4 @@
-import { fetchJSON } from "../helpers/http.js";
+import { fetchJSONGet } from "../helpers/http.js";
 import logger from "../logger.js";
 import type { JsonFetcher } from "../helpers/http.js";
 export const GEOCODE_SOURCE = "Géoplateforme (service d'autocomplétion)";
@@ -37,7 +37,7 @@ type RawGeocodeResponse = {
  * @param {JsonFetcher<RawGeocodeResponse>} [fetcher] - optional custom fetcher function
  * @returns {Promise<GeocodeResult[]>}
  */
-export async function geocode(text: string, maximumResponses = 3, fetcher: JsonFetcher<RawGeocodeResponse> = fetchJSON): Promise<GeocodeResult[]> {
+export async function geocode(text: string, maximumResponses = 3, fetcher: JsonFetcher<RawGeocodeResponse> = fetchJSONGet): Promise<GeocodeResult[]> {
     const normalizedText = typeof text === "string" ? text.trim() : "";
 
     if (!normalizedText) {

--- a/src/helpers/errors/toolError.ts
+++ b/src/helpers/errors/toolError.ts
@@ -1,0 +1,242 @@
+/**
+ * Centralized normalization for MCP tool errors.
+ *
+ * This helper converts heterogeneous runtime errors (Zod validation errors,
+ * upstream service errors, and generic exceptions) into one stable
+ * `structuredContent` contract consumed by tools through `BaseTool`.
+ */
+
+import { ZodError } from "zod";
+
+import { ServiceResponseError } from "../http.js";
+import { installZodErrorMapFr } from "./zodErrorMapFr.js";
+
+// Install the FR Zod error map at module load so the very first parse in the
+// process already emits localized messages.
+installZodErrorMapFr();
+
+// --- Public Contract ---
+
+type ToolErrorItem = {
+  code: string;
+  detail: string;
+  name?: string;
+};
+
+type ToolUpstreamInfo = {
+  status?: number;
+};
+
+export type ToolErrorPayload = {
+  type: string;
+  title: string;
+  detail: string;
+  errors: ToolErrorItem[];
+  upstream?: ToolUpstreamInfo;
+};
+
+type ClassifiedToolError =
+  | { kind: "invalid_tool_params"; error: ZodError }
+  | { kind: "upstream"; error: ServiceResponseError }
+  | { kind: "execution"; error: unknown };
+
+// --- Problem Type Constants ---
+
+/**
+ * Stable RFC7807-like problem type identifiers exposed in `structuredContent`.
+ */
+const INVALID_TOOL_PARAMS_TYPE = "urn:geocontext:problem:invalid-tool-params";
+const UPSTREAM_INVALID_REQUEST_TYPE = "urn:geocontext:problem:upstream-invalid-request";
+const UPSTREAM_ERROR_TYPE = "urn:geocontext:problem:upstream-error";
+const EXECUTION_ERROR_TYPE = "urn:geocontext:problem:execution-error";
+
+// --- Shared Helpers ---
+
+/**
+ * Returns the most specific string segment from a Zod issue path.
+ * 
+ * TODO: this is a best-effort heuristic to extract a user-friendly parameter name
+ *
+ * @param path Zod issue path.
+ * @returns Last non-empty string segment, or `undefined`.
+ */
+function issueName(path: Array<string | number>) {
+  for (let index = path.length - 1; index >= 0; index -= 1) {
+    const segment = path[index];
+    if (typeof segment === "string" && segment.length > 0) {
+      return segment;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Builds a compact end-user summary from normalized validation errors.
+ *
+ * @param errors Normalized validation errors.
+ * @returns A short, localized validation summary.
+ */
+function summarizeValidationDetail(errors: ToolErrorItem[]) {
+  if (errors.length === 0) {
+    return "Un ou plusieurs paramètres fournis à l'outil sont invalides.";
+  }
+
+  const details = errors.map((error) => error.detail);
+  const firstDetails = details.slice(0, 3).join(" ");
+  const suffix = details.length > 3 ? " (et d'autres erreurs)." : "";
+  return `Paramètres invalides : ${firstDetails}${suffix}`;
+}
+
+/**
+ * Converts service error codes to a snake_case machine-friendly form.
+ *
+ * @param value Error code to normalize.
+ * @returns A normalized snake_case code.
+ */
+function toSnakeCase(value: string) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s\-]+/g, "_")
+    .toLowerCase();
+}
+
+// --- Zod Error Mapping ---
+
+/**
+ * Converts Zod issues to normalized `errors[]` entries.
+ *
+ * Note: issue messages are expected to already be localized through
+ * `zodErrorMapFr` (installed once at module load).
+ */
+function normalizeZodIssues(error: ZodError): ToolErrorItem[] {
+  const errors: ToolErrorItem[] = [];
+
+  for (const issue of error.issues) {
+    if (issue.code === "unrecognized_keys") {
+      const keys = issue.keys.length > 0 ? issue.keys : ["<inconnu>"];
+      for (const key of keys) {
+        errors.push({
+          code: "unknown_parameter",
+          detail: `Le paramètre '${key}' n'est pas reconnu.`,
+          name: key,
+        });
+      }
+      continue;
+    }
+
+    const name = issueName(issue.path);
+    errors.push({
+      code: issue.code,
+      detail: issue.message || "Valeur invalide.",
+      ...(name ? { name } : {}),
+    });
+  }
+
+  return errors;
+}
+
+// --- Upstream Error Mapping ---
+
+/**
+ * Maps a `ServiceResponseError` to the shared upstream problem payload.
+ *
+ * @param error Structured upstream service error.
+ * @returns A normalized upstream problem payload.
+ */
+function buildUpstreamProblem(error: ServiceResponseError): ToolErrorPayload {
+  const status = typeof error.httpStatus === "number" ? error.httpStatus : undefined;
+
+  const serviceDetail = error.serviceDetail ?? error.message ?? "Erreur amont inconnue.";
+  const inferredErrorCode = /Illegal property name:/i.test(serviceDetail)
+    ? "invalid_property_name"
+    : error.serviceCode
+      ? toSnakeCase(error.serviceCode)
+      : "upstream_error";
+  const isInvalidRequest = status !== undefined && status >= 400 && status < 500;
+
+  return {
+    type: isInvalidRequest ? UPSTREAM_INVALID_REQUEST_TYPE : UPSTREAM_ERROR_TYPE,
+    title: isInvalidRequest
+      ? "Requête rejetée par le service amont"
+      : "Erreur du service amont",
+    detail: `Le service distant a rejeté la requête : ${serviceDetail}`,
+    errors: [
+      {
+        code: inferredErrorCode,
+        detail: serviceDetail,
+      },
+    ],
+    ...(status !== undefined ? { upstream: { status } } : {}),
+  };
+}
+
+/**
+ * Maps unknown runtime errors to one of the normalization categories.
+ *
+ * @param error Unknown runtime error.
+ * @returns Classified error with a normalized kind and a narrowed payload.
+ */
+function classifyToolError(error: unknown): ClassifiedToolError {
+  if (error instanceof ZodError) {
+    return { kind: "invalid_tool_params", error };
+  }
+  if (error instanceof ServiceResponseError) {
+    return { kind: "upstream", error };
+  }
+  return { kind: "execution", error };
+}
+
+/**
+ * Maps generic runtime errors to the shared execution problem payload.
+ *
+ * @param error Unknown runtime error.
+ * @returns A normalized execution problem payload.
+ */
+function buildExecutionProblem(error: unknown): ToolErrorPayload {
+  const message = error instanceof Error
+    ? error.message.trim()
+    : typeof error === "string"
+      ? error.trim()
+      : "";
+  const detail = message.length > 0 ? message : "Erreur interne inattendue.";
+
+  return {
+    type: EXECUTION_ERROR_TYPE,
+    title: "Erreur d’exécution de l’outil",
+    detail,
+    errors: [
+      {
+        code: "execution_error",
+        detail,
+      },
+    ],
+  };
+}
+
+// --- Public API ---
+
+/**
+ * Normalizes any runtime error into the shared MCP tool problem contract.
+ *
+ * @param error Unknown runtime error to normalize.
+ * @returns A stable payload intended for MCP `structuredContent`.
+ */
+export function normalizeToolError(error: unknown): ToolErrorPayload {
+  const classifiedError = classifyToolError(error);
+
+  switch (classifiedError.kind) {
+    case "invalid_tool_params": {
+      const errors = normalizeZodIssues(classifiedError.error);
+      return {
+        type: INVALID_TOOL_PARAMS_TYPE,
+        title: "Paramètres d’outil invalides",
+        detail: summarizeValidationDetail(errors),
+        errors,
+      };
+    }
+    case "upstream":
+      return buildUpstreamProblem(classifiedError.error);
+    case "execution":
+      return buildExecutionProblem(classifiedError.error);
+  }
+}

--- a/src/helpers/errors/zodErrorMapFr.ts
+++ b/src/helpers/errors/zodErrorMapFr.ts
@@ -1,0 +1,214 @@
+/**
+ * French Zod error map used as the global default for tool input validation.
+ *
+ * TODO: We are doing this because we are forced to use zod 3 for now
+ * and zod 3 does not support per-schema error maps. Once we upgrade to zod 4,
+ * we should refactor to use per-schema error maps and remove this global map.
+ * 
+ * Goal:
+ * - keep custom schema messages intact
+ * - replace default English Zod messages with concise FR equivalents
+ */
+
+import { z, type ZodErrorMap } from "zod";
+
+// --- Types ---
+
+type ErrorMapIssue = Parameters<ZodErrorMap>[0];
+type IssuePath = ErrorMapIssue["path"];
+type TooSmallIssue = Extract<ErrorMapIssue, { code: "too_small" }>;
+type TooBigIssue = Extract<ErrorMapIssue, { code: "too_big" }>;
+
+// --- Internal State ---
+
+let isInstalled = false;
+
+// --- Shared Helpers ---
+
+function issueName(path: IssuePath) {
+  for (let index = path.length - 1; index >= 0; index -= 1) {
+    const segment = path[index];
+    if (typeof segment === "string" && segment.length > 0) {
+      return segment;
+    }
+  }
+  return undefined;
+}
+
+function describeExpectedType(expected: string) {
+  switch (expected) {
+    case "string":
+      return "une chaîne de caractères";
+    case "number":
+      return "un nombre";
+    case "integer":
+      return "un entier";
+    case "boolean":
+      return "un booléen";
+    case "array":
+      return "un tableau";
+    case "object":
+      return "un objet";
+    case "date":
+      return "une date";
+    default:
+      return `un type ${expected}`;
+  }
+}
+
+function describeReceivedType(received: string) {
+  switch (received) {
+    case "undefined":
+      return "non défini";
+    case "null":
+      return "null";
+    case "nan":
+      return "NaN";
+    default:
+      return `de type ${received}`;
+  }
+}
+
+function formatTooSmallIssue(issue: TooSmallIssue) {
+  if (issue.exact) {
+    switch (issue.type) {
+      case "string":
+        return `La valeur doit contenir exactement ${issue.minimum} caractère(s).`;
+      case "array":
+        return `La valeur doit contenir exactement ${issue.minimum} élément(s).`;
+      case "number":
+      case "bigint":
+        return `La valeur doit être exactement égale à ${issue.minimum}.`;
+      default:
+        return `La valeur doit être exactement égale à ${issue.minimum}.`;
+    }
+  }
+
+  switch (issue.type) {
+    case "string":
+      return `La valeur doit contenir au moins ${issue.minimum} caractère(s).`;
+    case "array":
+      return `La valeur doit contenir au moins ${issue.minimum} élément(s).`;
+    case "number":
+    case "bigint":
+      return `La valeur doit être au moins ${issue.minimum}.`;
+    case "set":
+      return `L'ensemble doit contenir au moins ${issue.minimum} élément(s).`;
+    case "date":
+      return "La date fournie est antérieure au minimum autorisé.";
+    default:
+      return `La valeur doit respecter une contrainte de borne (au moins ${issue.minimum}).`;
+  }
+}
+
+function formatTooBigIssue(issue: TooBigIssue) {
+  if (issue.exact) {
+    switch (issue.type) {
+      case "string":
+        return `La valeur doit contenir exactement ${issue.maximum} caractère(s).`;
+      case "array":
+        return `La valeur doit contenir exactement ${issue.maximum} élément(s).`;
+      case "number":
+      case "bigint":
+        return `La valeur doit être exactement égale à ${issue.maximum}.`;
+      default:
+        return `La valeur doit être exactement égale à ${issue.maximum}.`;
+    }
+  }
+
+  switch (issue.type) {
+    case "string":
+      return `La valeur doit contenir au plus ${issue.maximum} caractère(s).`;
+    case "array":
+      return `La valeur doit contenir au plus ${issue.maximum} élément(s).`;
+    case "number":
+    case "bigint":
+      return `La valeur doit être au plus ${issue.maximum}.`;
+    case "set":
+      return `L'ensemble doit contenir au plus ${issue.maximum} élément(s).`;
+    case "date":
+      return "La date fournie est postérieure au maximum autorisé.";
+    default:
+      return `La valeur doit respecter une contrainte de borne (au plus ${issue.maximum}).`;
+  }
+}
+
+// --- FR Error Map ---
+
+/**
+ * Global Zod error map that localizes default messages in French.
+ */
+export const zodErrorMapFr: ZodErrorMap = (issue, ctx) => {
+  switch (issue.code) {
+    case "too_small":
+      return { message: formatTooSmallIssue(issue) };
+    case "too_big":
+      return { message: formatTooBigIssue(issue) };
+    case "invalid_type":
+      if (issue.received === "undefined") {
+        const name = issueName(issue.path);
+        return {
+          message: name
+            ? `Le paramètre '${name}' est requis.`
+            : "Un paramètre requis est manquant.",
+        };
+      }
+      return {
+        message: `Type invalide : attendu ${describeExpectedType(issue.expected)}, reçu une valeur ${describeReceivedType(issue.received)}.`,
+      };
+    case "invalid_enum_value":
+      return {
+        message: `Valeur invalide. Valeurs autorisées : ${issue.options.map((option) => `'${String(option)}'`).join(", ")}.`,
+      };
+    case "invalid_string":
+      if (typeof issue.validation === "string") {
+        switch (issue.validation) {
+          case "email":
+            return { message: "Format d'email invalide." };
+          case "url":
+            return { message: "Format d'URL invalide." };
+          case "uuid":
+            return { message: "Format UUID invalide." };
+          case "datetime":
+            return { message: "Format de date/heure invalide." };
+          default:
+            return { message: `Format de chaîne invalide (${issue.validation}).` };
+        }
+      }
+
+      if ("includes" in issue.validation) {
+        return { message: `La chaîne doit contenir '${issue.validation.includes}'.` };
+      }
+      if ("startsWith" in issue.validation) {
+        return { message: `La chaîne doit commencer par '${issue.validation.startsWith}'.` };
+      }
+      if ("endsWith" in issue.validation) {
+        return { message: `La chaîne doit se terminer par '${issue.validation.endsWith}'.` };
+      }
+      return { message: "Format de chaîne invalide." };
+    case "unrecognized_keys":
+      return {
+        message: issue.keys.length > 0
+          ? `Clé(s) non reconnue(s) : ${issue.keys.map((key) => `'${key}'`).join(", ")}.`
+          : "Présence de clés non reconnues.",
+      };
+    case "custom":
+      return { message: issue.message || "Valeur invalide." };
+    default:
+      return { message: ctx.defaultError };
+  }
+};
+
+// --- Public API ---
+
+/**
+ * Installs the FR Zod error map once per process.
+ */
+export function installZodErrorMapFr() {
+  if (isInstalled) {
+    return;
+  }
+
+  z.setErrorMap(zodErrorMapFr);
+  isInstalled = true;
+}

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,31 +1,75 @@
-import fetch from 'node-fetch';
+/**
+ * Shared HTTP transport and response parsing helpers used across GeoContext services.
+ *
+ * Responsibilities:
+ * - centralize GET/POST fetch wrappers (`fetchJSONGet`, `fetchJSONPost`);
+ * - normalize HTTP, XML and JSON upstream failures as `ServiceResponseError`;
+ * - extract known structured error payloads (OGC/WFS XML, GeoServer/altimetry/autocompletion JSON);
+ * - keep parser diagnostics explicit for malformed or unsupported payloads.
+ *
+ * Organization:
+ * - this file is intentionally ordered by runtime call flow (top-down),
+ *   from public entry points to lower-level parsing/scalar helpers.
+ */
+
+
+import fetch from "node-fetch";
 import type { RequestInit } from "node-fetch";
-import { HttpsProxyAgent } from 'https-proxy-agent';
-import { parseXml, XmlElement } from '@rgrove/parse-xml';
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { parseXml, XmlElement } from "@rgrove/parse-xml";
 
 import logger from "../logger.js";
 
+
 // --- Transport Types ---
 
-type HeadersLike = {
+type RequestHeaders = Record<string, string>;
+
+type ResponseHeadersLike = {
   get(name: string): string | null;
 };
 
 type ResponseLike = {
   status: number;
   statusText: string;
-  ok?: boolean;
-  headers?: HeadersLike;
+  ok: boolean;
+  headers: ResponseHeadersLike;
   text(): Promise<string>;
 };
 
-type RequestHeaders = Record<string, string>;
+export type JsonFetcher<T> = (url: string) => Promise<T>;
+
+// --- Parsing Types ---
+
+type ResponseParsingContext = {
+  text: string;
+  contentType: string;
+  looksLikeXml: boolean;
+  responseLabel: string;
+  isOk: boolean;
+  status: number;
+};
 
 type ServiceResponseErrorOptions = {
-  httpStatus?: number;
-  responseLabel?: string;
-  serviceCode?: string;
-  serviceDetail?: string;
+  http: {
+    status: number;
+    statusText?: string;
+  };
+  service?: {
+    code?: string;
+    detail?: string;
+  };
+};
+
+type XmlServiceError = {
+  code?: string;
+  detail?: string;
+  message: string;
+};
+
+type JsonServiceError = {
+  code?: string;
+  detail: string;
 };
 
 // --- Shared Fetch State ---
@@ -39,7 +83,11 @@ const fetchOpts: RequestInit = {
   headers: defaultHeaders,
 };
 
-export type JsonFetcher<T> = (url: string) => Promise<T>;
+// Reuse the standard proxy environment variable so every shared HTTP helper
+// transparently follows the same outbound network path when a proxy is required.
+if (process.env.HTTP_PROXY) {
+  fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY);
+}
 
 // --- Service Errors ---
 
@@ -48,205 +96,37 @@ export type JsonFetcher<T> = (url: string) => Promise<T>;
  */
 export class ServiceResponseError extends Error {
   httpStatus?: number;
-  responseLabel?: string;
+  httpStatusText?: string;
   serviceCode?: string;
   serviceDetail?: string;
 
-  constructor(message: string, options: ServiceResponseErrorOptions = {}) {
+  constructor(message: string, options: ServiceResponseErrorOptions) {
     super(message);
     this.name = "ServiceResponseError";
-    this.httpStatus = options.httpStatus;
-    this.responseLabel = options.responseLabel;
-    this.serviceCode = options.serviceCode;
-    this.serviceDetail = options.serviceDetail;
+    this.httpStatus = options.http.status;
+    this.httpStatusText = options.http.statusText;
+    this.serviceCode = options.service?.code;
+    this.serviceDetail = options.service?.detail;
   }
 }
+
+// --- Constants ---
+
+const UNKNOWN_UPSTREAM_DETAIL = "Erreur amont inconnue.";
+const JSON_EXCEPTION_CODE_FIELDS = ["code", "exceptionCode"] as const;
+const JSON_EXCEPTION_DETAIL_FIELDS = ["text", "message", "detail"] as const;
+const JSON_NESTED_ERROR_DETAIL_FIELDS = ["description", "message", "detail"] as const;
+const JSON_ROOT_DETAIL_FIELDS = ["message", "detail"] as const;
+
+// --- Transport Functions ---
 
 /**
- * Checks whether an unknown error exposes the structured service-error shape.
- *
- * @param error Unknown error value caught by the caller.
- * @returns `true` when the error can be treated as a `ServiceResponseError`.
- */
-export function isServiceResponseError(error: unknown): error is ServiceResponseError {
-  return error instanceof Error && (
-    error instanceof ServiceResponseError
-    || error.name === "ServiceResponseError"
-    || "serviceCode" in error
-    || "serviceDetail" in error
-  );
-}
-
-// Reuse the standard proxy environment variable so every shared HTTP helper
-// transparently follows the same outbound network path when a proxy is required.
-if (process.env.HTTP_PROXY) {
-  fetchOpts.agent = new HttpsProxyAgent(process.env.HTTP_PROXY);
-}
-
-// --- XML Helpers ---
-
-/**
- * Returns the first child XML element matching the requested local name.
- *
- * @param element Parent element to inspect.
- * @param localName Local XML name without namespace prefix.
- * @returns The matching child element, or `null` when none is found.
- */
-function getChild(element: XmlElement | null | undefined, localName: string): XmlElement | null {
-  if (!element) {
-    return null;
-  }
-
-  const child = element.children.find(
-    (candidate): candidate is XmlElement =>
-      candidate instanceof XmlElement &&
-      candidate.name.split(":").pop() === localName
-  );
-
-  return child ?? null;
-}
-
-/**
- * Tries to extract an OGC/WFS-style service error from an XML response body.
- *
- * @param text Raw XML response body.
- * @returns A structured service error, or `null` when the XML payload is not a recognized error report.
- */
-function extractXmlError(text: string): ServiceResponseError | null {
-  try {
-    const root = parseXml(text).children.find((child) => child instanceof XmlElement);
-    const rootName = root?.name.split(":").pop();
-    if (rootName !== "ExceptionReport" && rootName !== "ServiceExceptionReport") {
-      return null;
-    }
-
-    const exception = getChild(root, "Exception") || getChild(root, "ServiceException");
-    if (!exception) {
-      return null;
-    }
-
-    const code = exception.attributes?.exceptionCode || exception.attributes?.code;
-    const message = getChild(exception, "ExceptionText")?.text?.trim() || exception.text?.trim() || "";
-    const errorMessage = [code, message].filter(Boolean).join(": ");
-
-    return errorMessage
-      ? new ServiceResponseError(errorMessage, {
-        serviceCode: code,
-        serviceDetail: message || undefined,
-      })
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Returns a short single-line preview of a response body for diagnostics.
- *
- * @param text Raw response body.
- * @returns A trimmed preview limited to 200 characters.
- */
-function previewBody(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  return trimmed.replace(/\s+/g, " ").slice(0, 200);
-}
-
-// --- Response Parsing ---
-
-/**
- * Parses an HTTP response expected to contain JSON and upgrades recognizable
- * XML/JSON service errors to richer structured exceptions.
- *
- * @param res HTTP-like response object returned by `fetch`.
- * @returns The parsed JSON payload.
- */
-export async function parseJsonResponse(res: ResponseLike): Promise<any> {
-  const contentType = (res.headers?.get?.("content-type") || "").toLowerCase();
-  const text = await res.text();
-  const looksLikeXml = contentType.includes("xml") || text.trim().startsWith("<");
-  const responseLabel = [res.status, res.statusText].filter(Boolean).join(" ") || "réponse HTTP";
-  const hasValidStatus = Number.isFinite(res.status);
-  const isOk = typeof res.ok === "boolean"
-    ? res.ok
-    : hasValidStatus && res.status >= 200 && res.status < 300;
-
-  if (text.trim() === "") {
-    throw new Error(`Réponse vide du service (${responseLabel})`);
-  }
-
-  if (looksLikeXml) {
-    const xmlError = extractXmlError(text);
-
-    if (xmlError) {
-      if (!isOk) {
-        throw new ServiceResponseError(
-          `Erreur HTTP du service (${responseLabel}): ${xmlError.message}`,
-          {
-            httpStatus: hasValidStatus ? res.status : undefined,
-            responseLabel,
-            serviceCode: xmlError.serviceCode,
-            serviceDetail: xmlError.serviceDetail,
-          },
-        );
-      }
-
-      xmlError.httpStatus = hasValidStatus ? res.status : undefined;
-      xmlError.responseLabel = responseLabel;
-      throw xmlError;
-    }
-
-    const details = [`content-type=${contentType || "inconnu"}`];
-    const bodyPreview = previewBody(text);
-    if (bodyPreview) {
-      details.push(`extrait=${bodyPreview}`);
-    }
-
-    throw new Error(`Réponse XML non exploitable du service (${responseLabel}, ${details.join(", ")})`);
-  }
-
-  let json;
-  try {
-    json = JSON.parse(text);
-  } catch {
-    const details = [`content-type=${contentType || "inconnu"}`];
-    const bodyPreview = previewBody(text);
-    if (bodyPreview) {
-      details.push(`extrait=${bodyPreview}`);
-    }
-
-    throw new Error(`Réponse JSON invalide du service (${responseLabel}, ${details.join(", ")})`);
-  }
-
-  if (!isOk) {
-    const errorMessage = json?.message
-      || json?.error
-      || json?.errorMessage
-      || json?.msg
-      || json?.title
-      || json?.detail
-      || (typeof json === "string" ? json : previewBody(JSON.stringify(json)));
-
-    throw new ServiceResponseError(`Erreur HTTP du service (${responseLabel}): ${errorMessage}`, {
-      httpStatus: hasValidStatus ? res.status : undefined,
-      responseLabel,
-      serviceDetail: errorMessage,
-    });
-  }
-
-  return json;
-}
-
-/**
- * Fetches and parses a JSON response from a URL.
+ * Sends a GET request expected to return JSON and parses the response.
  *
  * @param url Target URL.
  * @returns The parsed JSON payload.
  */
-export async function fetchJSON(url: string): Promise<any> {
+export async function fetchJSONGet(url: string): Promise<any> {
   logger.info(`[HTTP] GET ${url} ...`);
   const result = await fetch(url, fetchOpts).then(parseJsonResponse);
   logger.debug(`[HTTP] GET ${url} : ${JSON.stringify(result)}`);
@@ -254,7 +134,25 @@ export async function fetchJSON(url: string): Promise<any> {
 }
 
 /**
- * Builds the fetch options used by the shared JSON helpers.
+ * Sends a POST request expected to return JSON and parses the response.
+ *
+ * @param url Target URL.
+ * @param body Optional encoded request body.
+ * @param headers Additional request headers.
+ * @returns The parsed JSON payload.
+ */
+export async function fetchJSONPost(url: string, body: string = "", headers: RequestHeaders = {}) {
+  logger.info(`[HTTP] POST ${url} ...`);
+  const result = await fetch(url, buildFetchOptions("POST", body, headers)).then(parseJsonResponse);
+  logger.debug(`[HTTP] POST ${url} : ${JSON.stringify(result)}`);
+  return result;
+}
+
+/**
+ * Builds the fetch options used by the shared fetchJSONPost helper.
+ * Inherits shared transport settings from `fetchOpts` (including proxy agent),
+ * merges `defaultHeaders` with caller-provided headers, and only adds `body`
+ * when it is explicitly provided.
  *
  * @param method HTTP method to use.
  * @param body Optional request body.
@@ -273,17 +171,412 @@ function buildFetchOptions(method: string, body: string | undefined, headers: Re
   };
 }
 
+// --- Response Parsing ---
+
 /**
- * Sends a POST request expected to return JSON and parses the response.
+ * Parses an HTTP response expected to contain JSON and upgrades recognizable
+ * XML/JSON service errors to richer structured exceptions.
  *
- * @param url Target URL.
- * @param body Optional encoded request body.
- * @param headers Additional request headers.
+ * @param res HTTP-like response object returned by `fetch`.
  * @returns The parsed JSON payload.
  */
-export async function fetchJSONPost(url: string, body: string = "", headers: RequestHeaders = {}) {
-  logger.info(`[HTTP] POST ${url} ...`);
-  const result = await fetch(url, buildFetchOptions("POST", body, headers)).then(parseJsonResponse);
-  logger.debug(`[HTTP] POST ${url} : ${JSON.stringify(result)}`);
-  return result;
+export async function parseJsonResponse(res: ResponseLike): Promise<any> {
+  const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
+  const text = await res.text();
+  const context = buildResponseContext(res, text, contentType);
+
+  if (context.text.trim() === "") {
+    throw new Error(`Réponse vide du service (${context.responseLabel})`);
+  }
+
+  // handleXmlResponse always throws, either with a structured service error or an explicit parsing error.
+  if (context.looksLikeXml) {
+    handleXmlResponse(context);
+  }
+
+  const json = parseJsonBody(context);
+
+  // If the response is not OK, try to extract structured error details from the JSON body 
+  // and throw a ServiceResponseError with as much context as possible.
+  if (!context.isOk) {
+    const serviceError = extractJsonServiceError(json);
+    throw buildServiceResponseError(
+      context,
+      `Erreur HTTP du service (${context.responseLabel}): ${serviceError.detail}`,
+      {
+        code: serviceError.code,
+        detail: serviceError.detail,
+      },
+    );
+  }
+
+  return json;
+}
+
+/**
+ * Parses a JSON payload or throws a stable parsing error.
+ *
+ * @param context Normalized response context.
+ * @returns Parsed JSON payload.
+ */
+function parseJsonBody(context: ResponseParsingContext): unknown {
+  try {
+    return JSON.parse(context.text);
+  } catch {
+    const details = buildBodyDetails(context.contentType, context.text);
+    throw new Error(`Réponse JSON invalide du service (${context.responseLabel}, ${details.join(", ")})`);
+  }
+}
+
+// --- XML Error Extraction ---
+
+/**
+ * Handles XML-like responses and either throws structured upstream errors
+ * or explicit parsing diagnostics.
+ *
+ * @param context Normalized response context.
+ * @throws {ServiceResponseError | Error} Always throws for XML-like responses.
+ */
+function handleXmlResponse(context: ResponseParsingContext): never {
+  const xmlError = extractXmlServiceError(context.text);
+  if (xmlError) {
+    if (!context.isOk) {
+      throw buildServiceResponseError(
+        context,
+        `Erreur HTTP du service (${context.responseLabel}): ${xmlError.message}`,
+        {
+          code: xmlError.code,
+          detail: xmlError.detail,
+        },
+      );
+    }
+
+    throw buildServiceResponseError(context, xmlError.message, {
+      code: xmlError.code,
+      detail: xmlError.detail,
+    });
+  }
+
+  const unstructuredDetail = previewBody(context.text) || UNKNOWN_UPSTREAM_DETAIL;
+  if (!context.isOk) {
+    throw buildServiceResponseError(
+      context,
+      `Erreur HTTP du service (${context.responseLabel}): ${unstructuredDetail}`,
+      { detail: unstructuredDetail },
+    );
+  }
+
+  const details = buildBodyDetails(context.contentType, context.text);
+  throw new Error(`Réponse XML non exploitable du service (${context.responseLabel}, ${details.join(", ")})`);
+}
+
+/**
+ * Tries to extract an OGC/WFS-style service error from an XML response body.
+ *
+ * @param text Raw XML response body.
+ * @returns A parsed service error payload, or `null` when the XML payload is not a recognized error report.
+ */
+function extractXmlServiceError(text: string): XmlServiceError | null {
+  try {
+    const root = parseXml(text).children.find((child) => child instanceof XmlElement);
+    const rootName = root?.name.split(":").pop();
+    if (rootName !== "ExceptionReport" && rootName !== "ServiceExceptionReport") {
+      return null;
+    }
+
+    const exception = getChild(root, "Exception") || getChild(root, "ServiceException");
+    if (!exception) {
+      return null;
+    }
+
+    const code = exception.attributes?.exceptionCode || exception.attributes?.code;
+    const message = getChild(exception, "ExceptionText")?.text?.trim() || exception.text?.trim() || "";
+    const errorMessage = [code, message].filter(Boolean).join(": ");
+
+    return errorMessage
+      ? {
+        code,
+        detail: message || undefined,
+        message: errorMessage,
+      }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the first child XML element matching the requested local name.
+ *
+ * @param element Parent element to inspect.
+ * @param localName Local XML name without namespace prefix.
+ * @returns The matching child element, or `null` when none is found.
+ */
+function getChild(element: XmlElement | null | undefined, localName: string): XmlElement | null {
+  if (!element) {
+    return null;
+  }
+
+  const child = element.children.find(
+    (candidate): candidate is XmlElement =>
+      candidate instanceof XmlElement &&
+      candidate.name.split(":").pop() === localName,
+  );
+
+  return child ?? null;
+}
+
+// --- JSON Error Extraction ---
+
+/**
+ * Extracts structured upstream error details from a parsed JSON error body.
+ *
+ * @param json Parsed JSON payload.
+ * @returns A normalized `{ code, detail }` pair.
+ */
+function extractJsonServiceError(json: unknown): JsonServiceError {
+  if (typeof json === "string") {
+    return { detail: asNonEmptyString(json) ?? UNKNOWN_UPSTREAM_DETAIL };
+  }
+
+  const rootRecord = asRecord(json) ?? {};
+  const nestedError = asRecord(rootRecord.error);
+  const firstException = firstRecordItem(rootRecord.exceptions);
+  const rootDetailItem = firstStringItem(rootRecord.detail);
+  const nestedErrorDetailItem = firstStringItem(nestedError?.detail);
+  const rootCode = asErrorCode(rootRecord.code);
+  const nestedErrorCode = asErrorCode(nestedError?.code);
+
+  const code = pickFirstString([
+    pickFirstStringField(firstException, JSON_EXCEPTION_CODE_FIELDS),
+    rootCode,
+    nestedErrorCode,
+  ]);
+
+  const detail = pickFirstString([
+    pickFirstStringField(firstException, JSON_EXCEPTION_DETAIL_FIELDS),
+    pickFirstStringField(nestedError, JSON_NESTED_ERROR_DETAIL_FIELDS),
+    nestedErrorDetailItem,
+    rootDetailItem,
+    pickFirstStringField(rootRecord, JSON_ROOT_DETAIL_FIELDS),
+    typeof rootRecord.error === "string" ? rootRecord.error : undefined,
+  ]) || previewBody(JSON.stringify(json)) || UNKNOWN_UPSTREAM_DETAIL;
+
+  return { code, detail };
+}
+
+// --- Context Builders ---
+
+/**
+ * Builds a normalized response context consumed by parsing helpers.
+ *
+ * @param res HTTP-like response object.
+ * @param text Raw response body.
+ * @param contentType Normalized content-type header.
+ * @returns Structured context used by XML/JSON parsers.
+ */
+function buildResponseContext(
+  res: ResponseLike,
+  text: string,
+  contentType: string,
+): ResponseParsingContext {
+  return {
+    text,
+    contentType,
+    looksLikeXml: isLikelyXml(contentType, text),
+    responseLabel: buildResponseLabel(res.status, res.statusText),
+    isOk: res.ok,
+    status: res.status,
+  };
+}
+
+/**
+ * Checks whether a response likely contains XML data.
+ *
+ * TODO: Use a less stupid heuristic. Ok for a proof of concept but should be improved for production use.
+ *
+ * @param contentType Normalized content-type header.
+ * @param text Raw response body.
+ * @returns `true` when XML parsing should be attempted.
+ */
+function isLikelyXml(contentType: string, text: string) {
+  return contentType.includes("xml") || text.trim().startsWith("<");
+}
+
+/**
+ * Builds a structured service response error tied to the current HTTP context.
+ *
+ * @param context Normalized response context.
+ * @param message Error message.
+ * @param service Optional upstream service metadata.
+ * @returns A normalized `ServiceResponseError`.
+ */
+function buildServiceResponseError(
+  context: ResponseParsingContext,
+  message: string,
+  service?: { code?: string; detail?: string },
+) {
+  return new ServiceResponseError(message, {
+    http: {
+      status: context.status,
+      statusText: context.responseLabel,
+    },
+    ...(service ? { service } : {}),
+  });
+}
+
+/**
+ * Builds reusable diagnostic details for parser errors.
+ *
+ * @param contentType Normalized content-type header.
+ * @param text Raw response body.
+ * @returns A detail string list used in human-readable error messages.
+ */
+function buildBodyDetails(contentType: string, text: string) {
+  const details = [`content-type=${contentType || "inconnu"}`];
+  const bodyPreview = previewBody(text);
+  if (bodyPreview) {
+    details.push(`extrait=${bodyPreview}`);
+  }
+  return details;
+}
+
+/**
+ * Builds a human-readable response label combining HTTP status and text.
+ *
+ * @param status HTTP status code.
+ * @param statusText HTTP status text.
+ * @returns A label such as `400 Bad Request`.
+ */
+function buildResponseLabel(status: number, statusText: string) {
+  return [status, statusText].filter(Boolean).join(" ") || "réponse HTTP";
+}
+
+/**
+ * Returns a short single-line preview of a response body for diagnostics.
+ *
+ * @param text Raw response body.
+ * @returns A trimmed preview limited to 200 characters.
+ */
+function previewBody(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.replace(/\s+/g, " ").slice(0, 200);
+}
+
+// --- Scalar Helpers ---
+
+/**
+ * Converts an unknown scalar code to a normalized string.
+ *
+ * @param value Unknown code value.
+ * @returns A non-empty string representation, or `undefined`.
+ */
+function asErrorCode(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return asNonEmptyString(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+/**
+ * Returns the first non-empty string from an array-like unknown value.
+ *
+ * @param value Unknown value to inspect.
+ * @returns The first non-empty string item, or `undefined`.
+ */
+function firstStringItem(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return pickFirstString(value);
+}
+
+/**
+ * Returns the first non-empty string for a record among ordered field names.
+ *
+ * @param record Object-like value to inspect.
+ * @param fields Ordered field names.
+ * @returns The first non-empty string value, or `undefined`.
+ */
+function pickFirstStringField(
+  record: Record<string, unknown> | undefined,
+  fields: readonly string[],
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  return pickFirstString(fields.map((field) => record[field]));
+}
+
+/**
+ * Returns the first non-empty string in the provided values.
+ *
+ * @param values Candidate values ordered by priority.
+ * @returns The first normalized non-empty string, or `undefined`.
+ */
+function pickFirstString(values: unknown[]): string | undefined {
+  for (const value of values) {
+    const normalized = asNonEmptyString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns the first object item from an unknown array value.
+ *
+ * @param value Unknown value to inspect.
+ * @returns First object item as a record, or `undefined`.
+ */
+function firstRecordItem(value: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  for (const item of value) {
+    const record = asRecord(item);
+    if (record) {
+      return record;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns a plain record when the provided value is an object.
+ *
+ * @param value Unknown value to inspect.
+ * @returns A record view of the object, or `undefined`.
+ */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Returns a trimmed string when the provided value is a non-empty string.
+ *
+ * @param value Unknown value to inspect.
+ * @returns A normalized string or `undefined`.
+ */
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }

--- a/src/helpers/jsonSchema.ts
+++ b/src/helpers/jsonSchema.ts
@@ -10,7 +10,7 @@ export type PublishedInputSchema = {
 };
 
 /**
- * Converts a Zod input schema into an MCP-compatible JSON Schema for publication.
+ * Converts a Zod v3 input schema into an MCP-compatible JSON Schema for publication.
  *
  * Uses strict union emission and, for `z.pipe(...)`, publishes the pre-transform
  * argument shape (the value callers must send), not the transformed output shape.

--- a/src/helpers/wfs.ts
+++ b/src/helpers/wfs.ts
@@ -10,7 +10,7 @@
  * not preserve full FeatureCollection semantics in its public outputs.
  */
 
-import { fetchJSON } from "./http.js";
+import { fetchJSONGet } from "./http.js";
 import type { JsonFetcher } from "./http.js";
 import type { Geometry, Point } from "geojson";
 
@@ -58,13 +58,14 @@ export async function fetchWfsFeatures<TFeature extends WfsFeatureBase = WfsFeat
   typeNames: string[],
   cqlFilter: string,
   errorLabel: string,
-  fetcher: JsonFetcher<WfsFeatureCollection<TFeature>> = fetchJSON,
+  fetcher: JsonFetcher<WfsFeatureCollection<TFeature>> = fetchJSONGet,
 ): Promise<TFeature[]> {
   const url = GPF_WFS_BASE_URL + "?" + new URLSearchParams({
     service: "WFS",
     request: "GetFeature",
     typeName: typeNames.join(","),
     outputFormat: "application/json",
+    exceptions: "application/json",
     cql_filter: cqlFilter,
   }).toString();
 

--- a/src/helpers/wfs_engine/features.ts
+++ b/src/helpers/wfs_engine/features.ts
@@ -8,7 +8,7 @@
 
 import type { Collection } from "@ignfab/gpf-schema-store";
 
-import { isServiceResponseError } from "../http.js";
+import { ServiceResponseError } from "../http.js";
 import logger from "../../logger.js";
 import { fetchFeatureById, requireSingleFeatureById } from "./byId.js";
 import {
@@ -186,7 +186,7 @@ export async function executeGetFeatures(input: GpfWfsGetFeaturesInput) {
     featureCollection = await fetchFeatureCollection(request);
   } catch (error: unknown) {
     if (
-      isServiceResponseError(error) &&
+      error instanceof ServiceResponseError &&
       error.serviceCode === "InvalidParameterValue" &&
       error.serviceDetail === `Illegal property name: ${compiled.geometryProperty.name}`
     ) {

--- a/src/helpers/wfs_engine/request.ts
+++ b/src/helpers/wfs_engine/request.ts
@@ -105,6 +105,7 @@ export function buildMainRequest(
     request: "GetFeature",
     typeNames: input.typename,
     outputFormat: "application/json",
+    exceptions: "application/json",
     count: input.result_type === "hits" ? "1" : String(input.limit),
   };
 
@@ -140,6 +141,7 @@ export function buildReferenceGeometryRequest(typename: string, featureId: strin
     request: "GetFeature",
     typeNames: typename,
     outputFormat: "application/json",
+    exceptions: "application/json",
     featureID: featureId,
     propertyName: geometryPropertyName,
     count: "1",
@@ -173,6 +175,7 @@ export function buildGetFeatureByIdRequest(
     request: "GetFeature",
     typeNames: typename,
     outputFormat: "application/json",
+    exceptions: "application/json",
     featureID: featureId,
     count: "2",
   };

--- a/src/tools/AdminexpressTool.ts
+++ b/src/tools/AdminexpressTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing administrative units that cover a given point.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { getAdminUnits, ADMINEXPRESS_TYPES, ADMINEXPRESS_SOURCE } from "../gpf/adminexpress.js";
@@ -35,7 +35,7 @@ const adminexpressOutputSchema = z.object({
 
 // --- Tool ---
 
-class AdminexpressTool extends MCPTool<AdminexpressInput> {
+class AdminexpressTool extends BaseTool<AdminexpressInput> {
   name = "adminexpress";
   title = "Unités administratives";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/AltitudeTool.ts
+++ b/src/tools/AltitudeTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing altitude lookup for a single geographic position.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { ALTITUDE_SOURCE, getAltitudeByLocation } from "../gpf/altitude.js";
@@ -33,7 +33,7 @@ const altitudeOutputSchema = z.object({
 
 // --- Tool ---
 
-class AltitudeTool extends MCPTool<AltitudeInput> {
+class AltitudeTool extends BaseTool<AltitudeInput> {
   name = "altitude";
   title = "Altitude d’une position";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/AssietteSupTool.ts
+++ b/src/tools/AssietteSupTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing nearby servitudes d'utilité publique for a given point.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { getAssiettesServitudes, URBANISME_SOURCE } from "../gpf/urbanisme.js";
@@ -36,7 +36,7 @@ const assietteSupOutputSchema = z.object({
 
 // --- Tool ---
 
-class AssietteSupTool extends MCPTool<AssietteSupInput> {
+class AssietteSupTool extends BaseTool<AssietteSupInput> {
   name = "assiette_sup";
   title = "Servitudes d’utilité publique";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -1,0 +1,21 @@
+import { MCPTool } from "mcp-framework";
+
+import { normalizeToolError } from "../helpers/errors/toolError.js";
+
+export default abstract class BaseTool<TInput extends Record<string, any> = any> extends MCPTool<TInput> {
+  protected createErrorResponse(error: unknown) {
+    const payload = normalizeToolError(error);
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: payload.detail,
+        },
+      ],
+      structuredContent: payload as Record<string, unknown>,
+      isError: true,
+    };
+    
+  }
+}

--- a/src/tools/CadastreTool.ts
+++ b/src/tools/CadastreTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing nearby cadastral objects for a given point.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { getParcellaireExpress, PARCELLAIRE_EXPRESS_TYPES, PARCELLAIRE_EXPRESS_SOURCE } from "../gpf/parcellaire-express.js";
@@ -37,7 +37,7 @@ const cadastreOutputSchema = z.object({
 
 // --- Tool ---
 
-class CadastreTool extends MCPTool<CadastreInput> {
+class CadastreTool extends BaseTool<CadastreInput> {
   name = "cadastre";
   title = "Informations cadastrales";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/GeocodeTool.ts
+++ b/src/tools/GeocodeTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing free-text geocoding and autocomplete.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { geocode, GEOCODE_SOURCE } from "../gpf/geocode.js";
@@ -44,7 +44,7 @@ const geocodeOutputSchema = z.object({
 
 // --- Tool ---
 
-class GeocodeTool extends MCPTool<GeocodeInput> {
+class GeocodeTool extends BaseTool<GeocodeInput> {
   name = "geocode";
   title = "Géocodage de lieux et d’adresses";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing detailed schema inspection for a single WFS type.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 import type { Collection } from "@ignfab/gpf-schema-store";
 
@@ -45,7 +45,7 @@ const gpfWfsDescribeTypeOutputSchema = z.object({
 
 // --- Tool ---
 
-class GpfWfsDescribeTypeTool extends MCPTool<GpfWfsDescribeTypeInput> {
+class GpfWfsDescribeTypeTool extends BaseTool<GpfWfsDescribeTypeInput> {
   name = "gpf_wfs_describe_type";
   title = "Description d’un type WFS";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -6,7 +6,7 @@
  * is delegated to the structured WFS engine.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { buildPropertyName, executeGetFeatureById } from "../helpers/wfs_engine/byId.js";
@@ -24,7 +24,7 @@ import {
 
 // --- Tool ---
 
-class GpfWfsGetFeatureByIdTool extends MCPTool<GpfWfsGetFeatureByIdInput> {
+class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
   name = "gpf_wfs_get_feature_by_id";
   title = "Lecture d’un objet WFS par identifiant";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -1,4 +1,4 @@
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import {
@@ -23,7 +23,7 @@ import {
 
 // --- Tool ---
 
-class GpfWfsGetFeaturesTool extends MCPTool<GpfWfsGetFeaturesInput> {
+class GpfWfsGetFeaturesTool extends BaseTool<GpfWfsGetFeaturesInput> {
   name = "gpf_wfs_get_features";
   title = "Lecture d’objets WFS";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/GpfWfsSearchTypesTool.ts
+++ b/src/tools/GpfWfsSearchTypesTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing keyword-based search over the embedded WFS type catalog.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
@@ -42,7 +42,7 @@ const gpfWfsSearchTypesOutputSchema = z.object({
 
 // --- Tool ---
 
-class GpfWfsSearchTypesTool extends MCPTool<GpfWfsSearchTypesInput> {
+class GpfWfsSearchTypesTool extends BaseTool<GpfWfsSearchTypesInput> {
   name = "gpf_wfs_search_types";
   title = "Recherche de types WFS";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/src/tools/UrbanismeTool.ts
+++ b/src/tools/UrbanismeTool.ts
@@ -2,7 +2,7 @@
  * MCP tool exposing urban planning information around a given point.
  */
 
-import { MCPTool } from "mcp-framework";
+import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
 import { getUrbanisme, URBANISME_SOURCE } from "../gpf/urbanisme.js";
@@ -48,7 +48,7 @@ const URBANISME_TOOL_DESCRIPTION = [
 
 // --- Tool ---
 
-class UrbanismeTool extends MCPTool<UrbanismeInput> {
+class UrbanismeTool extends BaseTool<UrbanismeInput> {
   name = "urbanisme";
   title = "Informations d’urbanisme";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;

--- a/test/helpers/http.test.ts
+++ b/test/helpers/http.test.ts
@@ -7,13 +7,12 @@ function createResponse(
         status = 200,
         statusText = "OK",
         ok,
-        includeOk = true,
-    }: { status?: number; statusText?: string; ok?: boolean; includeOk?: boolean } = {}
+    }: { status?: number; statusText?: string; ok?: boolean } = {}
 ) {
     return {
         status,
         statusText,
-        ...(includeOk ? { ok: ok ?? (status >= 200 && status < 300) } : {}),
+        ok: ok ?? (status >= 200 && status < 300),
         headers: {
             get(name: string) {
                 return name.toLowerCase() === "content-type" ? contentType : null;
@@ -89,16 +88,54 @@ describe("Test HTTP helpers", () => {
         ).rejects.toThrow("Erreur HTTP du service (400 Bad Request): bad filter");
     });
 
-    it("should reject responses with invalid status when ok is absent", async () => {
+    it("should extract code and text from GeoServer JSON exceptions payloads", async () => {
+        const geoserverJson = JSON.stringify({
+            version: null,
+            exceptions: [
+                {
+                    code: "InvalidParameterValue",
+                    locator: "GetFeature",
+                    text: "Requested property: toto=toto is not available for BDTOPO_V3:batiment.",
+                },
+            ],
+        });
+
+        await expect(
+            parseJsonResponse(
+                createResponse(geoserverJson, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toThrow(
+            "Erreur HTTP du service (400 Bad Request): Requested property: toto=toto is not available for BDTOPO_V3:batiment."
+        );
+
+        await expect(
+            parseJsonResponse(
+                createResponse(geoserverJson, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceCode: "InvalidParameterValue",
+            serviceDetail: "Requested property: toto=toto is not available for BDTOPO_V3:batiment.",
+            httpStatusText: "400 Bad Request",
+        });
+    });
+
+    it("should trust explicit ok=false even with a 2xx status", async () => {
         await expect(
             parseJsonResponse(
                 createResponse('{"message":"bad filter"}', "application/json", {
-                    status: Number.NaN,
-                    statusText: "Bad Request",
-                    includeOk: false,
+                    status: 200,
+                    statusText: "OK",
+                    ok: false,
                 })
             )
-        ).rejects.toThrow("Erreur HTTP du service (Bad Request): bad filter");
+        ).rejects.toThrow("Erreur HTTP du service (200 OK): bad filter");
     });
 
     it("should reject non-2xx XML responses with extracted OGC errors", async () => {
@@ -140,7 +177,7 @@ describe("Test HTTP helpers", () => {
             name: "ServiceResponseError",
             serviceCode: "InvalidParameterValue",
             serviceDetail: "Illegal property name: geom",
-            responseLabel: "400 Bad Request",
+            httpStatusText: "400 Bad Request",
         });
     });
 
@@ -155,7 +192,120 @@ describe("Test HTTP helpers", () => {
         ).rejects.toMatchObject({
             name: "ServiceResponseError",
             serviceDetail: "bad filter",
-            responseLabel: "400 Bad Request",
+            httpStatusText: "400 Bad Request",
         });
     });
+
+    it("should extract code and description from altimetry error payloads", async () => {
+        const payload = JSON.stringify({
+            error: {
+                code: "BAD_PARAMETER",
+                description: "The parameter [lat] is missing.",
+            },
+        });
+
+        await expect(
+            parseJsonResponse(
+                createResponse(payload, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toThrow("Erreur HTTP du service (400 Bad Request): The parameter [lat] is missing.");
+
+        await expect(
+            parseJsonResponse(
+                createResponse(payload, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceCode: "BAD_PARAMETER",
+            serviceDetail: "The parameter [lat] is missing.",
+            httpStatusText: "400 Bad Request",
+        });
+    });
+
+    it("should extract detailed messages from autocomplete error payloads", async () => {
+        const payload = JSON.stringify({
+            code: 400,
+            message: "Failed parsing query",
+            detail: [
+                "text: required param",
+            ],
+        });
+
+        await expect(
+            parseJsonResponse(
+                createResponse(payload, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toThrow("Erreur HTTP du service (400 Bad Request): text: required param");
+
+        await expect(
+            parseJsonResponse(
+                createResponse(payload, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceCode: "400",
+            serviceDetail: "text: required param",
+            httpStatusText: "400 Bad Request",
+        });
+    });
+
+    it("should normalize non-2xx HTML responses as upstream service errors", async () => {
+        const html = "<!DOCTYPE html><html><body><h1>Bad Request</h1><p>Missing lat parameter</p></body></html>";
+
+        await expect(
+            parseJsonResponse(
+                createResponse(html, "text/html", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toThrow("Erreur HTTP du service (400 Bad Request):");
+
+        await expect(
+            parseJsonResponse(
+                createResponse(html, "text/html", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceDetail: "<!DOCTYPE html><html><body><h1>Bad Request</h1><p>Missing lat parameter</p></body></html>",
+            httpStatusText: "400 Bad Request",
+        });
+    });
+
+    it("should not infer non-explicit JSON keys as known error detail fields", async () => {
+        const payload = JSON.stringify({
+            title: "This key is not part of known JSON error payloads",
+            msg: "Neither is this one",
+            errorMessage: "Nor this one",
+        });
+
+        await expect(
+            parseJsonResponse(
+                createResponse(payload, "application/json", {
+                    status: 400,
+                    statusText: "Bad Request",
+                })
+            )
+        ).rejects.toMatchObject({
+            name: "ServiceResponseError",
+            serviceDetail: "{\"title\":\"This key is not part of known JSON error payloads\",\"msg\":\"Neither is this one\",\"errorMessage\":\"Nor this one\"}",
+            httpStatusText: "400 Bad Request",
+        });
+    });
+
 });

--- a/test/helpers/toolError.test.ts
+++ b/test/helpers/toolError.test.ts
@@ -1,0 +1,139 @@
+import { z } from "zod";
+import { vi } from "vitest";
+
+import { ServiceResponseError } from "../../src/helpers/http.js";
+import { normalizeToolError } from "../../src/helpers/errors/toolError.js";
+
+describe("Test toolError helper", () => {
+  it("should install the FR Zod error map at module load", async () => {
+    vi.resetModules();
+    const { z: freshZ } = await import("zod");
+
+    // Reset to default messages, then import toolError to trigger module-level install.
+    freshZ.setErrorMap((issue, ctx) => ({ message: ctx.defaultError }));
+    await import("../../src/helpers/errors/toolError.js");
+
+    const schema = freshZ.object({
+      lon: freshZ.number().max(180),
+    });
+    const result = schema.safeParse({ lon: 600 });
+
+    if (result.success) {
+      throw new Error("expected parse failure");
+    }
+
+    expect(result.error.issues[0].message).toContain("au plus");
+  });
+
+  it("should normalize a Zod error with French messages", () => {
+    const schema = z.object({
+      lon: z.number().max(180),
+    }).strict();
+    const result = schema.safeParse({
+      lon: 600,
+      unexpected: true,
+    });
+
+    if (result.success) {
+      throw new Error("expected parse failure");
+    }
+
+    const payload = normalizeToolError(result.error);
+
+    expect(payload).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      title: "Paramètres d’outil invalides",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "lon",
+          code: "too_big",
+        }),
+        expect.objectContaining({
+          code: "unknown_parameter",
+          detail: expect.stringContaining("unexpected"),
+        }),
+      ]),
+    });
+    expect(payload.detail).toContain("Paramètres invalides");
+  });
+
+  it("should keep custom French validation messages when present", () => {
+    const schema = z.object({
+      typename: z.string().min(1, "le nom du type ne doit pas être vide"),
+    });
+    const result = schema.safeParse({
+      typename: "",
+    });
+
+    if (result.success) {
+      throw new Error("expected parse failure");
+    }
+
+    const payload = normalizeToolError(result.error);
+    expect(payload).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "typename",
+          code: "too_small",
+          detail: "le nom du type ne doit pas être vide",
+        }),
+      ]),
+    });
+  });
+
+  it("should normalize ServiceResponseError as upstream error", () => {
+    const payload = normalizeToolError(new ServiceResponseError("bad filter", {
+      http: {
+        status: 400,
+        statusText: "400 Bad Request",
+      },
+      service: {
+        code: "InvalidParameterValue",
+        detail: "bad filter",
+      },
+    }));
+
+    expect(payload).toMatchObject({
+      type: "urn:geocontext:problem:upstream-invalid-request",
+      title: "Requête rejetée par le service amont",
+      detail: "Le service distant a rejeté la requête : bad filter",
+      upstream: {
+        status: 400,
+      },
+      errors: [
+        {
+          code: "invalid_parameter_value",
+          detail: "bad filter",
+        },
+      ],
+    });
+  });
+
+  it("should normalize generic errors as execution error", () => {
+    const payload = normalizeToolError(new Error("boom"));
+
+    expect(payload).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+      title: "Erreur d’exécution de l’outil",
+      detail: "boom",
+      errors: [
+        {
+          code: "execution_error",
+          detail: "boom",
+        },
+      ],
+    });
+  });
+
+  it("should not classify generic errors with service-like fields as upstream errors", () => {
+    const payload = normalizeToolError(Object.assign(new Error("boom"), {
+      serviceCode: "InvalidParameterValue",
+    }));
+
+    expect(payload).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+      detail: "boom",
+    });
+  });
+});

--- a/test/helpers/wfs.test.ts
+++ b/test/helpers/wfs.test.ts
@@ -1,0 +1,34 @@
+import { fetchWfsFeatures } from "../../src/helpers/wfs.js";
+
+describe("Test legacy WFS helper", () => {
+  it("should force JSON exceptions on WFS requests", async () => {
+    let capturedUrl = "";
+
+    const features = await fetchWfsFeatures(
+      ["ADMINEXPRESS-COG.LATEST:commune"],
+      "code_insee = '01001'",
+      "WFS",
+      async (url: string) => {
+        capturedUrl = url;
+        return {
+          features: [
+            {
+              id: "commune.1",
+              properties: { code_insee: "01001" },
+            },
+          ],
+        };
+      },
+    );
+
+    expect(features).toHaveLength(1);
+
+    const parsed = new URL(capturedUrl);
+    expect(parsed.searchParams.get("service")).toEqual("WFS");
+    expect(parsed.searchParams.get("request")).toEqual("GetFeature");
+    expect(parsed.searchParams.get("typeName")).toEqual("ADMINEXPRESS-COG.LATEST:commune");
+    expect(parsed.searchParams.get("outputFormat")).toEqual("application/json");
+    expect(parsed.searchParams.get("exceptions")).toEqual("application/json");
+    expect(parsed.searchParams.get("cql_filter")).toEqual("code_insee = '01001'");
+  });
+});

--- a/test/tools/adminexpress.test.ts
+++ b/test/tools/adminexpress.test.ts
@@ -141,6 +141,15 @@ describe("Test AdminexpressTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("Number must be less than or equal to 180");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "lon",
+                    code: "too_big",
+                }),
+            ]),
+        });
     });
 });

--- a/test/tools/altitude.test.ts
+++ b/test/tools/altitude.test.ts
@@ -87,6 +87,15 @@ describe("Test AltitudeTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("Number must be less than or equal to 180");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "lon",
+                    code: "too_big",
+                }),
+            ]),
+        });
     });
 });

--- a/test/tools/base-tool-error.test.ts
+++ b/test/tools/base-tool-error.test.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+import BaseTool from "../../src/tools/BaseTool.js";
+
+describe("Test BaseTool error response", () => {
+  class DummyTool extends BaseTool<{ lon: number }> {
+    name = "dummy_error_tool";
+    title = "Dummy Error Tool";
+    description = "Dummy tool used to test BaseTool error normalization.";
+    schema = z.object({
+      lon: z.number().max(180),
+    }).strict();
+
+    async execute() {
+      throw new Error("runtime failure");
+    }
+  }
+
+  it("should return normalized validation errors", async () => {
+    const tool = new DummyTool();
+
+    const response = await tool.toolCall({
+      params: {
+        name: "dummy_error_tool",
+        arguments: {
+          lon: 600,
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Paramètres invalides"),
+    });
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "lon",
+          code: "too_big",
+        }),
+      ]),
+    });
+  });
+
+  it("should return normalized runtime errors", async () => {
+    const tool = new DummyTool();
+
+    const response = await tool.toolCall({
+      params: {
+        name: "dummy_error_tool",
+        arguments: {
+          lon: 2.3,
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: "runtime failure",
+    });
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+      detail: "runtime failure",
+      errors: [
+        {
+          code: "execution_error",
+          detail: "runtime failure",
+        },
+      ],
+    });
+  });
+});

--- a/test/tools/cadastre.test.ts
+++ b/test/tools/cadastre.test.ts
@@ -126,6 +126,15 @@ describe("Test CadastreTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("Number must be less than or equal to 180");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "lon",
+                    code: "too_big",
+                }),
+            ]),
+        });
     });
 });

--- a/test/tools/geocode.test.ts
+++ b/test/tools/geocode.test.ts
@@ -89,6 +89,16 @@ describe("Test GeocodeTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("le texte ne doit pas être vide");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "text",
+                    code: "too_small",
+                    detail: "le texte ne doit pas être vide",
+                }),
+            ]),
+        });
     });
 });

--- a/test/tools/strict-input.test.ts
+++ b/test/tools/strict-input.test.ts
@@ -85,7 +85,16 @@ describe("Strict tool input schemas", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    expect(textContent.text).toMatch(/unrecognized/i);
-    expect(textContent.text).toContain("unexpected");
+    expect(textContent.text).toContain("Paramètres invalides");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          code: "unknown_parameter",
+          name: "unexpected",
+          detail: expect.stringContaining("unexpected"),
+        }),
+      ]),
+    });
   });
 });

--- a/test/tools/urbanisme.test.ts
+++ b/test/tools/urbanisme.test.ts
@@ -123,7 +123,16 @@ describe("Test UrbanismeTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("Number must be less than or equal to 180");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "lon",
+                    code: "too_big",
+                }),
+            ]),
+        });
     });
 });
 
@@ -248,6 +257,15 @@ describe("Test AssietteSupTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("Number must be less than or equal to 180");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "lon",
+                    code: "too_big",
+                }),
+            ]),
+        });
     });
 });

--- a/test/tools/wfs/describeType.test.ts
+++ b/test/tools/wfs/describeType.test.ts
@@ -92,7 +92,17 @@ describe("Test GpfWfsDescribeTypeTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("le nom du type ne doit pas être vide");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "typename",
+                    code: "too_small",
+                    detail: "le nom du type ne doit pas être vide",
+                }),
+            ]),
+        });
     });
 
     it("should return isError=true when execute fails", async () => {
@@ -116,5 +126,8 @@ describe("Test GpfWfsDescribeTypeTool",() => {
         }
         expect(textContent.text).toContain("Le type 'BDTOPO_V3:not_found' est introuvable");
         expect(textContent.text).toContain("gpf_wfs_search_types");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:execution-error",
+        });
     });
 });

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -1,5 +1,6 @@
 import type { Collection } from "@ignfab/gpf-schema-store";
 import { vi } from "vitest";
+import { ServiceResponseError } from "../../../src/helpers/http.js";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<Collection>>();
 const mockFetchJSONPost = vi.fn<(
@@ -17,6 +18,7 @@ vi.doMock("../../../src/gpf/wfs-schema-catalog.js", () => ({
 
 vi.doMock("../../../src/helpers/http.js", () => ({
   fetchJSONPost: mockFetchJSONPost,
+  ServiceResponseError,
 }));
 
 const { default: GpfWfsGetFeatureByIdTool } = await import("../../../src/tools/GpfWfsGetFeatureByIdTool");
@@ -104,6 +106,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     expect(request.method).toEqual("POST");
     expect(request.query.featureID).toEqual("commune.1");
     expect(request.query.typeNames).toEqual("ADMINEXPRESS-COG.LATEST:commune");
+    expect(request.query.exceptions).toEqual("application/json");
     expect(request.query.propertyName).toEqual("code_insee,geometrie");
     expect(request.query.count).toEqual("2");
     expect(response.structuredContent).toMatchObject({
@@ -153,6 +156,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
 
     expect(response.isError).toBeUndefined();
     expect(requests).toHaveLength(1);
+    expect(requests[0].query.exceptions).toEqual("application/json");
     const textContent = response.content[0];
     if (textContent.type !== "text") {
       throw new Error("expected text content");
@@ -191,6 +195,9 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     }
     expect(textContent.text).toContain("est introuvable");
     expect(textContent.text).toContain("commune.404");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
   });
 
   it("should fail clearly when multiple features are returned", async () => {
@@ -221,6 +228,9 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
       throw new Error("expected text content");
     }
     expect(textContent.text).toContain("devrait être unique");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
   });
 
   it("should fail clearly when the returned feature id mismatches", async () => {
@@ -250,6 +260,9 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
       throw new Error("expected text content");
     }
     expect(textContent.text).toContain("au lieu de");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
   });
 
   it("should reject invalid result_type values such as hits", async () => {
@@ -270,7 +283,16 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    expect(textContent.text).toContain("results");
-    expect(textContent.text).toContain("request");
+    expect(textContent.text).toContain("Paramètres invalides");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "result_type",
+          code: "invalid_enum_value",
+          detail: expect.stringContaining("results"),
+        }),
+      ]),
+    });
   });
 });

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -1,5 +1,6 @@
 import type { Collection } from "@ignfab/gpf-schema-store";
 import { vi } from "vitest";
+import { ServiceResponseError } from "../../../src/helpers/http.js";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<Collection>>();
 const mockFetchJSONPost = vi.fn<(
@@ -7,14 +8,6 @@ const mockFetchJSONPost = vi.fn<(
   body?: string,
   headers?: Record<string, string>,
 ) => Promise<unknown>>();
-const mockIsServiceResponseError = (
-  error: unknown,
-): error is Error & { serviceCode?: string; serviceDetail?: string } =>
-  error instanceof Error && (
-    error.name === "ServiceResponseError" ||
-    "serviceCode" in error ||
-    "serviceDetail" in error
-  );
 
 vi.doMock("../../../src/gpf/wfs-schema-catalog.js", () => ({
   GPF_WFS_URL: "https://data.geopf.fr/wfs",
@@ -25,7 +18,7 @@ vi.doMock("../../../src/gpf/wfs-schema-catalog.js", () => ({
 
 vi.doMock("../../../src/helpers/http.js", () => ({
   fetchJSONPost: mockFetchJSONPost,
-  isServiceResponseError: mockIsServiceResponseError,
+  ServiceResponseError,
 }));
 
 const { default: GpfWfsGetFeaturesTool } = await import(
@@ -239,6 +232,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     expect(request.method).toEqual("POST");
     expect(request.url).toContain("https://data.geopf.fr/wfs");
     expect(request.query.service).toEqual("WFS");
+    expect(request.query.exceptions).toEqual("application/json");
     expect(request.query.propertyName).toEqual("code_insee,geometrie");
     expect(request.body).toContain("cql_filter=");
     expect(response.structuredContent).toMatchObject({
@@ -266,7 +260,17 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    expect(textContent.text).toContain("le nom du type ne doit pas être vide");
+    expect(textContent.text).toContain("Paramètres invalides");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "typename",
+          code: "too_small",
+          detail: "le nom du type ne doit pas être vide",
+        }),
+      ]),
+    });
   });
 
   it("should reject legacy inputs removed from the public schema", async () => {
@@ -286,8 +290,17 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    expect(textContent.text).toMatch(/unrecognized/i);
-    expect(textContent.text).toContain("cql_filter");
+    expect(textContent.text).toContain("Paramètres invalides");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          code: "unknown_parameter",
+          name: "cql_filter",
+          detail: expect.stringContaining("cql_filter"),
+        }),
+      ]),
+    });
   });
 
   it("should build a POST request with query params and encoded body", async () => {
@@ -310,6 +323,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
 
     expect(response.isError).toBeUndefined();
     expect(requests).toHaveLength(1);
+    expect(requests[0].query.exceptions).toEqual("application/json");
     expect(requests[0].query.count).toEqual("7");
     expect(requests[0].query.propertyName).toEqual("code_insee,population");
     expect(requests[0].query.sortBy).toEqual("population D");
@@ -320,12 +334,17 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     const tool = new GpfWfsGetFeaturesTool();
     mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
     mockFetchJSONPost.mockRejectedValue(
-      Object.assign(
-        new Error("Erreur HTTP du service (400 Bad Request): InvalidParameterValue: Illegal property name: geometrie"),
+      new ServiceResponseError(
+        "Erreur HTTP du service (400 Bad Request): InvalidParameterValue: Illegal property name: geometrie",
         {
-          name: "ServiceResponseError",
-          serviceCode: "InvalidParameterValue",
-          serviceDetail: "Illegal property name: geometrie",
+          http: {
+            status: 400,
+            statusText: "400 Bad Request",
+          },
+          service: {
+            code: "InvalidParameterValue",
+            detail: "Illegal property name: geometrie",
+          },
         },
       ),
     );
@@ -346,6 +365,9 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     }
     expect(textContent.text).toContain("catalogue embarqué est rejeté");
     expect(textContent.text).toContain("géométrique 'geometrie'");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
   });
 
   it("should keep hits independent from limit and omit propertyName", async () => {
@@ -366,6 +388,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     });
 
     expect(response.isError).toBeUndefined();
+    expect(requests[0].query.exceptions).toEqual("application/json");
     expect(requests[0].query.count).toEqual("1");
     expect(requests[0].query.propertyName).toBeUndefined();
     const textContent = response.content[0];
@@ -419,6 +442,9 @@ describe("Test GpfWfsGetFeaturesTool", () => {
       throw new Error("expected text content");
     }
     expect(textContent.text).toContain('numberMatched="unknown"');
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
   });
 
   it("should return feature_ref for non point layers with geometry set to null", async () => {
@@ -577,6 +603,9 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     }
     expect(textContent.text).toContain("est introuvable");
     expect(textContent.text).toContain("localisant.404");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
   });
 
   it("should reject intersects_feature on the same typename and guide to by-id tool", async () => {
@@ -602,6 +631,9 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     }
     expect(textContent.text).toContain("gpf_wfs_get_feature_by_id");
     expect(textContent.text).toContain("intersects_feature");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+    });
     expect(requests).toHaveLength(0);
   });
 });

--- a/test/tools/wfs/searchTypes.test.ts
+++ b/test/tools/wfs/searchTypes.test.ts
@@ -86,6 +86,16 @@ describe("Test GpfWfsSearchTypesTool",() => {
         if (textContent.type !== "text") {
             throw new Error("expected text content");
         }
-        expect(textContent.text).toContain("la requête de recherche ne doit pas être vide");
+        expect(textContent.text).toContain("Paramètres invalides");
+        expect(response.structuredContent).toMatchObject({
+            type: "urn:geocontext:problem:invalid-tool-params",
+            errors: expect.arrayContaining([
+                expect.objectContaining({
+                    name: "query",
+                    code: "too_small",
+                    detail: "la requête de recherche ne doit pas être vide",
+                }),
+            ]),
+        });
     });
 });


### PR DESCRIPTION
Closes #35 

## Overview
This PR introduces a unified error contract for all MCP tools and improves upstream error parsing to make failures more consistent, actionable, and localized (French) across the project.

## What Changed
- Added a shared `BaseTool` class and moved tool error response creation to a single normalization path.
- Introduced `src/helpers/errors/` with:
  - `toolError.ts` for centralized error classification/normalization (`invalid_tool_params`, `upstream`, `execution`).
  - `zodErrorMapFr.ts` for French Zod messages, installed at module load to avoid first-call English messages.
- Refactored `src/helpers/http.ts`:
  - Reorganized file in runtime call order with improved top-level documentation.
  - Standardized `ServiceResponseError` shape to nested metadata (`http` + `service`).
  - Improved XML/JSON/HTML upstream error extraction and diagnostics.
  - Tightened JSON error field extraction to known, non-parasitic field lists.
- Updated tools to extend the new `BaseTool` so all tool failures share the same MCP `structuredContent` error contract.
- Updated WFS engine error checks to rely on `instanceof ServiceResponseError`.
- Updated MCP docs generation:
  - Excluded `BaseTool` from generated tool docs.
  - Added an auto-generated “MCP error contract” section in `docs/mcp-tools.md`.
  - Made `docs:mcp` run a build first to ensure docs are generated from current compiled tools.
- Expanded and aligned tests:
  - Added dedicated tests for `toolError` and `BaseTool` normalization.
  - Extended HTTP parser coverage (JSON/XML/HTML/non-2xx cases).
  - Aligned WFS tests to use the real `ServiceResponseError` constructor/signature.

## Why
- Ensure clients receive a stable, machine-readable MCP error payload regardless of where a failure happens.
- Prevent misleading or inconsistent error details across tools.
- Improve observability and user-facing clarity for upstream service failures.
- Keep generated docs aligned with runtime behavior.

## Validation
- `npm run typecheck` passes.
- `npm test` passes (`124` tests).

## Notes
- `mcp-framework` build output may still report `Validated 11 tools successfully` because its internal validator scans compiled files differently; runtime loading and docs generation explicitly exclude `BaseTool`.
