### PR TITLE
test(E2E): add 2 building scenarios and more robust numeric assertions

### DIFF
--- a/test/integration/level2-agent/level2-agent.test.ts
+++ b/test/integration/level2-agent/level2-agent.test.ts
@@ -19,7 +19,7 @@ const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip
 
 /**
  * Test if the given text contains a number in the specified range.
- * The function looks for numbers with up to 11 digits, possibly separated by spaces.
+ * The function looks for numbers containing up to 11 characters, including optional spaces.
  */
 function containsNumberInRange(text: string, min: number, max: number): boolean {
   const values = [...text.matchAll(/\b\d[\d ]{0,10}\b/g)]
@@ -87,7 +87,7 @@ const mcpScenarios = [
     userInput: "Combien y a t il de batiments de plus de 30 mètres sur la commune d'Angoulême?",
     toolMode: "mcp",
     requiredToolCalls: ["geocode", "gpf_wfs_search_types", "gpf_wfs_describe_type", "gpf_wfs_get_features"],
-    // assuming that it want change often and that the number is correct at the moment of writing
+    // assuming that it won't often change and that the number is correct at the moment of writing
     // (switch to assertScenarioResult with a range if needed in the future)
     expectedResponseFragments: ["19", "batiments"] 
   }

--- a/test/integration/level2-agent/level2-agent.test.ts
+++ b/test/integration/level2-agent/level2-agent.test.ts
@@ -19,10 +19,10 @@ const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip
 
 /**
  * Test if the given text contains a number in the specified range.
- * The function looks for numbers with up to 15 digits, possibly separated by spaces.
+ * The function looks for numbers with up to 11 digits, possibly separated by spaces.
  */
 function containsNumberInRange(text: string, min: number, max: number): boolean {
-  const values = [...text.matchAll(/\b\d[\d ]{0,14}\b/g)]
+  const values = [...text.matchAll(/\b\d[\d ]{0,10}\b/g)]
     .map(([value]) => Number(value.replace(/\s+/g, "")))
     .filter((value) => Number.isFinite(value));
 

--- a/test/integration/level2-agent/level2-agent.test.ts
+++ b/test/integration/level2-agent/level2-agent.test.ts
@@ -17,8 +17,12 @@ import { runLevel2Scenario } from "../helpers/level2-scenarios.js";
 
 const describeIfProvider = HAS_MODEL_PROVIDER_API_KEY ? describe : describe.skip;
 
-function hasAltitudeInRange(text: string, min: number, max: number): boolean {
-  const values = [...text.matchAll(/\b\d[\d ]{0,5}\b/g)]
+/**
+ * Test if the given text contains a number in the specified range.
+ * The function looks for numbers with up to 15 digits, possibly separated by spaces.
+ */
+function containsNumberInRange(text: string, min: number, max: number): boolean {
+  const values = [...text.matchAll(/\b\d[\d ]{0,14}\b/g)]
     .map(([value]) => Number(value.replace(/\s+/g, "")))
     .filter((value) => Number.isFinite(value));
 
@@ -58,7 +62,7 @@ const mcpScenarios = [
     toolMode: "mcp",
     requiredToolCalls: ["geocode", "altitude"],
     assertScenarioResult: ({ normalizedFinalMessage }) => {
-      expect(hasAltitudeInRange(normalizedFinalMessage, 1000, 1100)).toBe(true);
+      expect(containsNumberInRange(normalizedFinalMessage, 1000, 1100)).toBe(true);
     },
   },
   {
@@ -67,6 +71,25 @@ const mcpScenarios = [
     expectedResponseFragments: ["14", "lycées"],
     toolMode: "mcp",
     requiredToolCalls: ["geocode", "gpf_wfs_search_types", "gpf_wfs_describe_type", "gpf_wfs_get_features"],
+  },
+  {
+    testName: "should find about 1 741 batiments in the commune of Saint Mandé",
+    userInput: "Combien y a t il de batiments sur la commune de saint mandé?",
+    toolMode: "mcp",
+    requiredToolCalls: ["geocode", "gpf_wfs_search_types", "gpf_wfs_describe_type", "gpf_wfs_get_features"],
+    expectedResponseFragments: ["batiments"],
+    assertScenarioResult: ({ normalizedFinalMessage }) => {
+      expect(containsNumberInRange(normalizedFinalMessage, 1700, 1800)).toBe(true);
+    },
+  },
+  {
+    testName: "should find 19 batiments of more than 30 meters in Angouleme",
+    userInput: "Combien y a t il de batiments de plus de 30 mètres sur la commune d'Angoulême?",
+    toolMode: "mcp",
+    requiredToolCalls: ["geocode", "gpf_wfs_search_types", "gpf_wfs_describe_type", "gpf_wfs_get_features"],
+    // assuming that it want change often and that the number is correct at the moment of writing
+    // (switch to assertScenarioResult with a range if needed in the future)
+    expectedResponseFragments: ["19", "batiments"] 
   }
 ] satisfies Level2AgentScenario[];
 


### PR DESCRIPTION
# Context

This PR finalizes #88 Level 2 agent E2E coverage (MCP mode), with a focus on building-related queries and more reliable numeric assertions in natural-language responses.

## Main Changes

1. Refactored the numeric assertion helper:

- Renamed `hasAltitudeInRange` to `containsNumberInRange`
- Generalized usage beyond altitude-only checks
- Expanded number parsing to support longer values with space separators (5 characters-> 11 for max = "999 999 999")

2. Updated the existing altitude scenario to use the new helper.

3. Added 2 new Level 2 E2E scenarios (MCP mode):

- Building count for the municipality of Saint-Mandé, validated with a numeric range assertion (1700–1800)
- Count of buildings higher than 30 meters in Angoulême, validated through expected response fragments (19, batiments)

## Modified File

- level2-agent.test.ts

## Notes

- The Angoulême scenario currently validates a fixed expected value (19), with an inline note indicating it can be switched to a range-based assertion in the future if the underlying data becomes more volatile.

 (closes #88)