### PR TITLE
feat(tests): add comprehensive tests for WFS response transformations and spatial filters

### DIFF
--- a/test/helpers/wfs_engine/geometry.test.ts
+++ b/test/helpers/wfs_engine/geometry.test.ts
@@ -1,0 +1,105 @@
+import { geometryToEwkt } from "../../../src/helpers/wfs_engine/geometry";
+
+describe("geometryToEwkt", () => {
+  // --- Point and MultiPoint (already partially covered via queryPreparation tests) ---
+
+  it("should serialize a Point", () => {
+    expect(geometryToEwkt({ type: "Point", coordinates: [2.3, 48.8] })).toEqual(
+      "SRID=4326;POINT(2.3 48.8)",
+    );
+  });
+
+  it("should serialize a MultiPoint", () => {
+    expect(geometryToEwkt({ type: "MultiPoint", coordinates: [[2.3, 48.8], [2.4, 48.9]] })).toEqual(
+      "SRID=4326;MULTIPOINT((2.3 48.8),(2.4 48.9))",
+    );
+  });
+
+  it("should serialize a LineString", () => {
+    expect(geometryToEwkt({ type: "LineString", coordinates: [[2.3, 48.8], [2.4, 48.9]] })).toEqual(
+      "SRID=4326;LINESTRING(2.3 48.8,2.4 48.9)",
+    );
+  });
+
+  // --- Previously uncovered types ---
+
+  it("should serialize a MultiLineString", () => {
+    const geometry = {
+      type: "MultiLineString",
+      coordinates: [
+        [[2.3, 48.8], [2.4, 48.9]],
+        [[3.0, 49.0], [3.1, 49.1]],
+      ],
+    };
+
+    expect(geometryToEwkt(geometry)).toEqual(
+      "SRID=4326;MULTILINESTRING((2.3 48.8,2.4 48.9),(3 49,3.1 49.1))",
+    );
+  });
+
+  it("should serialize a Polygon with a single ring", () => {
+    const geometry = {
+      type: "Polygon",
+      coordinates: [
+        [[2.0, 48.0], [2.2, 48.0], [2.2, 48.2], [2.0, 48.0]],
+      ],
+    };
+
+    expect(geometryToEwkt(geometry)).toEqual(
+      "SRID=4326;POLYGON((2 48,2.2 48,2.2 48.2,2 48))",
+    );
+  });
+
+  it("should serialize a Polygon with multiple rings (outer + hole)", () => {
+    const geometry = {
+      type: "Polygon",
+      coordinates: [
+        [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+        [[2, 2], [8, 2], [8, 8], [2, 8], [2, 2]],
+      ],
+    };
+
+    expect(geometryToEwkt(geometry)).toEqual(
+      "SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0),(2 2,8 2,8 8,2 8,2 2))",
+    );
+  });
+
+  it("should serialize a MultiPolygon with a single polygon", () => {
+    const geometry = {
+      type: "MultiPolygon",
+      coordinates: [
+        [[[2, 48], [2.2, 48], [2.2, 48.2], [2, 48]]],
+      ],
+    };
+
+    expect(geometryToEwkt(geometry)).toEqual(
+      "SRID=4326;MULTIPOLYGON(((2 48,2.2 48,2.2 48.2,2 48)))",
+    );
+  });
+
+  it("should serialize a MultiPolygon with multiple polygons", () => {
+    const geometry = {
+      type: "MultiPolygon",
+      coordinates: [
+        [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+        [[[5, 5], [6, 5], [6, 6], [5, 5]]],
+      ],
+    };
+
+    expect(geometryToEwkt(geometry)).toEqual(
+      "SRID=4326;MULTIPOLYGON(((0 0,1 0,1 1,0 0)),((5 5,6 5,6 6,5 5)))",
+    );
+  });
+
+  it("should throw for an unsupported geometry type", () => {
+    expect(() =>
+      geometryToEwkt({ type: "GeometryCollection", coordinates: [] }),
+    ).toThrow("Le type de géométrie 'GeometryCollection' n'est pas supporté pour `intersects_feature`.");
+  });
+
+  it("should throw for a completely unknown type", () => {
+    expect(() =>
+      geometryToEwkt({ type: "CustomType", coordinates: null }),
+    ).toThrow("Le type de géométrie 'CustomType' n'est pas supporté pour `intersects_feature`.");
+  });
+});

--- a/test/helpers/wfs_engine/response.test.ts
+++ b/test/helpers/wfs_engine/response.test.ts
@@ -1,9 +1,125 @@
 import {
   mapToFlatItems,
   mapToFlatItemsWithGeometry,
+  transformFeatureCollectionResponse,
+  attachFeatureRefs,
 } from "../../../src/helpers/wfs_engine/response";
 
 describe("wfs_engine/response", () => {
+  // --- transformFeatureCollectionResponse ---
+
+  describe("transformFeatureCollectionResponse", () => {
+    it("should pass through a FeatureCollection without a features array", () => {
+      const input = { type: "FeatureCollection", totalFeatures: 0 };
+      expect(transformFeatureCollectionResponse(input)).toEqual(input);
+    });
+
+    it("should remove geometry and geometry_name, set geometry to null, and add feature_ref", () => {
+      const result = transformFeatureCollectionResponse({
+        type: "FeatureCollection",
+        crs: { type: "name", properties: { name: "EPSG:4326" } },
+        features: [
+          {
+            id: "commune.1",
+            geometry: { type: "Point", coordinates: [2.35, 48.85] },
+            geometry_name: "geometrie",
+            properties: { code_insee: "94080" },
+          },
+        ],
+      });
+
+      expect(result).not.toHaveProperty("crs");
+      expect(result.features).toHaveLength(1);
+      expect(result.features[0]).toEqual({
+        id: "commune.1",
+        properties: { code_insee: "94080" },
+        geometry: null,
+        feature_ref: { typename: null, feature_id: "commune.1" },
+      });
+    });
+
+    it("should not add feature_ref when feature id is not a string", () => {
+      const result = transformFeatureCollectionResponse({
+        features: [
+          { id: 42, properties: { name: "test" } },
+        ],
+      });
+
+      expect(result.features[0]).not.toHaveProperty("feature_ref");
+      expect(result.features[0]).toEqual({
+        id: 42,
+        properties: { name: "test" },
+        geometry: null,
+      });
+    });
+  });
+
+  // --- attachFeatureRefs ---
+
+  describe("attachFeatureRefs", () => {
+    it("should pass through when transformed result has no features array", () => {
+      const input = { type: "FeatureCollection" };
+      const result = attachFeatureRefs(input, "TEST:type");
+      expect(result).toEqual({ type: "FeatureCollection" });
+    });
+
+    it("should inject typename into feature_ref for features with string id", () => {
+      const result = attachFeatureRefs(
+        {
+          features: [
+            { id: "commune.1", geometry: { type: "Point", coordinates: [2.35, 48.85] }, properties: { nom: "Test" } },
+          ],
+        },
+        "ADMINEXPRESS-COG.LATEST:commune",
+      );
+
+      expect(result.features[0].feature_ref).toEqual({
+        typename: "ADMINEXPRESS-COG.LATEST:commune",
+        feature_id: "commune.1",
+      });
+    });
+
+    it("should skip features without feature_ref (non-string id)", () => {
+      const result = attachFeatureRefs(
+        {
+          features: [
+            { id: 42, properties: { name: "no-string-id" } },
+          ],
+        },
+        "TEST:type",
+      );
+
+      expect(result.features[0]).not.toHaveProperty("feature_ref");
+    });
+
+    it("should inject typename into feature_ref for multiple features", () => {
+      const result = attachFeatureRefs(
+        {
+          features: [
+            { id: "commune.1", geometry: null, properties: { nom: "A" } },
+            { id: "commune.2", geometry: null, properties: { nom: "B" } },
+            { id: 42, properties: { nom: "C" } },
+          ],
+        },
+        "ADMINEXPRESS-COG.LATEST:commune",
+      );
+
+      expect(result.features).toHaveLength(3);
+      expect(result.features[0].feature_ref).toEqual({
+        typename: "ADMINEXPRESS-COG.LATEST:commune",
+        feature_id: "commune.1",
+      });
+      expect(result.features[1].feature_ref).toEqual({
+        typename: "ADMINEXPRESS-COG.LATEST:commune",
+        feature_id: "commune.2",
+      });
+      // Non-string id: no feature_ref injected
+      expect(result.features[2]).not.toHaveProperty("feature_ref");
+    });
+  });
+
+  // --- mapToFlatItems / mapToFlatItemsWithGeometry ---
+
   it("should map a FeatureCollection to flat items with resolved feature_ref", () => {
     const items = mapToFlatItems(
       {

--- a/test/helpers/wfs_engine/spatialCql.test.ts
+++ b/test/helpers/wfs_engine/spatialCql.test.ts
@@ -1,0 +1,164 @@
+import {
+  compileBboxSpatialFilter,
+  compileIntersectsPointSpatialFilter,
+  compileDwithinSpatialFilter,
+  compileIntersectsFeatureSpatialFilter,
+} from "../../../src/helpers/wfs_engine/spatialCql";
+
+import type { CollectionProperty } from "@ignfab/gpf-schema-store";
+import type { SpatialFilter } from "../../../src/helpers/wfs_engine/schema";
+
+// --- Shared fixtures ---
+
+const geometryProperty: CollectionProperty = {
+  name: "the_geom",
+  type: "multipolygon",
+  defaultCrs: "EPSG:4326",
+};
+
+// --- compileBboxSpatialFilter ---
+
+describe("compileBboxSpatialFilter", () => {
+  it("should compile a valid bbox filter to a CQL BBOX predicate", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: 2.1, south: 48.7, east: 2.5, north: 48.9 });
+
+    const result = compileBboxSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("BBOX(the_geom,2.1,48.7,2.5,48.9,'EPSG:4326')");
+  });
+
+  it("should reject west >= east", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: 3.0, south: 48.0, east: 2.0, north: 49.0 });
+
+    expect(() => compileBboxSpatialFilter(geometryProperty, filter)).toThrow(
+      "Le bbox est invalide : `bbox_west` doit être strictement inférieur à `bbox_east`."
+    );
+  });
+
+  it("should reject equal west and east", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: 2.5, south: 48.0, east: 2.5, north: 49.0 });
+
+    expect(() => compileBboxSpatialFilter(geometryProperty, filter)).toThrow(
+      "Le bbox est invalide : `bbox_west` doit être strictement inférieur à `bbox_east`."
+    );
+  });
+
+  it("should reject south >= north", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: 2.0, south: 49.0, east: 3.0, north: 48.0 });
+
+    expect(() => compileBboxSpatialFilter(geometryProperty, filter)).toThrow(
+      "Le bbox est invalide : `bbox_south` doit être strictement inférieur à `bbox_north`."
+    );
+  });
+
+  it("should reject equal south and north", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: 2.0, south: 48.5, east: 3.0, north: 48.5 });
+
+    expect(() => compileBboxSpatialFilter(geometryProperty, filter)).toThrow(
+      "Le bbox est invalide : `bbox_south` doit être strictement inférieur à `bbox_north`."
+    );
+  });
+
+  it("should handle negative coordinates", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: -5.0, south: -10.0, east: -1.0, north: -2.0 });
+
+    const result = compileBboxSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("BBOX(the_geom,-5,-10,-1,-2,'EPSG:4326')");
+  });
+
+  it("should handle coordinates crossing the equator", () => {
+    const filter = extractSpatialFilter({ operator: "bbox", west: 10.0, south: -5.0, east: 20.0, north: 5.0 });
+
+    const result = compileBboxSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("BBOX(the_geom,10,-5,20,5,'EPSG:4326')");
+  });
+});
+
+// --- compileIntersectsPointSpatialFilter ---
+
+describe("compileIntersectsPointSpatialFilter", () => {
+  it("should compile an intersects_point filter to a CQL INTERSECTS predicate", () => {
+    const filter = extractSpatialFilter({ operator: "intersects_point", lon: 2.3522, lat: 48.8566 });
+
+    const result = compileIntersectsPointSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("INTERSECTS(the_geom,SRID=4326;POINT(2.3522 48.8566))");
+  });
+
+  it("should handle negative coordinates", () => {
+    const filter = extractSpatialFilter({ operator: "intersects_point", lon: -73.9857, lat: 40.7484 });
+
+    const result = compileIntersectsPointSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("INTERSECTS(the_geom,SRID=4326;POINT(-73.9857 40.7484))");
+  });
+});
+
+// --- compileDwithinSpatialFilter ---
+
+describe("compileDwithinSpatialFilter", () => {
+  it("should compile a dwithin_point filter to a CQL DWITHIN predicate", () => {
+    const filter = extractSpatialFilter({ operator: "dwithin_point", lon: 2.3522, lat: 48.8566, distance_m: 500 });
+
+    const result = compileDwithinSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("DWITHIN(the_geom,SRID=4326;POINT(2.3522 48.8566),500,meters)");
+  });
+
+  it("should handle a large distance", () => {
+    const filter = extractSpatialFilter({ operator: "dwithin_point", lon: 0, lat: 0, distance_m: 50000 });
+
+    const result = compileDwithinSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("DWITHIN(the_geom,SRID=4326;POINT(0 0),50000,meters)");
+  });
+
+  it("should handle a small fractional distance", () => {
+    const filter = extractSpatialFilter({ operator: "dwithin_point", lon: 5.0, lat: 43.0, distance_m: 0.5 });
+
+    const result = compileDwithinSpatialFilter(geometryProperty, filter);
+
+    expect(result).toEqual("DWITHIN(the_geom,SRID=4326;POINT(5 43),0.5,meters)");
+  });
+});
+
+// --- compileIntersectsFeatureSpatialFilter ---
+
+describe("compileIntersectsFeatureSpatialFilter", () => {
+  it("should compile an intersects_feature filter with EWKT geometry", () => {
+    const ewkt = "SRID=4326;MULTIPOLYGON(((2 48,2.2 48,2.2 48.2,2 48)))";
+
+    const result = compileIntersectsFeatureSpatialFilter(geometryProperty, ewkt);
+
+    expect(result).toEqual("INTERSECTS(the_geom,SRID=4326;MULTIPOLYGON(((2 48,2.2 48,2.2 48.2,2 48))))");
+  });
+
+  it("should compile with a POINT EWKT", () => {
+    const ewkt = "SRID=4326;POINT(2.3522 48.8566)";
+
+    const result = compileIntersectsFeatureSpatialFilter(geometryProperty, ewkt);
+
+    expect(result).toEqual("INTERSECTS(the_geom,SRID=4326;POINT(2.3522 48.8566))");
+  });
+});
+
+// --- Helpers ---
+
+const VALID_OPERATORS: readonly string[] = ["bbox", "intersects_point", "dwithin_point", "intersects_feature"];
+
+/**
+ * Type-safe helper to build a specific spatial filter variant with a runtime guard.
+ *
+ * Validates the operator at runtime so a mistyped fixture fails fast instead of
+ * silently passing due to a bare cast.
+ */
+function extractSpatialFilter<T extends SpatialFilter["operator"]>(
+  input: SpatialFilter & { operator: T },
+): Extract<SpatialFilter, { operator: T }> {
+  if (!VALID_OPERATORS.includes(input.operator)) {
+    throw new Error(`Test fixture error: unexpected operator '${String(input.operator)}'`);
+  }
+  return input as Extract<SpatialFilter, { operator: T }>;
+}

--- a/test/helpers/wfs_engine/spatialFilter.test.ts
+++ b/test/helpers/wfs_engine/spatialFilter.test.ts
@@ -1,0 +1,373 @@
+import { getSpatialFilter } from "../../../src/helpers/wfs_engine/spatialFilter";
+import type { GpfWfsGetFeaturesInput } from "../../../src/helpers/wfs_engine/schema";
+
+// --- Shared fixtures ---
+
+const baseInput: GpfWfsGetFeaturesInput = {
+  typename: "ADMINEXPRESS-COG.LATEST:commune",
+  limit: 100,
+  result_type: "results",
+};
+
+// --- getSpatialFilter: no operator ---
+
+describe("getSpatialFilter — no operator", () => {
+  it("should return undefined when no spatial_operator and no spatial params", () => {
+    expect(getSpatialFilter(baseInput)).toBeUndefined();
+  });
+
+  it("should throw when stray bbox params are present without spatial_operator", () => {
+    expect(() =>
+      getSpatialFilter({ ...baseInput, bbox_west: 2.0 }),
+    ).toThrow("paramètres spatiaux exigent `spatial_operator`");
+  });
+
+  it("should throw when stray intersects_point params are present without spatial_operator", () => {
+    expect(() =>
+      getSpatialFilter({ ...baseInput, intersects_lon: 2.3 }),
+    ).toThrow("paramètres spatiaux exigent `spatial_operator`");
+  });
+
+  it("should throw when stray dwithin params are present without spatial_operator", () => {
+    expect(() =>
+      getSpatialFilter({ ...baseInput, dwithin_lon: 2.3 }),
+    ).toThrow("paramètres spatiaux exigent `spatial_operator`");
+  });
+
+  it("should throw when stray intersects_feature params are present without spatial_operator", () => {
+    expect(() =>
+      getSpatialFilter({ ...baseInput, intersects_feature_typename: "TEST:type" }),
+    ).toThrow("paramètres spatiaux exigent `spatial_operator`");
+  });
+});
+
+// --- getSpatialFilter: bbox ---
+
+describe("getSpatialFilter — bbox", () => {
+  it("should return a bbox filter when all bbox params are provided", () => {
+    const result = getSpatialFilter({
+      ...baseInput,
+      spatial_operator: "bbox",
+      bbox_west: 2.1,
+      bbox_south: 48.7,
+      bbox_east: 2.5,
+      bbox_north: 48.9,
+    });
+
+    expect(result).toEqual({
+      operator: "bbox",
+      west: 2.1,
+      south: 48.7,
+      east: 2.5,
+      north: 48.9,
+    });
+  });
+
+  it("should throw when bbox params are incomplete (missing north)", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "bbox",
+        bbox_west: 2.1,
+        bbox_south: 48.7,
+        bbox_east: 2.5,
+      }),
+    ).toThrow("Le filtre spatial `bbox` exige `bbox_west`, `bbox_south`, `bbox_east` et `bbox_north`");
+  });
+
+  it("should throw when bbox operator is used with intersects_point params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "bbox",
+        bbox_west: 2.1,
+        bbox_south: 48.7,
+        bbox_east: 2.5,
+        bbox_north: 48.9,
+        intersects_lon: 2.3,
+      }),
+    ).toThrow("Le filtre spatial `bbox` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when bbox operator is used with dwithin params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "bbox",
+        bbox_west: 2.1,
+        bbox_south: 48.7,
+        bbox_east: 2.5,
+        bbox_north: 48.9,
+        dwithin_distance_m: 100,
+      }),
+    ).toThrow("Le filtre spatial `bbox` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when bbox operator is used with intersects_feature params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "bbox",
+        bbox_west: 2.1,
+        bbox_south: 48.7,
+        bbox_east: 2.5,
+        bbox_north: 48.9,
+        intersects_feature_typename: "TEST:type",
+      }),
+    ).toThrow("Le filtre spatial `bbox` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+});
+
+// --- getSpatialFilter: intersects_point ---
+
+describe("getSpatialFilter — intersects_point", () => {
+  it("should return an intersects_point filter when lon/lat are provided", () => {
+    const result = getSpatialFilter({
+      ...baseInput,
+      spatial_operator: "intersects_point",
+      intersects_lon: 2.3522,
+      intersects_lat: 48.8566,
+    });
+
+    expect(result).toEqual({
+      operator: "intersects_point",
+      lon: 2.3522,
+      lat: 48.8566,
+    });
+  });
+
+  it("should throw when intersects_lon is missing", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_point",
+        intersects_lat: 48.8566,
+      }),
+    ).toThrow("Le filtre spatial `intersects_point` exige `intersects_lon` et `intersects_lat`");
+  });
+
+  it("should throw when intersects_lat is missing", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_point",
+        intersects_lon: 2.3522,
+      }),
+    ).toThrow("Le filtre spatial `intersects_point` exige `intersects_lon` et `intersects_lat`");
+  });
+
+  it("should throw when intersects_point operator is used with bbox params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_point",
+        intersects_lon: 2.3522,
+        intersects_lat: 48.8566,
+        bbox_west: 2.0,
+      }),
+    ).toThrow("Le filtre spatial `intersects_point` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when intersects_point operator is used with dwithin params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_point",
+        intersects_lon: 2.3522,
+        intersects_lat: 48.8566,
+        dwithin_distance_m: 100,
+      }),
+    ).toThrow("Le filtre spatial `intersects_point` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when intersects_point operator is used with intersects_feature params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_point",
+        intersects_lon: 2.3522,
+        intersects_lat: 48.8566,
+        intersects_feature_id: "feature.1",
+      }),
+    ).toThrow("Le filtre spatial `intersects_point` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+});
+
+// --- getSpatialFilter: dwithin_point ---
+
+describe("getSpatialFilter — dwithin_point", () => {
+  it("should return a dwithin_point filter when lon/lat/distance are provided", () => {
+    const result = getSpatialFilter({
+      ...baseInput,
+      spatial_operator: "dwithin_point",
+      dwithin_lon: 2.3522,
+      dwithin_lat: 48.8566,
+      dwithin_distance_m: 500,
+    });
+
+    expect(result).toEqual({
+      operator: "dwithin_point",
+      lon: 2.3522,
+      lat: 48.8566,
+      distance_m: 500,
+    });
+  });
+
+  it("should throw when dwithin_distance_m is missing", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "dwithin_point",
+        dwithin_lon: 2.3522,
+        dwithin_lat: 48.8566,
+      }),
+    ).toThrow("Le filtre spatial `dwithin_point` exige `dwithin_lon`, `dwithin_lat` et `dwithin_distance_m`");
+  });
+
+  it("should throw when dwithin_lon is missing", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "dwithin_point",
+        dwithin_lat: 48.8566,
+        dwithin_distance_m: 500,
+      }),
+    ).toThrow("Le filtre spatial `dwithin_point` exige `dwithin_lon`, `dwithin_lat` et `dwithin_distance_m`");
+  });
+
+  it("should throw when dwithin_point operator is used with bbox params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "dwithin_point",
+        dwithin_lon: 2.3522,
+        dwithin_lat: 48.8566,
+        dwithin_distance_m: 500,
+        bbox_north: 49.0,
+      }),
+    ).toThrow("Le filtre spatial `dwithin_point` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when dwithin_point operator is used with intersects_point params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "dwithin_point",
+        dwithin_lon: 2.3522,
+        dwithin_lat: 48.8566,
+        dwithin_distance_m: 500,
+        intersects_lat: 48.0,
+      }),
+    ).toThrow("Le filtre spatial `dwithin_point` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when dwithin_point operator is used with intersects_feature params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "dwithin_point",
+        dwithin_lon: 2.3522,
+        dwithin_lat: 48.8566,
+        dwithin_distance_m: 500,
+        intersects_feature_typename: "TEST:type",
+      }),
+    ).toThrow("Le filtre spatial `dwithin_point` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+});
+
+// --- getSpatialFilter: intersects_feature ---
+
+describe("getSpatialFilter — intersects_feature", () => {
+  it("should return an intersects_feature filter when typename and feature_id are provided", () => {
+    const result = getSpatialFilter({
+      ...baseInput,
+      spatial_operator: "intersects_feature",
+      intersects_feature_typename: "ADMINEXPRESS-COG.LATEST:commune",
+      intersects_feature_id: "commune.8952",
+    });
+
+    expect(result).toEqual({
+      operator: "intersects_feature",
+      typename: "ADMINEXPRESS-COG.LATEST:commune",
+      feature_id: "commune.8952",
+    });
+  });
+
+  it("should throw when intersects_feature_typename is missing", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_id: "commune.8952",
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` exige `intersects_feature_typename` et `intersects_feature_id`");
+  });
+
+  it("should throw when intersects_feature_typename is an empty string", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_typename: "",
+        intersects_feature_id: "commune.8952",
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` exige `intersects_feature_typename` et `intersects_feature_id`");
+  });
+
+  it("should throw when intersects_feature_id is missing", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_typename: "ADMINEXPRESS-COG.LATEST:commune",
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` exige `intersects_feature_typename` et `intersects_feature_id`");
+  });
+
+  it("should throw when intersects_feature_id is an empty string", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_typename: "ADMINEXPRESS-COG.LATEST:commune",
+        intersects_feature_id: "",
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` exige `intersects_feature_typename` et `intersects_feature_id`");
+  });
+
+  it("should throw when intersects_feature operator is used with bbox params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_typename: "TEST:type",
+        intersects_feature_id: "feature.1",
+        bbox_south: 48.0,
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when intersects_feature operator is used with intersects_point params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_typename: "TEST:type",
+        intersects_feature_id: "feature.1",
+        intersects_lon: 2.3,
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+
+  it("should throw when intersects_feature operator is used with dwithin params", () => {
+    expect(() =>
+      getSpatialFilter({
+        ...baseInput,
+        spatial_operator: "intersects_feature",
+        intersects_feature_typename: "TEST:type",
+        intersects_feature_id: "feature.1",
+        dwithin_lon: 2.3,
+      }),
+    ).toThrow("Le filtre spatial `intersects_feature` n'accepte pas les paramètres d'un autre mode spatial");
+  });
+});


### PR DESCRIPTION
closes #80

## PR: Add unit tests for WFS engine spatial and response modules

### What

Adds 61 new tests covering previously untested branches in four WFS engine modules. Test count goes from 137 to 198. Overall branch coverage rises from 78% to 82%.

### Coverage impact

| File | Before | After |
|------|--------|-------|
| `spatialCql.ts` | 78% / 67% | **100% / 100%** |
| `spatialFilter.ts` | 81% / 68% | **100% / 100%** |
| `geometry.ts` | 83% / 60% | **100% / 100%** |
| `response.ts` | 91% / 81% | **97.7% / 93.75%** |

### Files changed

- **New** `test/helpers/wfs_engine/spatialCql.test.ts` — 14 tests: CQL compilation for all spatial operators, bbox validation (west≥east, south≥north), negative/equator coords, EWKT geometry
- **New** `test/helpers/wfs_engine/spatialFilter.test.ts` — 30 tests: all operator modes, stray params, missing params, cross-mode contamination, empty strings for `intersects_feature_*`
- **New** `test/helpers/wfs_engine/geometry.test.ts` — 10 tests: all GeoJSON types (MultiLineString, Polygon, MultiPolygon), unsupported type error
- **Modified** `test/helpers/wfs_engine/response.test.ts` — +7 tests: `transformFeatureCollectionResponse` (pass-through, geometry removal, crs stripping, non-string id), `attachFeatureRefs` (no features, mixed ids, typename injection)

### Design choices

- Test fixtures for spatial CQL use a runtime-validated helper (`extractSpatialFilter`) that checks operators against a whitelist, so a mistyped fixture fails fast instead of silently passing via a bare cast.
- Empty string edge cases for `intersects_feature_typename` and `intersects_feature_id` are tested explicitly even though the code already rejects them via falsy checks.
- Defensive branches in `attachFeatureRefs` (non-object `feature_ref`) are unreachable through the public API and left untested by design.
