### PR TITLE
feat: enhance response formatting and add structured content validation in GpfWfsGetFeatureByIdTool tests

### DIFF
--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -49,7 +49,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
   }
 
   /**
-   * Formats compact responses (`request`) into `structuredContent`.
+   * Formats compact responses (`request`, `results`) into `structuredContent`.
    *
    * We intentionally do not expose a single `outputSchemaShape` for the tool as
    * a whole: the `results` path returns a generic FeatureCollection whose
@@ -69,6 +69,18 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       return {
         content: [{ type: "text" as const, text: JSON.stringify(data) }],
         structuredContent: gpfWfsGetFeatureByIdRequestOutputSchema.parse(data),
+      };
+    }
+
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "type" in data &&
+      data.type === "FeatureCollection"
+    ) {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(data) }],
+        structuredContent: data as Record<string, unknown>,
       };
     }
 

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -84,7 +84,9 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       };
     }
 
-    return super.createSuccessResponse(data);
+    throw new Error(
+      "Réponse interne inattendue pour gpf_wfs_get_feature_by_id : le résultat devrait être une requête WFS ou une FeatureCollection.",
+    );
   }
 
   /**

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -162,8 +162,10 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
       throw new Error("expected text content");
     }
     const results = JSON.parse(textContent.text);
+    expect(response.structuredContent).toEqual(results);
     expect(results.totalFeatures).toEqual(1);
     expect(results.numberMatched).toEqual(1);
+    expect(results.numberReturned).toEqual(1);
     expect(results.features).toHaveLength(1);
     expect(results.features[0].geometry).toBeNull();
     expect(results.features[0].feature_ref).toEqual({

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -24,6 +24,12 @@ vi.doMock("../../../src/helpers/http.js", () => ({
 const { default: GpfWfsGetFeatureByIdTool } = await import("../../../src/tools/GpfWfsGetFeatureByIdTool");
 
 describe("Test GpfWfsGetFeatureByIdTool", () => {
+  class InvalidSuccessPayloadTool extends GpfWfsGetFeatureByIdTool {
+    async execute() {
+      return { unexpected: true } as never;
+    }
+  }
+
   const polygonFeatureType: Collection = {
     id: "ADMINEXPRESS-COG.LATEST:commune",
     namespace: "ADMINEXPRESS-COG.LATEST",
@@ -295,6 +301,32 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
           detail: expect.stringContaining("results"),
         }),
       ]),
+    });
+  });
+
+  it("should fail clearly when execution returns an unexpected success payload", async () => {
+    const tool = new InvalidSuccessPayloadTool();
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("Réponse interne inattendue");
+    expect(textContent.text).toContain("FeatureCollection");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:execution-error",
+      detail: expect.stringContaining("gpf_wfs_get_feature_by_id"),
     });
   });
 });


### PR DESCRIPTION
Closes #85 
Add `structuredContent` to `gpf_wfs_get_feature_by_id` for successful `result_type="results"` responses while keeping the existing text payload unchanged. The tool now returns the same transformed `FeatureCollection` both as `content[0].text` and as structured MCP output; `gpf_wfs_get_features` remains text-only for `results` by design. Unit tests were updated to verify parity between parsed text and `structuredContent` for by-id results, and to preserve the no-`structuredContent` contract for `gpf_wfs_get_features` results.