### PR TITLE
feat: implement multi-typename support with individual CQL filters for WFS queries

### DIFF
--- a/src/gpf/adminexpress.ts
+++ b/src/gpf/adminexpress.ts
@@ -48,19 +48,20 @@ const ADMINEXPRESS_TYPENAMES = ADMINEXPRESS_TYPES.map((type) => `ADMINEXPRESS-CO
 export async function getAdminUnits(lon: number, lat: number): Promise<AdminUnit[]> {
     logger.info(`[adminexpress] getAdminUnits(${lon},${lat})...`);
 
-    // Resolve the geometry property name from the embedded catalog
-    // (all ADMINEXPRESS types share the same schema, querying the first is sufficient)
-    const featureType = await getFeatureType(ADMINEXPRESS_TYPENAMES[0]);
-    const geometryProperty = getGeometryProperty(featureType);
-
-    // Compile the spatial filter using the engine
     const spatialFilter: SpatialFilter = { operator: "intersects_point", lon, lat };
-    const cqlFilter = compileIntersectsPointSpatialFilter(geometryProperty, spatialFilter);
+
+    // Resolve and compile one spatial filter per typename to avoid relying on
+    // cross-layer geometry property homogeneity.
+    const cqlFilters = await Promise.all(ADMINEXPRESS_TYPENAMES.map(async (typename) => {
+        const featureType = await getFeatureType(typename);
+        const geometryProperty = getGeometryProperty(featureType);
+        return compileIntersectsPointSpatialFilter(geometryProperty, spatialFilter);
+    }));
 
     // Execute the multi-typename WFS query
     const featureCollection: WfsFeatureCollectionResponse = await fetchWfsMultiTypename({
         typenames: ADMINEXPRESS_TYPENAMES,
-        cqlFilter,
+        cqlFilters,
         errorLabel: 'ADMINEXPRESS',
     });
 

--- a/src/gpf/parcellaire-express.ts
+++ b/src/gpf/parcellaire-express.ts
@@ -72,23 +72,25 @@ function filterByDistance(items: ParcellaireExpressItem[]): ParcellaireExpressIt
 export async function getParcellaireExpress(lon: number, lat: number): Promise<ParcellaireExpressItem[]> {
     logger.info(`getParcellaireExpress(${lon},${lat}) ...`);
 
-    // Resolve the geometry property name from the embedded catalog
-    const featureType = await getFeatureType(PARCELLAIRE_EXPRESS_TYPENAMES[0]);
-    const geometryProperty = getGeometryProperty(featureType);
-
-    // Compile the spatial filter using the engine
     const spatialFilter: SpatialFilter = {
         operator: "dwithin_point",
         lon,
         lat,
         distance_m: 10,
     };
-    const cqlFilter = compileDwithinSpatialFilter(geometryProperty, spatialFilter);
+
+    // Resolve and compile one spatial filter per typename to avoid relying on
+    // cross-layer geometry property homogeneity.
+    const cqlFilters = await Promise.all(PARCELLAIRE_EXPRESS_TYPENAMES.map(async (typename) => {
+        const featureType = await getFeatureType(typename);
+        const geometryProperty = getGeometryProperty(featureType);
+        return compileDwithinSpatialFilter(geometryProperty, spatialFilter);
+    }));
 
     // Execute the multi-typename WFS query
     const featureCollection: WfsFeatureCollectionResponse = await fetchWfsMultiTypename({
         typenames: PARCELLAIRE_EXPRESS_TYPENAMES,
-        cqlFilter,
+        cqlFilters,
         errorLabel: 'PARCELLAIRE_EXPRESS',
     });
 

--- a/src/gpf/urbanisme.ts
+++ b/src/gpf/urbanisme.ts
@@ -65,23 +65,25 @@ function sanitizeUrbanismeItem(item: UrbanismeItem): Record<string, unknown> {
 export async function getUrbanisme(lon: number, lat: number): Promise<Record<string, unknown>[]> {
     logger.info(`getUrbanisme(${lon},${lat})...`);
 
-    // Resolve the geometry property name from the embedded catalog
-    const featureType = await getFeatureType(URBANISME_TYPES[0]);
-    const geometryProperty = getGeometryProperty(featureType);
-
-    // Compile the spatial filter using the engine
     const spatialFilter: SpatialFilter = {
         operator: "dwithin_point",
         lon,
         lat,
         distance_m: 30,
     };
-    const cqlFilter = compileDwithinSpatialFilter(geometryProperty, spatialFilter);
+
+    // Resolve and compile one spatial filter per typename to avoid relying on
+    // cross-layer geometry property homogeneity.
+    const cqlFilters = await Promise.all(URBANISME_TYPES.map(async (typename) => {
+        const featureType = await getFeatureType(typename);
+        const geometryProperty = getGeometryProperty(featureType);
+        return compileDwithinSpatialFilter(geometryProperty, spatialFilter);
+    }));
 
     // Execute the multi-typename WFS query
     const featureCollection: WfsFeatureCollectionResponse = await fetchWfsMultiTypename({
         typenames: URBANISME_TYPES,
-        cqlFilter,
+        cqlFilters,
         errorLabel: 'Urbanisme',
     });
 
@@ -115,23 +117,25 @@ const ASSIETTES_SUP_TYPES = [
 export async function getAssiettesServitudes(lon: number, lat: number): Promise<UrbanismeItem[]> {
     logger.info(`getAssiettesServitudes(${lon},${lat})...`);
 
-    // Resolve the geometry property name from the embedded catalog
-    const featureType = await getFeatureType(ASSIETTES_SUP_TYPES[0]);
-    const geometryProperty = getGeometryProperty(featureType);
-
-    // Compile the spatial filter using the engine
     const spatialFilter: SpatialFilter = {
         operator: "dwithin_point",
         lon,
         lat,
         distance_m: 30,
     };
-    const cqlFilter = compileDwithinSpatialFilter(geometryProperty, spatialFilter);
+
+    // Resolve and compile one spatial filter per typename to avoid relying on
+    // cross-layer geometry property homogeneity.
+    const cqlFilters = await Promise.all(ASSIETTES_SUP_TYPES.map(async (typename) => {
+        const featureType = await getFeatureType(typename);
+        const geometryProperty = getGeometryProperty(featureType);
+        return compileDwithinSpatialFilter(geometryProperty, spatialFilter);
+    }));
 
     // Execute the multi-typename WFS query
     const featureCollection: WfsFeatureCollectionResponse = await fetchWfsMultiTypename({
         typenames: ASSIETTES_SUP_TYPES,
-        cqlFilter,
+        cqlFilters,
         errorLabel: 'Urbanisme',
     });
 

--- a/src/helpers/wfs_engine/execution.ts
+++ b/src/helpers/wfs_engine/execution.ts
@@ -10,7 +10,7 @@
 import type { CompiledRequest } from "./request.js";
 import { buildMultiTypenameRequest } from "./request.js";
 import { wfsClient } from "../../gpf/wfs-schema-catalog.js";
-import { fetchJSONGet, fetchJSONPost } from "../http.js";
+import { fetchJSONPost } from "../http.js";
 
 // --- Response Types ---
 
@@ -88,8 +88,10 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
 export type MultiTypenameExecutionInput = {
   /** Fully qualified WFS type names to query. */
   typenames: string[];
-  /** Pre-compiled CQL filter string, when the request needs one. */
+  /** Pre-compiled CQL filter string, when one shared filter is intentionally reused for all typenames. */
   cqlFilter?: string;
+  /** Pre-compiled CQL filters aligned with `typenames` (same length, same order). */
+  cqlFilters?: string[];
   /** Service label used in error messages. */
   errorLabel: string;
 };
@@ -97,9 +99,9 @@ export type MultiTypenameExecutionInput = {
 /**
  * Executes a WFS GetFeature request targeting multiple typenames.
  *
- * Uses GET instead of POST because the GPF GeoServer rejects CQL filters
- * with geometry column references when multiple typenames are queried via POST
- * ("Extracted invalid join sub-filter ... it users more than one feature type").
+ * Uses the WFS 2.0.0 multi-typename format expected by GeoServer:
+ * - `typeNames=(type1)(type2)...`
+ * - `cql_filter=filter1;filter2;...` (one filter per typename, same order)
  *
  * This helper is used by domain-oriented modules (`src/gpf/*`) that
  * query several WFS layers at once with a pre-compiled CQL filter.
@@ -113,18 +115,14 @@ export async function fetchWfsMultiTypename(
   const request = buildMultiTypenameRequest({
     typenames: input.typenames,
     cqlFilter: input.cqlFilter,
+    cqlFilters: input.cqlFilters,
   });
 
-  const params = new URLSearchParams(request.query);
-  if (request.body) {
-    const bodyParams = new URLSearchParams(request.body);
-    for (const [key, value] of bodyParams.entries()) {
-      params.set(key, value);
-    }
-  }
-
-  const url = `${request.url}?${params.toString()}`;
-  const featureCollection = await fetchJSONGet(url) as WfsFeatureCollectionResponse;
+  const url = `${request.url}?${new URLSearchParams(request.query).toString()}`;
+  const featureCollection = await fetchJSONPost(url, request.body, {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Accept": "application/json",
+  }) as WfsFeatureCollectionResponse;
 
   if (!Array.isArray(featureCollection?.features)) {
     throw new Error(

--- a/src/helpers/wfs_engine/request.ts
+++ b/src/helpers/wfs_engine/request.ts
@@ -201,8 +201,10 @@ export function buildGetFeatureByIdRequest(
 export type MultiTypenameRequestInput = {
   /** Fully qualified WFS type names to query. */
   typenames: string[];
-  /** Pre-compiled CQL filter string, when the request needs one. */
+  /** Pre-compiled CQL filter string, when one shared filter is intentionally reused for all typenames. */
   cqlFilter?: string;
+  /** Pre-compiled CQL filters aligned with `typenames` (same length, same order). */
+  cqlFilters?: string[];
 };
 
 /**
@@ -218,17 +220,35 @@ export type MultiTypenameRequestInput = {
 export function buildMultiTypenameRequest(
   input: MultiTypenameRequestInput,
 ): CompiledRequest {
+  if (input.cqlFilter && input.cqlFilters) {
+    throw new Error("`cqlFilter` et `cqlFilters` ne peuvent pas être utilisés ensemble.");
+  }
+  if (input.cqlFilters && input.cqlFilters.length !== input.typenames.length) {
+    throw new Error(
+      `Le nombre de filtres CQL (${input.cqlFilters.length}) doit correspondre au nombre de typenames (${input.typenames.length}).`,
+    );
+  }
+
+  const encodedTypeNames = input.typenames.map((typename) => `(${typename})`).join("");
+
+  const expandedCqlFilter = input.cqlFilters
+    ? input.cqlFilters.join(";")
+    : input.cqlFilter
+      ? input.typenames.map(() => input.cqlFilter).join(";")
+      : undefined;
+
   const query: Record<string, string> = {
     service: "WFS",
     version: "2.0.0",
     request: "GetFeature",
-    typeNames: input.typenames.join(","),
+    typeNames: encodedTypeNames,
     outputFormat: "application/json",
     exceptions: "application/json",
+    srsName: "EPSG:4326",
   };
 
-  const body = input.cqlFilter
-    ? new URLSearchParams({ cql_filter: input.cqlFilter }).toString()
+  const body = expandedCqlFilter
+    ? new URLSearchParams({ cql_filter: expandedCqlFilter }).toString()
     : "";
 
   return {
@@ -236,6 +256,6 @@ export function buildMultiTypenameRequest(
     url: GPF_WFS_URL,
     query,
     body,
-    get_url: buildGetUrl(GPF_WFS_URL, query, input.cqlFilter),
+    get_url: buildGetUrl(GPF_WFS_URL, query, expandedCqlFilter),
   };
 }

--- a/test/gpf/adminexpress.test.ts
+++ b/test/gpf/adminexpress.test.ts
@@ -82,6 +82,15 @@ describe("Test getAdminUnits", () => {
         const c = mairieLoray.coordinates;
         const items: any[] = await getAdminUnits(c[0], c[1]);
 
+        expect(mockGetFeatureType).toHaveBeenCalledTimes(9);
+        expect(mockFetchWfsMultiTypename).toHaveBeenCalledWith(expect.objectContaining({
+            typenames: expect.any(Array),
+            cqlFilters: expect.any(Array),
+        }));
+        const fetchInput = mockFetchWfsMultiTypename.mock.calls[0]?.[0];
+        expect(fetchInput?.cqlFilters).toHaveLength(9);
+        expect(fetchInput?.cqlFilter).toBeUndefined();
+
         const itemsTypes = items.map((item) => item.type);
         expect(itemsTypes).toEqual([
             "commune",

--- a/test/gpf/parcellaire-express.test.ts
+++ b/test/gpf/parcellaire-express.test.ts
@@ -77,6 +77,15 @@ describe("Test getParcellaireExpress", () => {
         const c = mairieLoray.coordinates;
         const items: any[] = await getParcellaireExpress(c[0], c[1]);
 
+        expect(mockGetFeatureType).toHaveBeenCalledTimes(6);
+        expect(mockFetchWfsMultiTypename).toHaveBeenCalledWith(expect.objectContaining({
+            typenames: expect.any(Array),
+            cqlFilters: expect.any(Array),
+        }));
+        const fetchInput = mockFetchWfsMultiTypename.mock.calls[0]?.[0];
+        expect(fetchInput?.cqlFilters).toHaveLength(6);
+        expect(fetchInput?.cqlFilter).toBeUndefined();
+
         const itemsTypes = items.map((item) => item.type);
         expect(itemsTypes).toEqual([
             "commune",

--- a/test/gpf/urbanisme.test.ts
+++ b/test/gpf/urbanisme.test.ts
@@ -103,6 +103,15 @@ describe("Test getUrbanisme", () => {
         const c = chamonix.coordinates;
         const items: any[] = await getUrbanisme(c[0], c[1]);
 
+        expect(mockGetFeatureType).toHaveBeenCalledTimes(10);
+        expect(mockFetchWfsMultiTypename).toHaveBeenCalledWith(expect.objectContaining({
+            typenames: expect.any(Array),
+            cqlFilters: expect.any(Array),
+        }));
+        const fetchInput = mockFetchWfsMultiTypename.mock.calls[0]?.[0];
+        expect(fetchInput?.cqlFilters).toHaveLength(10);
+        expect(fetchInput?.cqlFilter).toBeUndefined();
+
         const itemsTypes = items.map((item) => item.type);
         expect(itemsTypes).toContain('document');
 
@@ -123,6 +132,10 @@ describe("Test getUrbanisme", () => {
     it("should filter non relevant urbanisme properties", async () => {
         const c = chamonix.coordinates;
         const items: any[] = await getUrbanisme(c[0], c[1]);
+
+        expect(mockGetFeatureType).toHaveBeenCalledTimes(10);
+        const fetchInput = mockFetchWfsMultiTypename.mock.calls[0]?.[0];
+        expect(fetchInput?.cqlFilters).toHaveLength(10);
 
         expect(items.length).toBeGreaterThan(0);
 
@@ -153,6 +166,11 @@ describe("Test getAssiettesServitudes", () => {
     it("should return the expected assiettes for Loray", async () => {
         const c = mairieLoray.coordinates;
         const items: any[] = await getAssiettesServitudes(c[0], c[1]);
+
+        expect(mockGetFeatureType).toHaveBeenCalledTimes(3);
+        const fetchInput = mockFetchWfsMultiTypename.mock.calls[0]?.[0];
+        expect(fetchInput?.cqlFilters).toHaveLength(3);
+        expect(fetchInput?.cqlFilter).toBeUndefined();
 
         const itemsTypes = items.map((item) => item.type);
         expect(itemsTypes).toContain('assiette_sup_s');

--- a/test/helpers/wfs_engine/execution.test.ts
+++ b/test/helpers/wfs_engine/execution.test.ts
@@ -1,6 +1,5 @@
 import { vi } from "vitest";
 
-const mockFetchJSONGet = vi.fn<(url: string) => Promise<unknown>>();
 const mockFetchJSONPost = vi.fn<(
   url: string,
   body?: string,
@@ -9,7 +8,6 @@ const mockFetchJSONPost = vi.fn<(
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<unknown>>();
 
 vi.doMock("../../../src/helpers/http.js", () => ({
-  fetchJSONGet: mockFetchJSONGet,
   fetchJSONPost: mockFetchJSONPost,
 }));
 
@@ -27,13 +25,12 @@ const {
 
 describe("wfs_engine/execution", () => {
   afterEach(() => {
-    mockFetchJSONGet.mockReset();
     mockFetchJSONPost.mockReset();
     mockGetFeatureType.mockReset();
   });
 
-  it("should execute multi-typename requests as GET and preserve cql_filter", async () => {
-    mockFetchJSONGet.mockResolvedValue({
+  it("should execute multi-typename requests as POST and preserve per-typename cql_filters", async () => {
+    mockFetchJSONPost.mockResolvedValue({
       type: "FeatureCollection",
       features: [],
     });
@@ -43,15 +40,20 @@ describe("wfs_engine/execution", () => {
         "ADMINEXPRESS-COG.LATEST:commune",
         "ADMINEXPRESS-COG.LATEST:departement",
       ],
-      cqlFilter: "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+      cqlFilters: [
+        "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+        "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85)) AND code_insee = '25'",
+      ],
       errorLabel: "ADMINEXPRESS",
     });
 
-    expect(mockFetchJSONGet).toHaveBeenCalledTimes(1);
-    const requestedUrl = mockFetchJSONGet.mock.calls[0]?.[0];
+    expect(mockFetchJSONPost).toHaveBeenCalledTimes(1);
+    const requestedUrl = mockFetchJSONPost.mock.calls[0]?.[0];
     if (!requestedUrl) {
       throw new Error("missing requested URL");
     }
+    const requestedBody = mockFetchJSONPost.mock.calls[0]?.[1];
+    const requestedHeaders = mockFetchJSONPost.mock.calls[0]?.[2];
 
     const parsedUrl = new URL(requestedUrl);
     expect(parsedUrl.origin + parsedUrl.pathname).toEqual("https://data.geopf.fr/wfs");
@@ -59,13 +61,21 @@ describe("wfs_engine/execution", () => {
     expect(parsedUrl.searchParams.get("version")).toEqual("2.0.0");
     expect(parsedUrl.searchParams.get("request")).toEqual("GetFeature");
     expect(parsedUrl.searchParams.get("typeNames")).toEqual(
-      "ADMINEXPRESS-COG.LATEST:commune,ADMINEXPRESS-COG.LATEST:departement",
+      "(ADMINEXPRESS-COG.LATEST:commune)(ADMINEXPRESS-COG.LATEST:departement)",
     );
+    expect(parsedUrl.searchParams.get("srsName")).toEqual("EPSG:4326");
     expect(parsedUrl.searchParams.get("outputFormat")).toEqual("application/json");
     expect(parsedUrl.searchParams.get("exceptions")).toEqual("application/json");
-    expect(parsedUrl.searchParams.get("cql_filter")).toEqual(
-      "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+    expect(parsedUrl.searchParams.get("cql_filter")).toBeNull();
+
+    const parsedBody = new URLSearchParams(requestedBody);
+    expect(parsedBody.get("cql_filter")).toEqual(
+      "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85));INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85)) AND code_insee = '25'",
     );
+    expect(requestedHeaders).toEqual({
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
+    });
 
     expect(response).toMatchObject({
       type: "FeatureCollection",
@@ -74,7 +84,7 @@ describe("wfs_engine/execution", () => {
   });
 
   it("should fail when multi-typename response has no features array", async () => {
-    mockFetchJSONGet.mockResolvedValue({
+    mockFetchJSONPost.mockResolvedValue({
       type: "FeatureCollection",
       totalFeatures: 12,
     });
@@ -86,6 +96,21 @@ describe("wfs_engine/execution", () => {
     })).rejects.toThrow(
       "Le service ADMINEXPRESS n'a pas retourné de collection d'objets exploitable",
     );
+  });
+
+  it("should reject cqlFilters length mismatch before executing HTTP", async () => {
+    await expect(fetchWfsMultiTypename({
+      typenames: [
+        "ADMINEXPRESS-COG.LATEST:commune",
+        "ADMINEXPRESS-COG.LATEST:departement",
+      ],
+      cqlFilters: [
+        "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+      ],
+      errorLabel: "ADMINEXPRESS",
+    })).rejects.toThrow("Le nombre de filtres CQL");
+
+    expect(mockFetchJSONPost).not.toHaveBeenCalled();
   });
 
   it("should extract matched count from numberMatched then fallback to totalFeatures", () => {
@@ -102,4 +127,3 @@ describe("wfs_engine/execution", () => {
     );
   });
 });
-

--- a/test/helpers/wfs_engine/request.test.ts
+++ b/test/helpers/wfs_engine/request.test.ts
@@ -17,20 +17,22 @@ describe("wfs_engine/request", () => {
         service: "WFS",
         version: "2.0.0",
         request: "GetFeature",
-        typeNames: "ADMINEXPRESS-COG.LATEST:commune,ADMINEXPRESS-COG.LATEST:departement",
+        typeNames: "(ADMINEXPRESS-COG.LATEST:commune)(ADMINEXPRESS-COG.LATEST:departement)",
         outputFormat: "application/json",
         exceptions: "application/json",
+        srsName: "EPSG:4326",
       },
     });
     expect(request.body).toContain("cql_filter=");
 
     const bodyParams = new URLSearchParams(request.body);
     expect(bodyParams.get("cql_filter")).toEqual(
-      "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+      "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85));INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
     );
 
-    expect(request.get_url).toContain("typeNames=ADMINEXPRESS-COG.LATEST%3Acommune%2CADMINEXPRESS-COG.LATEST%3Adepartement");
-    expect(request.get_url).toContain("cql_filter=INTERSECTS%28geometrie%2CSRID%3D4326%3BPOINT%282.35+48.85%29%29");
+    expect(request.get_url).toContain("typeNames=%28ADMINEXPRESS-COG.LATEST%3Acommune%29%28ADMINEXPRESS-COG.LATEST%3Adepartement%29");
+    expect(request.get_url).toContain("srsName=EPSG%3A4326");
+    expect(request.get_url).toContain("cql_filter=INTERSECTS%28geometrie%2CSRID%3D4326%3BPOINT%282.35+48.85%29%29%3BINTERSECTS%28geometrie%2CSRID%3D4326%3BPOINT%282.35+48.85%29%29");
   });
 
   it("should build a multi-typename request without body when cql_filter is absent", () => {
@@ -39,8 +41,46 @@ describe("wfs_engine/request", () => {
     });
 
     expect(request.body).toEqual("");
-    expect(request.get_url).toContain("typeNames=ADMINEXPRESS-COG.LATEST%3Aregion");
+    expect(request.get_url).toContain("typeNames=%28ADMINEXPRESS-COG.LATEST%3Aregion%29");
     expect(request.get_url).not.toContain("cql_filter=");
+  });
+
+  it("should build a multi-typename request with one explicit filter per typename", () => {
+    const request = buildMultiTypenameRequest({
+      typenames: [
+        "ADMINEXPRESS-COG.LATEST:commune",
+        "ADMINEXPRESS-COG.LATEST:departement",
+      ],
+      cqlFilters: [
+        "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+        "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85)) AND code_insee = '25'",
+      ],
+    });
+
+    const bodyParams = new URLSearchParams(request.body);
+    expect(bodyParams.get("cql_filter")).toEqual(
+      "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85));INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85)) AND code_insee = '25'",
+    );
+  });
+
+  it("should reject cqlFilters length mismatch", () => {
+    expect(() => buildMultiTypenameRequest({
+      typenames: [
+        "ADMINEXPRESS-COG.LATEST:commune",
+        "ADMINEXPRESS-COG.LATEST:departement",
+      ],
+      cqlFilters: [
+        "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+      ],
+    })).toThrow("Le nombre de filtres CQL");
+  });
+
+  it("should reject using cqlFilter and cqlFilters together", () => {
+    expect(() => buildMultiTypenameRequest({
+      typenames: ["ADMINEXPRESS-COG.LATEST:region"],
+      cqlFilter: "INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))",
+      cqlFilters: ["INTERSECTS(geometrie,SRID=4326;POINT(2.35 48.85))"],
+    })).toThrow("`cqlFilter` et `cqlFilters`");
   });
 
   it("should omit get_url when it exceeds the max length", () => {
@@ -52,4 +92,3 @@ describe("wfs_engine/request", () => {
     expect(request.get_url).toBeNull();
   });
 });
-


### PR DESCRIPTION
Closes #77 

This pull request updates how spatial queries are performed against multiple WFS typenames, ensuring that each typename receives its own correctly-compiled CQL filter. This avoids assumptions about geometry property homogeneity across layers and improves compatibility with GeoServer's multi-typename query format. The changes also update the request construction, switch to POST requests for these queries, and enhance related tests for correctness and robustness.

**WFS Multi-Typename Query Improvements:**

* Updated the query logic in `getAdminUnits`, `getParcellaireExpress`, `getUrbanisme`, and `getAssiettesServitudes` to generate and use one CQL filter per typename, rather than assuming a shared geometry property across all layers. 
* Modified the WFS execution and request helpers to support an array of CQL filters (`cqlFilters`), enforce correct array length, and throw errors if both `cqlFilter` and `cqlFilters` are provided or if the lengths mismatch.
* Changed the WFS multi-typename request format to use GeoServer's expected POST format, with typenames encoded as `(type1)(type2)...` and CQL filters joined by semicolons in the body.

**Testing and Robustness Enhancements:**

* Updated and expanded tests to verify that the correct number of filters are generated, that only `cqlFilters` is used, and that errors are thrown for mismatches. Also updated mocks to reflect the switch from GET to POST requests.

**Code Cleanup:**

* Removed unused imports and updated documentation/comments to reflect the new query and filter logic.

These changes make the codebase more robust, future-proof, and compatible with WFS servers that require per-layer filter specification.