### PR TITLE
refactor: simplify output structure for altitude and WFS describe type tools

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -225,7 +225,10 @@ Renvoie l'altitude (en mètres) et la précision de la mesure (accuracy) d'un po
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `result` | object | yes | Le résultat altimétrique pour la position demandée. |
+| `accuracy` | string | yes | L'information de précision associée à l'altitude. |
+| `altitude` | number | yes | L'altitude du point. |
+| `lat` | number | yes | La latitude du point. |
+| `lon` | number | yes | La longitude du point. |
 
 <details>
 <summary>Raw output schema</summary>
@@ -234,37 +237,28 @@ Renvoie l'altitude (en mètres) et la précision de la mesure (accuracy) d'un po
 {
   "type": "object",
   "properties": {
-    "result": {
-      "type": "object",
-      "description": "Le résultat altimétrique pour la position demandée.",
-      "properties": {
-        "lon": {
-          "type": "number",
-          "description": "La longitude du point."
-        },
-        "lat": {
-          "type": "number",
-          "description": "La latitude du point."
-        },
-        "altitude": {
-          "type": "number",
-          "description": "L'altitude du point."
-        },
-        "accuracy": {
-          "type": "string",
-          "description": "L'information de précision associée à l'altitude."
-        }
-      },
-      "required": [
-        "lon",
-        "lat",
-        "altitude",
-        "accuracy"
-      ]
+    "lon": {
+      "type": "number",
+      "description": "La longitude du point."
+    },
+    "lat": {
+      "type": "number",
+      "description": "La latitude du point."
+    },
+    "altitude": {
+      "type": "number",
+      "description": "L'altitude du point."
+    },
+    "accuracy": {
+      "type": "string",
+      "description": "L'information de précision associée à l'altitude."
     }
   },
   "required": [
-    "result"
+    "lon",
+    "lat",
+    "altitude",
+    "accuracy"
   ]
 }
 ```
@@ -674,7 +668,12 @@ Title: Description d’un type WFS
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `result` | object | yes | La description détaillée du type WFS. |
+| `description` | string | yes | La description du type WFS. |
+| `id` | string | yes | L'identifiant complet du type WFS. |
+| `name` | string | yes | Le nom court du type WFS. |
+| `namespace` | string | yes | L'espace de nommage du type WFS. |
+| `properties` | array | yes | La liste des propriétés du type WFS. |
+| `title` | string | yes | Le titre lisible du type WFS. |
 
 <details>
 <summary>Raw output schema</summary>
@@ -683,83 +682,74 @@ Title: Description d’un type WFS
 {
   "type": "object",
   "properties": {
-    "result": {
-      "type": "object",
-      "description": "La description détaillée du type WFS.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "L'identifiant complet du type WFS."
-        },
-        "namespace": {
-          "type": "string",
-          "description": "L'espace de nommage du type WFS."
-        },
-        "name": {
-          "type": "string",
-          "description": "Le nom court du type WFS."
-        },
-        "title": {
-          "type": "string",
-          "description": "Le titre lisible du type WFS."
-        },
-        "description": {
-          "type": "string",
-          "description": "La description du type WFS."
-        },
+    "id": {
+      "type": "string",
+      "description": "L'identifiant complet du type WFS."
+    },
+    "namespace": {
+      "type": "string",
+      "description": "L'espace de nommage du type WFS."
+    },
+    "name": {
+      "type": "string",
+      "description": "Le nom court du type WFS."
+    },
+    "title": {
+      "type": "string",
+      "description": "Le titre lisible du type WFS."
+    },
+    "description": {
+      "type": "string",
+      "description": "La description du type WFS."
+    },
+    "properties": {
+      "type": "array",
+      "description": "La liste des propriétés du type WFS.",
+      "items": {
+        "type": "object",
         "properties": {
-          "type": "array",
-          "description": "La liste des propriétés du type WFS.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Le nom de la propriété."
-              },
-              "type": {
-                "type": "string",
-                "description": "Le type de la propriété."
-              },
-              "title": {
-                "type": "string",
-                "description": "Le titre lisible de la propriété."
-              },
-              "description": {
-                "type": "string",
-                "description": "La description de la propriété."
-              },
-              "enum": {
-                "type": "array",
-                "description": "Les valeurs possibles de la propriété.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "defaultCrs": {
-                "type": "string",
-                "description": "Le système de coordonnées par défaut si la propriété est géométrique."
-              }
-            },
-            "required": [
-              "name",
-              "type"
-            ]
+          "name": {
+            "type": "string",
+            "description": "Le nom de la propriété."
+          },
+          "type": {
+            "type": "string",
+            "description": "Le type de la propriété."
+          },
+          "title": {
+            "type": "string",
+            "description": "Le titre lisible de la propriété."
+          },
+          "description": {
+            "type": "string",
+            "description": "La description de la propriété."
+          },
+          "enum": {
+            "type": "array",
+            "description": "Les valeurs possibles de la propriété.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaultCrs": {
+            "type": "string",
+            "description": "Le système de coordonnées par défaut si la propriété est géométrique."
           }
-        }
-      },
-      "required": [
-        "id",
-        "namespace",
-        "name",
-        "title",
-        "description",
-        "properties"
-      ]
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      }
     }
   },
   "required": [
-    "result"
+    "id",
+    "namespace",
+    "name",
+    "title",
+    "description",
+    "properties"
   ]
 }
 ```

--- a/src/tools/AltitudeTool.ts
+++ b/src/tools/AltitudeTool.ts
@@ -27,9 +27,7 @@ const altitudeResultSchema = z.object({
   accuracy: z.string().describe("L'information de précision associée à l'altitude."),
 });
 
-const altitudeOutputSchema = z.object({
-  result: altitudeResultSchema.describe("Le résultat altimétrique pour la position demandée."),
-});
+const altitudeOutputSchema = altitudeResultSchema;
 
 // --- Tool ---
 
@@ -49,9 +47,7 @@ class AltitudeTool extends BaseTool<AltitudeInput> {
    * @returns The altitude payload returned by the upstream service.
    */
   async execute(input: AltitudeInput) {
-    return {
-      result: await getAltitudeByLocation(input.lon, input.lat),
-    };
+    return await getAltitudeByLocation(input.lon, input.lat);
   }
 }
 

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -33,14 +33,12 @@ const gpfWfsPropertySchema = z.object({
 });
 
 const gpfWfsDescribeTypeOutputSchema = z.object({
-  result: z.object({
-    id: z.string().describe("L'identifiant complet du type WFS."),
-    namespace: z.string().describe("L'espace de nommage du type WFS."),
-    name: z.string().describe("Le nom court du type WFS."),
-    title: z.string().describe("Le titre lisible du type WFS."),
-    description: z.string().describe("La description du type WFS."),
-    properties: z.array(gpfWfsPropertySchema).describe("La liste des propriétés du type WFS."),
-  }).describe("La description détaillée du type WFS."),
+  id: z.string().describe("L'identifiant complet du type WFS."),
+  namespace: z.string().describe("L'espace de nommage du type WFS."),
+  name: z.string().describe("Le nom court du type WFS."),
+  title: z.string().describe("Le titre lisible du type WFS."),
+  description: z.string().describe("La description du type WFS."),
+  properties: z.array(gpfWfsPropertySchema).describe("La liste des propriétés du type WFS."),
 });
 
 // --- Tool ---
@@ -68,9 +66,7 @@ class GpfWfsDescribeTypeTool extends BaseTool<GpfWfsDescribeTypeInput> {
   async execute(input: GpfWfsDescribeTypeInput) {
     try {
       const featureType: Collection = await wfsClient.getFeatureType(input.typename);
-      return {
-        result: featureType,
-      };
+      return featureType;
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       throw new Error(`${message}. Utiliser gpf_wfs_search_types pour trouver un type valide.`);

--- a/test/integration/level1-protocol/altitude.test.ts
+++ b/test/integration/level1-protocol/altitude.test.ts
@@ -10,12 +10,10 @@ import { INTEGRATION_CONFIG } from "../config/shared.js";
 import { paris, chamonix } from "../samples.js";
 
 interface AltitudeResult {
-  result: {
-    lon: number;
-    lat: number;
-    altitude: number;
-    accuracy: string;
-  };
+  lon: number;
+  lat: number;
+  altitude: number;
+  accuracy: string;
 }
 
 describe("Altitude Tool (integration)", () => {
@@ -27,13 +25,12 @@ describe("Altitude Tool (integration)", () => {
       lat: paris.lat,
     });
 
-    expect(result.result).toBeDefined();
-    expect(result.result.altitude).toBeDefined();
-    expect(typeof result.result.altitude).toBe("number");
+    expect(result.altitude).toBeDefined();
+    expect(typeof result.altitude).toBe("number");
     // Paris altitude is approximately 35 m, with some tolerance
-    expect(result.result.altitude).toBeGreaterThan(20);
-    expect(result.result.altitude).toBeLessThan(100);
-    expect(result.result.accuracy).toBeDefined();
+    expect(result.altitude).toBeGreaterThan(20);
+    expect(result.altitude).toBeLessThan(100);
+    expect(result.accuracy).toBeDefined();
   }, INTEGRATION_CONFIG.timeout);
 
   it("should return altitude for Chamonix (~1035 m)", async () => {
@@ -42,12 +39,11 @@ describe("Altitude Tool (integration)", () => {
       lat: chamonix.lat,
     });
 
-    expect(result.result).toBeDefined();
-    expect(result.result.altitude).toBeDefined();
-    expect(typeof result.result.altitude).toBe("number");
+    expect(result.altitude).toBeDefined();
+    expect(typeof result.altitude).toBe("number");
     // Chamonix altitude is approximately 1035 m
-    expect(result.result.altitude).toBeGreaterThan(900);
-    expect(result.result.altitude).toBeLessThan(1100);
+    expect(result.altitude).toBeGreaterThan(900);
+    expect(result.altitude).toBeLessThan(1100);
   }, INTEGRATION_CONFIG.timeout);
 
   it("should return an error for out-of-range coordinates", async () => {

--- a/test/integration/level1-protocol/wfs-describe.test.ts
+++ b/test/integration/level1-protocol/wfs-describe.test.ts
@@ -9,21 +9,19 @@ import { expectToolCallToThrow } from "../helpers/level1-assertions.js";
 import { INTEGRATION_CONFIG } from "../config/shared.js";
 
 interface WfsDescribeResult {
-  result: {
-    id: string;
-    namespace: string;
+  id: string;
+  namespace: string;
+  name: string;
+  title: string;
+  description: string;
+  properties: Array<{
     name: string;
-    title: string;
-    description: string;
-    properties: Array<{
-      name: string;
-      type: string;
-      title?: string;
-      description?: string;
-      enum?: string[];
-      defaultCrs?: string;
-    }>;
-  };
+    type: string;
+    title?: string;
+    description?: string;
+    enum?: string[];
+    defaultCrs?: string;
+  }>;
 }
 
 describe("WFS Describe Type (integration)", () => {
@@ -34,14 +32,13 @@ describe("WFS Describe Type (integration)", () => {
       typename: "BDTOPO_V3:batiment",
     });
 
-    expect(result.result).toBeDefined();
-    expect(result.result.id).toBe("BDTOPO_V3:batiment");
-    expect(result.result.name).toBe("batiment");
-    expect(result.result.properties).toBeDefined();
-    expect(result.result.properties.length).toBeGreaterThan(0);
+    expect(result.id).toBe("BDTOPO_V3:batiment");
+    expect(result.name).toBe("batiment");
+    expect(result.properties).toBeDefined();
+    expect(result.properties.length).toBeGreaterThan(0);
 
     // Check that properties have expected fields
-    const firstProp = result.result.properties[0];
+    const firstProp = result.properties[0];
     expect(firstProp.name).toBeDefined();
     expect(firstProp.type).toBeDefined();
   }, INTEGRATION_CONFIG.timeout);

--- a/test/tools/altitude.test.ts
+++ b/test/tools/altitude.test.ts
@@ -5,12 +5,10 @@ describe("Test AltitudeTool",() => {
     class TestableAltitudeTool extends AltitudeTool {
         async execute() {
             return {
-                result: {
-                    lon: paris.coordinates[0],
-                    lat: paris.coordinates[1],
-                    altitude: 34.78,
-                    accuracy: "Variable suivant la source de mesure",
-                },
+                lon: paris.coordinates[0],
+                lat: paris.coordinates[1],
+                altitude: 34.78,
+                accuracy: "Variable suivant la source de mesure",
             };
         }
     }
@@ -53,17 +51,13 @@ describe("Test AltitudeTool",() => {
             throw new Error("expected text content");
         }
         expect(JSON.parse(textContent.text)).toMatchObject({
-            result: {
-                lon: c[0],
-                lat: c[1],
-            },
+            lon: c[0],
+            lat: c[1],
         });
         expect(response.structuredContent).toBeDefined();
         expect(response.structuredContent).toMatchObject({
-            result: {
-                lon: c[0],
-                lat: c[1],
-            },
+            lon: c[0],
+            lat: c[1],
         });
     });
 

--- a/test/tools/wfs/describeType.test.ts
+++ b/test/tools/wfs/describeType.test.ts
@@ -19,9 +19,7 @@ describe("Test GpfWfsDescribeTypeTool",() => {
 
     class TestableGpfWfsDescribeTypeTool extends GpfWfsDescribeTypeTool {
         async execute() {
-            return {
-                result: mockCollection,
-            };
+            return mockCollection;
         }
     }
 
@@ -61,15 +59,11 @@ describe("Test GpfWfsDescribeTypeTool",() => {
             throw new Error("expected text content");
         }
         expect(JSON.parse(textContent.text)).toMatchObject({
-            result: {
-                id: "BDTOPO_V3:batiment",
-            },
+            id: "BDTOPO_V3:batiment",
         });
         expect(response.structuredContent).toBeDefined();
         expect(response.structuredContent).toMatchObject({
-            result: {
-                id: "BDTOPO_V3:batiment",
-            },
+            id: "BDTOPO_V3:batiment",
         });
     });
 


### PR DESCRIPTION
Closes #86 

This PR removes the redundant `result` wrapper from singleton MCP tool outputs so their domain fields are exposed directly in `structuredContent` and in the serialized JSON text payload.

The change is intentionally limited to singleton object responses:
- `altitude` now returns `{ lon, lat, altitude, accuracy }`
- `gpf_wfs_describe_type` now returns `{ id, namespace, name, title, description, properties }`

The corresponding `outputSchema` definitions were flattened to match the new top-level shape, and the unit/integration tests were updated accordingly. List-style outputs using `results` are unchanged, and WFS `FeatureCollection` responses are explicitly out of scope.

This is an API cleanup and consistency change aligned with MCP output schema examples. It is a breaking response-shape change for any client currently reading `structuredContent.result`.