### PR TITLE
feat(integration): add comprehensive tests for MCP server tools and agent functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.vscode/
 .npmrc
 .codex
+.env.e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,15 @@
         "geocontext": "dist/index.js"
       },
       "devDependencies": {
+        "@langchain/anthropic": "^1.3.28",
+        "@langchain/core": "^1.1.42",
+        "@langchain/langgraph": "^1.2.9",
+        "@langchain/mcp-adapters": "^1.1.3",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/geojson": "^7946.0.16",
         "@types/node": "^24.10.1",
         "@vitest/coverage-v8": "^3.2.4",
+        "langchain": "^1.3.5",
         "supertest": "^7.1.4",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -47,6 +53,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -83,6 +110,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -130,6 +167,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -610,7 +654,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -712,12 +755,210 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@langchain/anthropic": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.28.tgz",
+      "integrity": "sha512-gOF8oXJL8xDdYes2KXNI9vFm/9TldBBBHOjuCdt27kganVaQKzLvTw5kV6R4mjbnFagV5CWteNH7APLZYCpdwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.42"
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.42.tgz",
+      "integrity": "sha512-d0tN96BrwPMryYyWR9VfyAntSivn7EQrZCe5Kpxum93tcjTXbKKmKvItFec8AluQt88iTcmAJrahUZUNfzGwTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
+      "integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph-sdk": "~1.8.9",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.40",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
+      "integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/mcp-adapters": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.3.tgz",
+      "integrity": "sha512-OPHIQNkTUJjnRj1pr+cp2nguMBZeF3Q1pVT1hCbgU7BrHgV7lov99wbU8po8Cm4zZzmeRtVO/T9X1SrDD1ogtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "debug": "^4.4.3",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20.10.0"
+      },
+      "optionalDependencies": {
+        "extended-eventsource": "^1.7.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0",
+        "@langchain/langgraph": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": false
+        },
+        "@langchain/langgraph": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1213,6 +1454,13 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@turf/distance": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
@@ -1284,6 +1532,13 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -1481,7 +1736,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1504,7 +1758,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1521,7 +1774,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1548,13 +1800,13 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1618,12 +1870,32 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -1708,6 +1980,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
@@ -1820,7 +2105,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1843,7 +2127,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1869,7 +2152,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1920,6 +2202,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-eql": {
@@ -2008,8 +2300,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2029,7 +2320,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2133,8 +2423,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -2151,17 +2440,22 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -2174,7 +2468,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
       "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2220,7 +2513,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2264,7 +2556,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
       "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -2278,12 +2569,19 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extended-eventsource": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extended-eventsource/-/extended-eventsource-1.7.0.tgz",
+      "integrity": "sha512-s8rtvZuYcKBpzytHb5g95cHbZ1J99WeMnV18oKc5wKoxkHzlzpPc/bNAm7Da2Db0BDw0CAu1z3LpH+7UsyzIpw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -2306,8 +2604,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastpriorityqueue": {
       "version": "0.7.5",
@@ -2382,7 +2679,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -2514,7 +2810,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2524,7 +2819,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2728,7 +3022,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2787,7 +3080,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2810,7 +3102,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2820,7 +3111,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -2833,6 +3123,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2851,8 +3154,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -2955,13 +3257,22 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/js-tokens": {
@@ -2983,19 +3294,31 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -3091,6 +3414,59 @@
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
+    },
+    "node_modules/langchain": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.5.tgz",
+      "integrity": "sha512-QSB8TEo6G1tWupgNt1Osm8ylLLoOMq1lLw5NeijnIwRPI5BqdBjUn4/U8usbjEJJcQnbXSK2qTKgTx7zvblnBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph": "^1.2.9",
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.42"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
+      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
     },
     "node_modules/limiter": {
       "version": "1.1.5",
@@ -3343,7 +3719,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3353,7 +3728,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3389,7 +3763,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3399,7 +3772,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3449,6 +3821,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3473,7 +3855,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3561,7 +3942,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3583,7 +3963,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -3607,6 +3986,16 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -3639,6 +4028,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3663,7 +4098,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3715,7 +4149,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -3763,7 +4196,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -3830,7 +4262,6 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -3859,7 +4290,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3869,7 +4299,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -3899,7 +4328,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3954,7 +4382,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -4018,7 +4445,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -4045,7 +4471,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -4520,6 +4945,13 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4531,7 +4963,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -4596,12 +5027,25 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4984,6 +5428,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5034,7 +5491,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "coverage": "vitest run --coverage",
+    "test:integration": "npm run build && vitest run --config vitest.integration.config.mts",
+    "test:e2e": "vitest run --config vitest.e2e.config.mts",
+    "test:coverage": "vitest run --coverage",
     "reset": "rm -rf node_modules package-lock.json dist build .next .turbo coverage",
     "fresh": "npm run reset && npm cache verify && npm install && npm run build && npm test"
   },
@@ -51,9 +53,15 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@langchain/anthropic": "^1.3.28",
+    "@langchain/core": "^1.1.42",
+    "@langchain/langgraph": "^1.2.9",
+    "@langchain/mcp-adapters": "^1.1.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/geojson": "^7946.0.16",
     "@types/node": "^24.10.1",
     "@vitest/coverage-v8": "^3.2.4",
+    "langchain": "^1.3.5",
     "supertest": "^7.1.4",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/test/integration/config/level2-agent.ts
+++ b/test/integration/config/level2-agent.ts
@@ -1,0 +1,95 @@
+/**
+ * Configuration for Level 2 (Agent E2E) integration tests.
+ *
+ * Equivalent of the Python config.py from geocontext-test.
+ *
+ * Environment variables:
+ * - MODEL_NAME: model identifier (default: "anthropic:claude-haiku-4-5")
+ * - Provider key depending on MODEL_NAME prefix (ex: ANTHROPIC_API_KEY, GOOGLE_API_KEY, OPENAI_API_KEY)
+ * - HTTPS_PROXY / HTTP_PROXY: proxy used for model provider calls
+ */
+
+import { initChatModel } from "langchain";
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { INTEGRATION_CONFIG, MILLISECONDS, PROXY_ENV_KEYS } from "./shared.js";
+import { setGlobalDispatcher, ProxyAgent } from "undici";
+
+let proxyConfigured = false;
+
+/** Model name for the LLM */
+export const MODEL_NAME = process.env.MODEL_NAME ?? "anthropic:claude-haiku-4-5";
+
+function requiredApiKeyEnvFromModelName(modelName: string): string | undefined {
+  const [provider] = modelName.split(":", 1);
+
+  if (provider === "anthropic") return "ANTHROPIC_API_KEY";
+  if (provider === "google_genai" || provider === "google") return "GOOGLE_API_KEY";
+  if (provider === "openai") return "OPENAI_API_KEY";
+  if (provider === "mistralai" || provider === "mistral") return "MISTRAL_API_KEY";
+
+  return undefined;
+}
+
+function configureModelProxy() {
+  if (proxyConfigured) {
+    return;
+  }
+
+  const proxyUrl = PROXY_ENV_KEYS
+    .map((key) => process.env[key])
+    .find((value) => Boolean(value));
+
+  if (proxyUrl) {
+    setGlobalDispatcher(new ProxyAgent(proxyUrl));
+  }
+
+  proxyConfigured = true;
+}
+
+/** System prompt for the agent */
+export const SYSTEM_PROMPT =
+  "You are a helpful assistant for geospatial data. You can use the tools to answer questions about geospatial data.";
+
+/** Timeout for agent E2E tests (2 minutes) */
+export const E2E_TIMEOUT = 120 * MILLISECONDS;
+
+/** Timeout for server connection */
+export const CONNECT_TIMEOUT = 30 * MILLISECONDS;
+
+export const MODEL_PROVIDER_API_KEY_ENV = requiredApiKeyEnvFromModelName(MODEL_NAME);
+export const HAS_MODEL_PROVIDER_API_KEY = MODEL_PROVIDER_API_KEY_ENV
+  ? Boolean(process.env[MODEL_PROVIDER_API_KEY_ENV])
+  : true;
+
+/**
+ * Create a provider-agnostic LangChain chat model instance.
+ */
+export async function createModel() {
+  if (!HAS_MODEL_PROVIDER_API_KEY) {
+    throw new Error(
+      `${MODEL_PROVIDER_API_KEY_ENV} is required to run level2-agent integration tests with MODEL_NAME=\"${MODEL_NAME}\".`,
+    );
+  }
+
+  configureModelProxy();
+
+  return initChatModel(MODEL_NAME, {
+    temperature: 0,
+  });
+}
+
+/**
+ * Create a MultiServerMCPClient connected to the geocontext server via stdio.
+ *
+ * Uses the local built geocontext server entrypoint.
+ */
+export function createMcpClient(): MultiServerMCPClient {
+  return new MultiServerMCPClient({
+    geocontext: {
+      transport: "stdio",
+      command: INTEGRATION_CONFIG.serverCommand,
+      args: [...INTEGRATION_CONFIG.serverArgs],
+      env: INTEGRATION_CONFIG.serverEnv(),
+    },
+  });
+}

--- a/test/integration/config/shared.ts
+++ b/test/integration/config/shared.ts
@@ -1,0 +1,51 @@
+/**
+ * Configuration for integration tests.
+ *
+ * Environment variables:
+ * - GEOCONTEXT_SERVER_PATH: path to the built server entry point (default: "dist/index.js")
+ * - HTTP_PROXY / HTTPS_PROXY / NO_PROXY: proxy settings forwarded to the server
+ * - GEOCONTEXT_LOG_LEVEL: log level for the server (default: "error")
+ */
+
+import { resolve } from "node:path";
+
+export const MILLISECONDS = 1000;
+export const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+] as const;
+export const NO_PROXY_ENV_KEYS = [
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+
+export const INTEGRATION_CONFIG = {
+
+  /** Timeout for each test involving real API calls (60 s) */
+  timeout: 60 * MILLISECONDS,
+
+  /** Timeout for the server startup / connection (30 s) */
+  connectTimeout: 30 * MILLISECONDS,
+
+  /** Command used to start the geocontext MCP server */
+  serverCommand: process.execPath,
+  serverArgs: [resolve(process.cwd(), process.env.GEOCONTEXT_SERVER_PATH ?? "dist/index.js")],
+
+  /** Environment variables forwarded to the server child process */
+  // TODO: we might want to add some more variables here in the future 
+  // (e.g. for minisearch weights for example)
+  serverEnv(): Record<string, string> {
+    const env: Record<string, string> = {
+      LOG_LEVEL: process.env.GEOCONTEXT_LOG_LEVEL ?? "error",
+    };
+    for (const key of [...PROXY_ENV_KEYS, ...NO_PROXY_ENV_KEYS]) {
+      const value = process.env[key];
+      if (value) {
+        env[key] = value;
+      }
+    }
+    return env;
+  },
+} as const;

--- a/test/integration/helpers/level1-assertions.ts
+++ b/test/integration/helpers/level1-assertions.ts
@@ -1,0 +1,51 @@
+import { expect } from "vitest";
+
+interface ResultsContainer<T> {
+  results?: readonly T[];
+}
+
+interface FeatureCollectionLike<TFeature> {
+  type?: unknown;
+  features?: readonly TFeature[];
+}
+
+/**
+ * Asserts that a tool result contains a non-empty `results` array.
+ *
+ * @param value Tool result containing a `results` field.
+ * @param minimum Minimum number of expected entries.
+ * @returns Nothing.
+ */
+export function expectNonEmptyResults<T>(
+  value: ResultsContainer<T>,
+  minimum = 1,
+): asserts value is { results: T[] } {
+  expect(value.results).toBeDefined();
+  expect(value.results.length).toBeGreaterThanOrEqual(minimum);
+}
+
+/**
+ * Asserts that a value is a `FeatureCollection` with a non-empty `features` array.
+ *
+ * @param value Candidate feature collection.
+ * @param minimum Minimum number of expected features.
+ * @returns Nothing.
+ */
+export function expectFeatureCollectionWithFeatures<TFeature>(
+  value: FeatureCollectionLike<TFeature>,
+  minimum = 1,
+): asserts value is { type: "FeatureCollection"; features: TFeature[] } {
+  expect(value.type).toBe("FeatureCollection");
+  expect(value.features).toBeDefined();
+  expect(value.features.length).toBeGreaterThanOrEqual(minimum);
+}
+
+/**
+ * Asserts that a tool call promise fails with an error.
+ *
+ * @param toolCallPromise Promise returned by a tool call.
+ * @returns Promise resolved when the failure assertion completes.
+ */
+export async function expectToolCallToThrow(toolCallPromise: Promise<unknown>): Promise<void> {
+  await expect(toolCallPromise).rejects.toThrow();
+}

--- a/test/integration/helpers/level1-fixtures.ts
+++ b/test/integration/helpers/level1-fixtures.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll } from "vitest";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+import { connectToServer } from "./mcp-client.js";
+import type { McpServerHandle } from "./mcp-client.js";
+
+/**
+ * Options used to configure the shared MCP server fixture for level1 tests.
+ */
+export interface McpServerFixtureOptions {
+  /**
+   * Optional setup callback executed after the MCP server is connected.
+   * It can prepare additional shared test state.
+   */
+  setup?: (handle: McpServerHandle) => Promise<void> | void;
+  /**
+   * Timeout used for the `beforeAll` setup phase.
+   */
+  connectTimeout?: number;
+}
+
+/**
+ * Registers a shared MCP server lifecycle for a test suite and returns a typed
+ * accessor to the connected server handle.
+ *
+ * @param options Optional fixture configuration.
+ * @returns Accessor for the connected MCP server handle.
+ */
+export function withMcpServer(options: McpServerFixtureOptions = {}) {
+  let handle: McpServerHandle | undefined;
+
+  beforeAll(async () => {
+    handle = await connectToServer();
+    await options.setup?.(handle);
+  }, options.connectTimeout ?? INTEGRATION_CONFIG.connectTimeout);
+
+  afterAll(async () => {
+    await handle?.cleanup();
+  });
+
+  return {
+    /**
+     * Returns the connected MCP server handle.
+     *
+     * @returns Connected MCP server handle.
+     * @throws {Error} When the fixture is accessed before setup.
+     */
+    getHandle(): McpServerHandle {
+      if (!handle) {
+        throw new Error("MCP server fixture is not initialized yet.");
+      }
+
+      return handle;
+    },
+  };
+}

--- a/test/integration/helpers/level2-agent.ts
+++ b/test/integration/helpers/level2-agent.ts
@@ -1,0 +1,50 @@
+import { createAgent } from "langchain";
+import { HumanMessage } from "@langchain/core/messages";
+import type { Callbacks } from "@langchain/core/callbacks/manager";
+import { createModel } from "../config/level2-agent.js";
+
+type AgentTools = Parameters<typeof createAgent>[0]["tools"];
+type AgentInstance = ReturnType<typeof createAgent>;
+type AgentInvokeResult = Awaited<ReturnType<AgentInstance["invoke"]>>;
+
+/**
+ * Defines options for invoking a LangChain agent in integration E2E tests.
+ */
+export interface InvokeAgentOptions {
+  /** End-user question sent as a single human message. */
+  userInput: string;
+  /** Toolset exposed to the agent for this test scenario. */
+  tools: AgentTools;
+  /** Optional system prompt to steer behavior. */
+  systemPrompt?: string;
+  /** Optional callback handlers (for example tool call tracking). */
+  callbacks?: Callbacks;
+}
+
+/**
+ * Builds a model-backed agent and invokes it with one user message.
+ *
+ * This helper centralizes the repeated `createModel` + `createAgent` + `invoke`
+ * sequence used by level2-agent tests.
+ *
+ * @param options Invocation options (user input, tools, optional prompt/callbacks).
+ * @returns Agent invoke result containing the conversation messages.
+ */
+export async function invokeAgent(options: InvokeAgentOptions): Promise<AgentInvokeResult> {
+  const model = await createModel();
+  const agent = createAgent({
+    model,
+    tools: options.tools,
+    systemPrompt: options.systemPrompt,
+  });
+
+  const input = {
+    messages: [new HumanMessage(options.userInput)],
+  };
+
+  if (options.callbacks) {
+    return agent.invoke(input, { callbacks: options.callbacks });
+  }
+
+  return agent.invoke(input);
+}

--- a/test/integration/helpers/level2-assertions.ts
+++ b/test/integration/helpers/level2-assertions.ts
@@ -1,0 +1,133 @@
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import type { Serialized } from "@langchain/core/load/serializable";
+import { expect } from "vitest";
+
+interface SerializedToolCandidate {
+  name?: unknown;
+  id?: unknown;
+}
+
+/**
+ * Extracts a human-readable tool name from LangChain serialized metadata.
+ *
+ * LangChain callbacks may expose either `name` directly, or only an `id` array
+ * where the last item corresponds to the runnable/tool name.
+ *
+ * @param tool Serialized LangChain runnable metadata.
+ * @returns Extracted tool name, or `undefined` when not found.
+ */
+export function extractToolName(tool: Serialized): string | undefined {
+  const candidate = tool as unknown as SerializedToolCandidate;
+
+  if (typeof candidate.name === "string" && candidate.name.length > 0) {
+    return candidate.name;
+  }
+
+  if (Array.isArray(candidate.id) && candidate.id.length > 0) {
+    const last = candidate.id[candidate.id.length - 1];
+    if (typeof last === "string" && last.length > 0) {
+      return last;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Normalizes text for resilient assertions by replacing non-breaking spaces,
+ * lowercasing content, and removing diacritics.
+ *
+ * @param text Raw text to normalize.
+ * @returns Normalized text suitable for robust `contains` assertions.
+ */
+export function normalizeText(text: string): string {
+  return text
+    .replace(/\u202f/g, " ")
+    .replace(/\xa0/g, " ")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "");
+}
+
+/** Minimal message shape required by this helper module. */
+export type MessageLike = {
+  content: unknown;
+};
+
+/**
+ * Returns the normalized content of the final agent message.
+ *
+ * @param messages Agent message list.
+ * @returns Normalized text content of the last message.
+ * @throws {Error} When the message list is empty.
+ */
+export function normalizedFinalMessage(messages: readonly MessageLike[]): string {
+  if (messages.length === 0) {
+    throw new Error("Agent returned no messages.");
+  }
+
+  return normalizeText(String(messages[messages.length - 1].content));
+}
+
+/**
+ * Asserts that all expected fragments are present in the input text.
+ *
+ * @param text Text to inspect.
+ * @param expectedFragments Fragments that must all be present.
+ * @returns Nothing.
+ */
+export function expectContainsAll(text: string, expectedFragments: readonly string[]): void {
+  const normalizedText = normalizeText(text);
+
+  for (const fragment of expectedFragments) {
+    expect(normalizedText).toContain(normalizeText(fragment));
+  }
+}
+
+/**
+ * Normalizes the final message, asserts all expected fragments, and returns
+ * the normalized message for additional assertions.
+ *
+ * @param messages Agent message list.
+ * @param expectedFragments Fragments that must all be present.
+ * @returns Normalized final message text.
+ */
+export function expectNormalizedFinalMessageContainsAll(
+  messages: readonly MessageLike[],
+  expectedFragments: readonly string[],
+): string {
+  const text = normalizedFinalMessage(messages);
+  expectContainsAll(text, expectedFragments);
+  return text;
+}
+
+/**
+ * Tracks tool calls observed through LangChain callbacks.
+ */
+export class ToolCallTracker extends BaseCallbackHandler {
+  name = "tool-call-tracker";
+  private readonly toolCalls = new Set<string>();
+
+  /**
+   * Records a tool call when LangChain starts a tool.
+   *
+   * @param tool Serialized tool metadata.
+   * @returns Nothing.
+   */
+  handleToolStart(tool: Serialized): void {
+    const toolName = extractToolName(tool);
+    if (toolName) {
+      this.toolCalls.add(toolName);
+    }
+  }
+
+  /**
+   * Checks whether a tool name was observed at least once.
+   *
+   * @param toolName Tool name to check.
+   * @returns `true` when the tool call has been observed, else `false`.
+   */
+  hasToolCall(toolName: string): boolean {
+    return this.toolCalls.has(toolName);
+  }
+}

--- a/test/integration/helpers/level2-assertions.ts
+++ b/test/integration/helpers/level2-assertions.ts
@@ -10,13 +10,19 @@ interface SerializedToolCandidate {
 /**
  * Extracts a human-readable tool name from LangChain serialized metadata.
  *
- * LangChain callbacks may expose either `name` directly, or only an `id` array
- * where the last item corresponds to the runnable/tool name.
+ * LangChain callbacks may expose the runnable name as the callback `runName`,
+ * as `name` on serialized metadata, or only as an `id` array where the last
+ * item corresponds to the runnable/tool class name.
  *
  * @param tool Serialized LangChain runnable metadata.
+ * @param runName Optional callback run name supplied by LangChain.
  * @returns Extracted tool name, or `undefined` when not found.
  */
-export function extractToolName(tool: Serialized): string | undefined {
+export function extractToolName(tool: Serialized, runName?: string): string | undefined {
+  if (typeof runName === "string" && runName.length > 0) {
+    return runName;
+  }
+
   const candidate = tool as unknown as SerializedToolCandidate;
 
   if (typeof candidate.name === "string" && candidate.name.length > 0) {
@@ -112,10 +118,24 @@ export class ToolCallTracker extends BaseCallbackHandler {
    * Records a tool call when LangChain starts a tool.
    *
    * @param tool Serialized tool metadata.
+   * @param _input Serialized tool input.
+   * @param _runId LangChain run identifier.
+   * @param _parentRunId Optional parent run identifier.
+   * @param _tags Callback tags.
+   * @param _metadata Callback metadata.
+   * @param runName Callback run name, usually the concrete tool name.
    * @returns Nothing.
    */
-  handleToolStart(tool: Serialized): void {
-    const toolName = extractToolName(tool);
+  handleToolStart(
+    tool: Serialized,
+    _input?: string,
+    _runId?: string,
+    _parentRunId?: string,
+    _tags?: string[],
+    _metadata?: Record<string, unknown>,
+    runName?: string,
+  ): void {
+    const toolName = extractToolName(tool, runName);
     if (toolName) {
       this.toolCalls.add(toolName);
     }

--- a/test/integration/helpers/mcp-client.ts
+++ b/test/integration/helpers/mcp-client.ts
@@ -1,0 +1,114 @@
+/**
+ * Provides helpers to connect to the geocontext MCP server via stdio.
+ *
+ * Usage in tests:
+ * ```ts
+ * const { client, cleanup } = await connectToServer();
+ * // ... use client ...
+ * await cleanup();
+ * ```
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+
+/**
+ * Represents a connected MCP server handle.
+ */
+export interface McpServerHandle {
+  /** Connected MCP client instance. */
+  client: Client;
+  /** Underlying stdio transport connected to the spawned server process. */
+  transport: StdioClientTransport;
+  /** Closes both the client and the transport. */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Starts the geocontext MCP server and connects a client to it via stdio.
+ *
+ * @returns A handle containing the connected client, the transport, and a cleanup function.
+ */
+export async function connectToServer(): Promise<McpServerHandle> {
+  const transport = new StdioClientTransport({
+    command: INTEGRATION_CONFIG.serverCommand,
+    args: [...INTEGRATION_CONFIG.serverArgs],
+    env: INTEGRATION_CONFIG.serverEnv(),
+    stderr: "pipe",
+  });
+
+  const client = new Client(
+    { name: "integration-test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  await client.connect(transport, { timeout: INTEGRATION_CONFIG.connectTimeout });
+
+  const cleanup = async () => {
+    await client.close();
+    await transport.close();
+  };
+
+  return { client, transport, cleanup };
+}
+
+// ─── Convenience helpers ─────────────────────────────────────────────
+
+interface TextContent {
+  type: "text";
+  text: string;
+}
+
+function isTextContent(value: unknown): value is TextContent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as { type?: unknown; text?: unknown };
+  return candidate.type === "text" && typeof candidate.text === "string";
+}
+
+function extractTextContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content.filter(isTextContent).map((item) => item.text).join("\n");
+}
+
+/**
+ * Calls a server tool and parses its textual JSON response.
+ *
+ * @param client Connected MCP client.
+  * @param toolName Tool name to call.
+  * @param args Tool input arguments.
+  * @returns Parsed JSON payload of the tool response.
+ * @throws {Error} When the tool returns `isError: true`.
+ * @throws {SyntaxError} When tool text output is not valid JSON.
+ */
+export async function callTool<T = unknown>(
+  client: Client,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const result = await client.callTool({ name: toolName, arguments: args });
+  const text = extractTextContent(result.content);
+
+  if (result.isError) {
+    throw new Error(`Tool "${toolName}" returned an error: ${text}`);
+  }
+
+  return JSON.parse(text) as T;
+}
+
+/**
+ * Lists all tools exposed by the server.
+ *
+ * @param client Connected MCP client.
+  * @returns Tool descriptors exposed by the server.
+ */
+export async function listTools(client: Client) {
+  const response = await client.listTools();
+  return response.tools;
+}

--- a/test/integration/level1-protocol/adminexpress.test.ts
+++ b/test/integration/level1-protocol/adminexpress.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Integration test: adminexpress tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectNonEmptyResults } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+import { paris } from "../samples.js";
+
+interface AdminexpressResult {
+  results: Array<{
+    type: string;
+    id: string;
+    bbox?: number[];
+    feature_ref: {
+      typename: string;
+      feature_id: string;
+    };
+    [key: string]: unknown;
+  }>;
+}
+
+describe("Adminexpress Tool (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should return administrative units for Paris", async () => {
+    const result = await callTool<AdminexpressResult>(getHandle().client, "adminexpress", {
+      lon: paris.lon,
+      lat: paris.lat,
+    });
+
+    expectNonEmptyResults(result);
+
+    // Check that at least one result has a type and id
+    const first = result.results[0];
+    expect(first.type).toBeDefined();
+    expect(first.id).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should include feature_ref in results", async () => {
+    const result = await callTool<AdminexpressResult>(getHandle().client, "adminexpress", {
+      lon: paris.lon,
+      lat: paris.lat,
+    });
+
+    expectNonEmptyResults(result);
+    for (const unit of result.results) {
+      expect(unit.feature_ref).toBeDefined();
+      expect(unit.feature_ref.typename).toBeDefined();
+      expect(unit.feature_ref.feature_id).toBeDefined();
+    }
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/altitude.test.ts
+++ b/test/integration/level1-protocol/altitude.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Integration test: altitude tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectToolCallToThrow } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+import { paris, chamonix } from "../samples.js";
+
+interface AltitudeResult {
+  result: {
+    lon: number;
+    lat: number;
+    altitude: number;
+    accuracy: string;
+  };
+}
+
+describe("Altitude Tool (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should return altitude for Paris (~35 m)", async () => {
+    const result = await callTool<AltitudeResult>(getHandle().client, "altitude", {
+      lon: paris.lon,
+      lat: paris.lat,
+    });
+
+    expect(result.result).toBeDefined();
+    expect(result.result.altitude).toBeDefined();
+    expect(typeof result.result.altitude).toBe("number");
+    // Paris altitude is approximately 35 m, with some tolerance
+    expect(result.result.altitude).toBeGreaterThan(20);
+    expect(result.result.altitude).toBeLessThan(100);
+    expect(result.result.accuracy).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return altitude for Chamonix (~1035 m)", async () => {
+    const result = await callTool<AltitudeResult>(getHandle().client, "altitude", {
+      lon: chamonix.lon,
+      lat: chamonix.lat,
+    });
+
+    expect(result.result).toBeDefined();
+    expect(result.result.altitude).toBeDefined();
+    expect(typeof result.result.altitude).toBe("number");
+    // Chamonix altitude is approximately 1035 m
+    expect(result.result.altitude).toBeGreaterThan(900);
+    expect(result.result.altitude).toBeLessThan(1100);
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for out-of-range coordinates", async () => {
+    await expectToolCallToThrow(callTool(getHandle().client, "altitude", { lon: 600, lat: 600 }));
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/cadastre.test.ts
+++ b/test/integration/level1-protocol/cadastre.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Integration test: cadastre tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectNonEmptyResults } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+import { paris } from "../samples.js";
+
+interface CadastreResult {
+  results: Array<{
+    type: string;
+    id: string;
+    bbox?: number[];
+    feature_ref: {
+      typename: string;
+      feature_id: string;
+    };
+    distance: number;
+    source: string;
+    [key: string]: unknown;
+  }>;
+}
+
+describe("Cadastre Tool (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should return cadastral objects near Paris", async () => {
+    const result = await callTool<CadastreResult>(getHandle().client, "cadastre", {
+      lon: paris.lon,
+      lat: paris.lat,
+    });
+
+    expectNonEmptyResults(result);
+
+    const first = result.results[0];
+    expect(first.type).toBeDefined();
+    expect(first.id).toBeDefined();
+    expect(first.distance).toBeDefined();
+    expect(typeof first.distance).toBe("number");
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should include feature_ref in cadastral results", async () => {
+    const result = await callTool<CadastreResult>(getHandle().client, "cadastre", {
+      lon: paris.lon,
+      lat: paris.lat,
+    });
+
+    expectNonEmptyResults(result);
+    for (const obj of result.results) {
+      expect(obj.feature_ref).toBeDefined();
+      expect(obj.feature_ref.typename).toBeDefined();
+      expect(obj.feature_ref.feature_id).toBeDefined();
+    }
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/geocode.test.ts
+++ b/test/integration/level1-protocol/geocode.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Integration test: geocode tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectNonEmptyResults, expectToolCallToThrow } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+
+interface GeocodeResult {
+  results: Array<{
+    lon: number;
+    lat: number;
+    fulltext: string;
+    kind?: string;
+    city?: string;
+    zipcode?: string;
+  }>;
+}
+
+describe("Geocode Tool (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should geocode 'Paris' and return results", async () => {
+    const result = await callTool<GeocodeResult>(getHandle().client, "geocode", {
+      text: "Paris",
+      maximumResponses: 3,
+    });
+
+    expectNonEmptyResults(result);
+
+    const first = result.results[0];
+    expect(first.lon).toBeDefined();
+    expect(first.lat).toBeDefined();
+    expect(first.fulltext).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should find Paris in geocoding results", async () => {
+    const result = await callTool<GeocodeResult>(getHandle().client, "geocode", {
+      text: "Paris",
+      maximumResponses: 1,
+    });
+
+    expectNonEmptyResults(result);
+    const text = JSON.stringify(result).toLowerCase();
+    expect(text).toContain("paris");
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should geocode 'Chamonix' and return the commune", async () => {
+    const result = await callTool<GeocodeResult>(getHandle().client, "geocode", {
+      text: "Chamonix",
+      maximumResponses: 1,
+    });
+
+    expectNonEmptyResults(result);
+    const text = JSON.stringify(result).toLowerCase();
+    expect(text).toContain("chamonix");
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for empty text", async () => {
+    await expectToolCallToThrow(callTool(getHandle().client, "geocode", { text: "" }));
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/tools-discovery.test.ts
+++ b/test/integration/level1-protocol/tools-discovery.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Integration test: verify that the geocontext MCP server exposes
+ * all expected tools with valid schemas.
+ */
+
+import { describe, it, expect } from "vitest";
+import { listTools } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { EXPECTED_TOOL_NAMES } from "../samples.js";
+
+describe("Tools Discovery", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should expose all expected tools", async () => {
+    const tools = await listTools(getHandle().client);
+    const toolNames = tools.map((t) => t.name);
+
+    for (const expected of EXPECTED_TOOL_NAMES) {
+      expect(toolNames).toContain(expected);
+    }
+  });
+
+  it("should expose exactly the expected number of tools", async () => {
+    const tools = await listTools(getHandle().client);
+    expect(tools).toHaveLength(EXPECTED_TOOL_NAMES.length);
+  });
+
+  it("each tool should have a valid inputSchema", async () => {
+    const tools = await listTools(getHandle().client);
+
+    for (const tool of tools) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.properties).toBeDefined();
+    }
+  });
+
+  it("each tool should have a description", async () => {
+    const tools = await listTools(getHandle().client);
+
+    for (const tool of tools) {
+      expect(tool.description).toBeDefined();
+      expect(tool.description!.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/integration/level1-protocol/urbanisme.test.ts
+++ b/test/integration/level1-protocol/urbanisme.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Integration test: urbanisme tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectNonEmptyResults } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+import { besancon } from "../samples.js";
+
+interface UrbanismeResult {
+  results: Array<{
+    type: string;
+    id: string;
+    bbox?: number[];
+    feature_ref?: {
+      typename: string;
+      feature_id: string;
+    };
+    distance: number;
+    [key: string]: unknown;
+  }>;
+}
+
+describe("Urbanisme Tool (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should return urban planning objects for Besançon", async () => {
+    const result = await callTool<UrbanismeResult>(getHandle().client, "urbanisme", {
+      lon: besancon.lon,
+      lat: besancon.lat,
+    });
+
+    expectNonEmptyResults(result);
+
+    const first = result.results[0];
+    expect(first.type).toBeDefined();
+    expect(first.id).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/wfs-describe.test.ts
+++ b/test/integration/level1-protocol/wfs-describe.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Integration test: WFS describe type tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectToolCallToThrow } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+
+interface WfsDescribeResult {
+  result: {
+    id: string;
+    namespace: string;
+    name: string;
+    title: string;
+    description: string;
+    properties: Array<{
+      name: string;
+      type: string;
+      title?: string;
+      description?: string;
+      enum?: string[];
+      defaultCrs?: string;
+    }>;
+  };
+}
+
+describe("WFS Describe Type (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should describe BDTOPO_V3:batiment", async () => {
+    const result = await callTool<WfsDescribeResult>(getHandle().client, "gpf_wfs_describe_type", {
+      typename: "BDTOPO_V3:batiment",
+    });
+
+    expect(result.result).toBeDefined();
+    expect(result.result.id).toBe("BDTOPO_V3:batiment");
+    expect(result.result.name).toBe("batiment");
+    expect(result.result.properties).toBeDefined();
+    expect(result.result.properties.length).toBeGreaterThan(0);
+
+    // Check that properties have expected fields
+    const firstProp = result.result.properties[0];
+    expect(firstProp.name).toBeDefined();
+    expect(firstProp.type).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for empty typename", async () => {
+    await expectToolCallToThrow(callTool(getHandle().client, "gpf_wfs_describe_type", { typename: "" }));
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/wfs-getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/wfs-getfeaturebyid.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Integration test: WFS GetFeatureById tool with real API calls.
+ *
+ * This test first calls adminexpress to get a valid feature_ref,
+ * then uses gpf_wfs_get_feature_by_id to retrieve it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import type { McpServerHandle } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import {
+  expectFeatureCollectionWithFeatures,
+  expectNonEmptyResults,
+  expectToolCallToThrow,
+} from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+import { paris } from "../samples.js";
+
+interface AdminexpressResult {
+  results: Array<{
+    type: string;
+    id: string;
+    feature_ref: {
+      typename: string;
+      feature_id: string;
+    };
+    [key: string]: unknown;
+  }>;
+}
+
+interface GetFeatureByIdResult {
+  type: "FeatureCollection";
+  features: Array<{
+    type: string;
+    id: string;
+    properties: Record<string, unknown>;
+    geometry?: unknown;
+    feature_ref?: {
+      typename: string;
+      feature_id: string;
+    };
+  }>;
+  totalFeatures?: number;
+  numberMatched?: number;
+}
+
+describe("WFS GetFeatureById (integration)", () => {
+  let featureRef: { typename: string; feature_id: string };
+
+  const { getHandle } = withMcpServer({
+    connectTimeout: INTEGRATION_CONFIG.timeout,
+    setup: async (handle: McpServerHandle) => {
+      // Get a valid feature_ref from adminexpress
+      const adminResult = await callTool<AdminexpressResult>(handle.client, "adminexpress", {
+        lon: paris.lon,
+        lat: paris.lat,
+      });
+
+      expectNonEmptyResults(adminResult);
+      featureRef = adminResult.results[0].feature_ref;
+    },
+  });
+
+  it("should retrieve a feature by typename and feature_id", async () => {
+    const result = await callTool<GetFeatureByIdResult>(getHandle().client, "gpf_wfs_get_feature_by_id", {
+      typename: featureRef.typename,
+      feature_id: featureRef.feature_id,
+    });
+
+    expectFeatureCollectionWithFeatures(result, 1);
+    expect(result.features.length).toBe(1);
+    expect(result.features[0].id).toBeDefined();
+    expect(result.features[0].properties).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for invalid typename", async () => {
+    await expectToolCallToThrow(
+      callTool(getHandle().client, "gpf_wfs_get_feature_by_id", {
+        typename: "INVALID:type",
+        feature_id: "nonexistent",
+      }),
+    );
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/wfs-getfeatures.test.ts
+++ b/test/integration/level1-protocol/wfs-getfeatures.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Integration test: WFS GetFeatures tool with real API calls.
+ *
+ * Uses BDTOPO_V3:commune to test attribute filtering with a known code INSEE.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import {
+  expectFeatureCollectionWithFeatures,
+  expectToolCallToThrow,
+} from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+
+interface GetFeaturesResult {
+  type: "FeatureCollection";
+  features: Array<{
+    type: string;
+    id: string;
+    properties: Record<string, unknown>;
+    geometry?: unknown;
+    feature_ref?: {
+      typename: string;
+      feature_id: string;
+    };
+  }>;
+  totalFeatures?: number;
+  numberMatched?: number;
+}
+
+describe("WFS GetFeatures (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should query BDTOPO_V3:commune with attribute filter (code_insee=75056)", async () => {
+    const result = await callTool<GetFeaturesResult>(getHandle().client, "gpf_wfs_get_features", {
+      typename: "BDTOPO_V3:commune",
+      where: [{ property: "code_insee", operator: "eq", value: "75056" }],
+      select: ["code_insee", "nom_officiel"],
+      limit: 1,
+    });
+
+    expectFeatureCollectionWithFeatures(result);
+
+    const first = result.features[0];
+    expect(first.properties).toBeDefined();
+    expect(first.properties.code_insee).toBe("75056");
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for invalid typename", async () => {
+    await expectToolCallToThrow(
+      callTool(getHandle().client, "gpf_wfs_get_features", {
+        typename: "INVALID:type",
+        limit: 1,
+      }),
+    );
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level1-protocol/wfs-search.test.ts
+++ b/test/integration/level1-protocol/wfs-search.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Integration test: WFS search types tool with real API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callTool } from "../helpers/mcp-client.js";
+import { withMcpServer } from "../helpers/level1-fixtures.js";
+import { expectNonEmptyResults, expectToolCallToThrow } from "../helpers/level1-assertions.js";
+import { INTEGRATION_CONFIG } from "../config/shared.js";
+
+interface WfsSearchResult {
+  results: Array<{
+    id: string;
+    title: string;
+    description: string;
+    score?: number;
+  }>;
+}
+
+describe("WFS Search Types (integration)", () => {
+  const { getHandle } = withMcpServer();
+
+  it("should find 'batiment' types", async () => {
+    const result = await callTool<WfsSearchResult>(getHandle().client, "gpf_wfs_search_types", {
+      query: "bâtiment",
+    });
+
+    expectNonEmptyResults(result);
+
+    const ids = result.results.map((r) => r.id);
+    expect(ids).toContain("BDTOPO_V3:batiment");
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should find cadastral parcel types", async () => {
+    const result = await callTool<WfsSearchResult>(getHandle().client, "gpf_wfs_search_types", {
+      query: "parcelle cadastrale",
+    });
+
+    expectNonEmptyResults(result);
+
+    const ids = result.results.map((r) => r.id);
+    // Should find parcellaire express types
+    expect(ids.some((id) => id.includes("PARCELLAIRE_EXPRESS") || id.includes("parcelle"))).toBe(true);
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for empty query", async () => {
+    await expectToolCallToThrow(callTool(getHandle().client, "gpf_wfs_search_types", { query: "" }));
+  }, INTEGRATION_CONFIG.timeout);
+});

--- a/test/integration/level2-agent/test-chaining-geocode-altitude.test.ts
+++ b/test/integration/level2-agent/test-chaining-geocode-altitude.test.ts
@@ -1,0 +1,69 @@
+/**
+ * E2E test: agent chains geocode → altitude tools.
+ *
+ * Port of test_chaining_geocode.py from geocontext-test.
+ *
+ * The agent should:
+ * 1. Geocode "mairie de Chamonix"
+ * 2. Use the resulting coordinates to get the altitude
+ * 3. Return a response containing "Chamonix" and the altitude (~1036 m)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { invokeAgent } from "../helpers/level2-agent.js";
+import {
+  expectNormalizedFinalMessageContainsAll,
+  ToolCallTracker,
+} from "../helpers/level2-assertions.js";
+import {
+  createMcpClient,
+  SYSTEM_PROMPT,
+  E2E_TIMEOUT,
+  CONNECT_TIMEOUT,
+  HAS_MODEL_PROVIDER_API_KEY,
+} from "../config/level2-agent.js";
+import type { MultiServerMCPClient } from "@langchain/mcp-adapters";
+
+const USER_INPUT = "Quelle est l'altitude de la mairie de Chamonix?";
+
+const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip;
+
+function hasAltitudeInRange(text: string, min: number, max: number): boolean {
+  const values = [...text.matchAll(/\b\d[\d ]{0,5}\b/g)]
+    .map(([value]) => Number(value.replace(/\s+/g, "")))
+    .filter((value) => Number.isFinite(value));
+
+  return values.some((value) => value >= min && value <= max);
+}
+
+describeIfProvider("Agent E2E: chaining geocode → altitude", () => {
+  let client: MultiServerMCPClient | undefined;
+
+  beforeAll(async () => {
+    client = createMcpClient();
+  }, CONNECT_TIMEOUT);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it("should chain geocode and altitude tools to answer the question", async () => {
+    const tools = await client.getTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const tracker = new ToolCallTracker();
+
+    const result = await invokeAgent({
+      userInput: USER_INPUT,
+      tools,
+      systemPrompt: SYSTEM_PROMPT,
+      callbacks: [tracker],
+    });
+
+    expect(tracker.hasToolCall("geocode")).toBe(true);
+    expect(tracker.hasToolCall("altitude")).toBe(true);
+
+    const normalizedText = expectNormalizedFinalMessageContainsAll(result.messages, ["chamonix"]);
+    expect(hasAltitudeInRange(normalizedText, 1000, 1100)).toBe(true);
+  }, E2E_TIMEOUT);
+});

--- a/test/integration/level2-agent/test-chaining-geocode-altitude.test.ts
+++ b/test/integration/level2-agent/test-chaining-geocode-altitude.test.ts
@@ -48,7 +48,7 @@ describeIfProvider("Agent E2E: chaining geocode → altitude", () => {
   });
 
   it("should chain geocode and altitude tools to answer the question", async () => {
-    const tools = await client.getTools();
+    const tools = await client!.getTools();
     expect(tools.length).toBeGreaterThan(0);
 
     const tracker = new ToolCallTracker();

--- a/test/integration/level2-agent/test-france-capital.test.ts
+++ b/test/integration/level2-agent/test-france-capital.test.ts
@@ -1,0 +1,25 @@
+/**
+ * E2E test: basic agent test without MCP tools.
+ *
+ * Port of test_france_capital.py from geocontext-test.
+ * This test verifies that the LLM agent itself works correctly.
+ */
+
+import { describe, it } from "vitest";
+import { E2E_TIMEOUT, HAS_MODEL_PROVIDER_API_KEY } from "../config/level2-agent.js";
+import { invokeAgent } from "../helpers/level2-agent.js";
+import { expectNormalizedFinalMessageContainsAll } from "../helpers/level2-assertions.js";
+
+const USER_INPUT = "Quelle est la capitale de la France?";
+const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip;
+
+describeIfProvider("Agent E2E: basic question (no tools)", () => {
+  it("should answer that Paris is the capital of France", async () => {
+    const result = await invokeAgent({
+      userInput: USER_INPUT,
+      tools: [],
+    });
+
+    expectNormalizedFinalMessageContainsAll(result.messages, ["paris"]);
+  }, E2E_TIMEOUT);
+});

--- a/test/integration/level2-agent/test-search-batiment.test.ts
+++ b/test/integration/level2-agent/test-search-batiment.test.ts
@@ -1,0 +1,49 @@
+/**
+ * E2E test: agent searches for WFS types about buildings.
+ *
+ * Port of test_search_batiment.py from geocontext-test.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { invokeAgent } from "../helpers/level2-agent.js";
+import { expectNormalizedFinalMessageContainsAll } from "../helpers/level2-assertions.js";
+import {
+  createMcpClient,
+  SYSTEM_PROMPT,
+  E2E_TIMEOUT,
+  CONNECT_TIMEOUT,
+  HAS_MODEL_PROVIDER_API_KEY,
+} from "../config/level2-agent.js";
+import type { MultiServerMCPClient } from "@langchain/mcp-adapters";
+
+const USER_INPUT = "Dans quelle table peut-on trouver des informations sur les bâtiments?";
+
+const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip;
+
+describeIfProvider("Agent E2E: search WFS types for buildings", () => {
+  let client: MultiServerMCPClient | undefined;
+
+  beforeAll(async () => {
+    client = createMcpClient();
+  }, CONNECT_TIMEOUT);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it("should mention building-related WFS tables", async () => {
+    const tools = await client.getTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const result = await invokeAgent({
+      userInput: USER_INPUT,
+      tools,
+      systemPrompt: SYSTEM_PROMPT,
+    });
+
+    expectNormalizedFinalMessageContainsAll(result.messages, [
+      "bdtopo_v3:batiment",
+      "cadastralparcels.parcellaire_express:batiment",
+    ]);
+  }, E2E_TIMEOUT);
+});

--- a/test/integration/level2-agent/test-search-batiment.test.ts
+++ b/test/integration/level2-agent/test-search-batiment.test.ts
@@ -32,7 +32,7 @@ describeIfProvider("Agent E2E: search WFS types for buildings", () => {
   });
 
   it("should mention building-related WFS tables", async () => {
-    const tools = await client.getTools();
+    const tools = await client!.getTools();
     expect(tools.length).toBeGreaterThan(0);
 
     const result = await invokeAgent({

--- a/test/integration/level2-agent/test-search-ecoles.test.ts
+++ b/test/integration/level2-agent/test-search-ecoles.test.ts
@@ -42,8 +42,6 @@ describeIfProvider("Agent E2E: search WFS types for schools", () => {
     });
 
     expectNormalizedFinalMessageContainsAll(result.messages, [
-      "bdtopo_v3:zone_d_activite_ou_d_interet",
-      "bdtopo_v3:erp",
-    ]);
+      "bdtopo_v3:zone_d_activite_ou_d_interet"    ]);
   }, E2E_TIMEOUT);
 });

--- a/test/integration/level2-agent/test-search-ecoles.test.ts
+++ b/test/integration/level2-agent/test-search-ecoles.test.ts
@@ -1,0 +1,49 @@
+/**
+ * E2E test: agent searches for WFS types about schools.
+ *
+ * Port of test_search_ecoles.py from geocontext-test.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { invokeAgent } from "../helpers/level2-agent.js";
+import { expectNormalizedFinalMessageContainsAll } from "../helpers/level2-assertions.js";
+import {
+  createMcpClient,
+  SYSTEM_PROMPT,
+  E2E_TIMEOUT,
+  CONNECT_TIMEOUT,
+  HAS_MODEL_PROVIDER_API_KEY,
+} from "../config/level2-agent.js";
+import type { MultiServerMCPClient } from "@langchain/mcp-adapters";
+
+const USER_INPUT = "Dans quelle table peut-on trouver des informations sur les écoles?";
+
+const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip;
+
+describeIfProvider("Agent E2E: search WFS types for schools", () => {
+  let client: MultiServerMCPClient | undefined;
+
+  beforeAll(async () => {
+    client = createMcpClient();
+  }, CONNECT_TIMEOUT);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it("should find ERP-related tables for schools", async () => {
+    const tools = await client.getTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const result = await invokeAgent({
+      userInput: USER_INPUT,
+      tools,
+      systemPrompt: SYSTEM_PROMPT,
+    });
+
+    expectNormalizedFinalMessageContainsAll(result.messages, [
+      "bdtopo_v3:zone_d_activite_ou_d_interet",
+      "bdtopo_v3:erp",
+    ]);
+  }, E2E_TIMEOUT);
+});

--- a/test/integration/level2-agent/test-search-ecoles.test.ts
+++ b/test/integration/level2-agent/test-search-ecoles.test.ts
@@ -32,7 +32,7 @@ describeIfProvider("Agent E2E: search WFS types for schools", () => {
   });
 
   it("should find ERP-related tables for schools", async () => {
-    const tools = await client.getTools();
+    const tools = await client!.getTools();
     expect(tools.length).toBeGreaterThan(0);
 
     const result = await invokeAgent({

--- a/test/integration/samples.ts
+++ b/test/integration/samples.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared test data for integration tests.
+ */
+
+/** Well-known coordinates for testing */
+export const paris = { lon: 2.333333, lat: 48.866667 };
+export const chamonix = { lon: 6.869433, lat: 45.923697 };
+export const marseille = { lon: 5.4, lat: 43.3 };
+export const besancon = { lon: 6.0240539, lat: 47.237829 };
+
+/**
+ * Expected list of tool names exposed by the geocontext MCP server.
+ * Keep in sync with src/tools/*.ts
+ */
+export const EXPECTED_TOOL_NAMES = [
+  "geocode",
+  "altitude",
+  "adminexpress",
+  "cadastre",
+  "urbanisme",
+  "assiette_sup",
+  "gpf_wfs_search_types",
+  "gpf_wfs_describe_type",
+  "gpf_wfs_get_features",
+  "gpf_wfs_get_feature_by_id",
+] as const;

--- a/vitest.e2e.config.mts
+++ b/vitest.e2e.config.mts
@@ -14,13 +14,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/integration/**/*"],
-    testTimeout: 60 * MILLISECONDS,
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "lcov"],
-      include: ["src/**/*.{ts,tsx,js,jsx}"],
-    },
+    include: ["test/integration/level2-agent/**/*.test.ts"],
+    testTimeout: 120 * MILLISECONDS,
+    // Run sequentially: each test starts its own MCP server
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
   },
 });

--- a/vitest.integration.config.mts
+++ b/vitest.integration.config.mts
@@ -14,13 +14,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/integration/**/*"],
+    include: ["test/integration/level1-protocol/**/*.test.ts"],
     testTimeout: 60 * MILLISECONDS,
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "lcov"],
-      include: ["src/**/*.{ts,tsx,js,jsx}"],
-    },
+    // Run sequentially to avoid overloading the GPF APIs
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
   },
 });


### PR DESCRIPTION
Closes #83
Closes https://github.com/ignfab/geocontext-test/issues/1

- Implemented level 1 integration tests for various tools including adminexpress, altitude, cadastre, geocode, and urbanisme.
- Added level 2 agent tests to validate chaining of geocode and altitude tools.
- Created helper functions for assertions and MCP server connection management.
- Established a shared sample data module for consistent test coordinates and expected tool names.
- Configured Vitest for both E2E and integration testing environments with appropriate timeouts and settings.