### PR TITLE
Enforce TypeScript type-checking for tests in validation and CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,8 +24,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+    - run: npm run verify:fast
     # basic functional testing
     # https://github.com/modelcontextprotocol/inspector?tab=readme-ov-file#cli-mode
     - name: List tools

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,8 +13,7 @@ jobs:
         with:
           node-version: 24.x
       - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
+      - run: npm run verify:fast
   
   publish-npm:
     needs: build
@@ -26,7 +25,7 @@ jobs:
           node-version: 24.5.0
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm run build --if-present
+      - run: npm run verify:fast
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ export NO_PROXY=localhost,127.0.0.1
 Les commandes principales sont :
 
 ```bash
+npm run typecheck
+npm run typecheck:test
 npm test
 npm run test:integration
 npm run test:e2e
@@ -208,6 +210,8 @@ npm run test:coverage
 npm run verify
 npm run verify:full
 ```
+
+`npm run verify:fast` inclut le type-check de l'application et des fichiers de test avant le build et les tests unitaires.
 
 Remarque :
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:integration": "vitest run --config vitest.integration.config.mts",
     "test:e2e": "vitest run --config vitest.e2e.config.mts",
     "test:coverage": "vitest run --coverage",
-    "verify:fast": "npm run typecheck && npm run build && npm run test:unit",
+    "verify:fast": "npm run typecheck && npm run typecheck:test && npm run build && npm run test:unit",
     "verify": "npm run verify:fast && npm run test:integration",
     "verify:full": "npm run verify && npm run test:e2e",
     "fresh": "npm run reset:local && npm ci && npm run verify",

--- a/test/gpf/adminexpress.test.ts
+++ b/test/gpf/adminexpress.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { vi, describe, expect, afterEach, beforeEach, it } from "vitest";
 import { mairieLoray } from "../samples";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<any>>();

--- a/test/gpf/altitude.test.ts
+++ b/test/gpf/altitude.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {getAltitudeByLocation} from "../../src/gpf/altitude.js";
 import { paris } from "../samples";
 

--- a/test/gpf/geocode.test.ts
+++ b/test/gpf/geocode.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {geocode} from "../../src/gpf/geocode.js";
 
 const rawGeocodeServiceResponse = {

--- a/test/gpf/parcellaire-express.test.ts
+++ b/test/gpf/parcellaire-express.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { vi, describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mairieLoray } from "../samples";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<any>>();

--- a/test/gpf/urbanisme.test.ts
+++ b/test/gpf/urbanisme.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, vi, it } from "vitest";
 import { chamonix, mairieLoray } from "../samples";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<any>>();

--- a/test/gpf/wfs-schema-catalog.test.ts
+++ b/test/gpf/wfs-schema-catalog.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, afterEach, beforeEach, it } from "vitest";
 import { FeatureTypeNotFoundError, WfsClient, wfsClient, loadMiniSearchOptionsFromEnv } from "../../src/gpf/wfs-schema-catalog";
 
 const GPF_WFS_MINISEARCH_OPTIONS_ENV = "GPF_WFS_MINISEARCH_OPTIONS";

--- a/test/helpers/distance.test.ts
+++ b/test/helpers/distance.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import distance from "../../src/helpers/distance.js";
 import type { Polygon } from "geojson";
 import {paris, marseille, besancon, parisMarseille} from '../samples';

--- a/test/helpers/http.test.ts
+++ b/test/helpers/http.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, vi, describe, it, expect } from "vitest";
 import fetch from "node-fetch";
 
 vi.mock("node-fetch", async () => {

--- a/test/helpers/toolError.test.ts
+++ b/test/helpers/toolError.test.ts
@@ -1,5 +1,5 @@
+import { vi, describe, it, expect } from "vitest";
 import { z } from "zod";
-import { vi } from "vitest";
 
 import { ServiceResponseError } from "../../src/helpers/http.js";
 import { normalizeToolError } from "../../src/helpers/errors/toolError.js";

--- a/test/helpers/wfs_engine/execution.test.ts
+++ b/test/helpers/wfs_engine/execution.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { vi, describe, expect, afterEach, it } from "vitest";
 
 const mockFetchJSONPost = vi.fn<(
   url: string,

--- a/test/helpers/wfs_engine/geometry.test.ts
+++ b/test/helpers/wfs_engine/geometry.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { geometryToEwkt } from "../../../src/helpers/wfs_engine/geometry";
 
 describe("geometryToEwkt", () => {

--- a/test/helpers/wfs_engine/queryPreparation.test.ts
+++ b/test/helpers/wfs_engine/queryPreparation.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import type { Collection } from "@ignfab/gpf-schema-store";
 
 import { compileQueryParts, geometryToEwkt } from "../../../src/helpers/wfs_engine/queryPreparation";

--- a/test/helpers/wfs_engine/request.test.ts
+++ b/test/helpers/wfs_engine/request.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { buildMultiTypenameRequest } from "../../../src/helpers/wfs_engine/request";
 
 describe("wfs_engine/request", () => {

--- a/test/helpers/wfs_engine/response.test.ts
+++ b/test/helpers/wfs_engine/response.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import {
   mapToFlatItems,
   mapToFlatItemsWithGeometry,

--- a/test/helpers/wfs_engine/spatialCql.test.ts
+++ b/test/helpers/wfs_engine/spatialCql.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import {
   compileBboxSpatialFilter,
   compileIntersectsPointSpatialFilter,

--- a/test/helpers/wfs_engine/spatialFilter.test.ts
+++ b/test/helpers/wfs_engine/spatialFilter.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import { getSpatialFilter } from "../../../src/helpers/wfs_engine/spatialFilter";
 import type { GpfWfsGetFeaturesInput } from "../../../src/helpers/wfs_engine/schema";
 

--- a/test/integration/helpers/level1-assertions.ts
+++ b/test/integration/helpers/level1-assertions.ts
@@ -21,7 +21,7 @@ export function expectNonEmptyResults<T>(
   minimum = 1,
 ): asserts value is { results: T[] } {
   expect(value.results).toBeDefined();
-  expect(value.results.length).toBeGreaterThanOrEqual(minimum);
+  expect(value.results!.length).toBeGreaterThanOrEqual(minimum);
 }
 
 /**
@@ -37,7 +37,7 @@ export function expectFeatureCollectionWithFeatures<TFeature>(
 ): asserts value is { type: "FeatureCollection"; features: TFeature[] } {
   expect(value.type).toBe("FeatureCollection");
   expect(value.features).toBeDefined();
-  expect(value.features.length).toBeGreaterThanOrEqual(minimum);
+  expect(value.features!.length).toBeGreaterThanOrEqual(minimum);
 }
 
 /**

--- a/test/tools/adminexpress.test.ts
+++ b/test/tools/adminexpress.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import AdminexpressTool from "../../src/tools/AdminexpressTool";
 import { mairieLoray } from "../samples";
 

--- a/test/tools/altitude.test.ts
+++ b/test/tools/altitude.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import AltitudeTool from "../../src/tools/AltitudeTool";
 import { paris } from "../samples";
 

--- a/test/tools/base-tool-error.test.ts
+++ b/test/tools/base-tool-error.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import { z } from "zod";
 
 import BaseTool from "../../src/tools/BaseTool.js";

--- a/test/tools/cadastre.test.ts
+++ b/test/tools/cadastre.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import CadastreTool from "../../src/tools/CadastreTool";
 import { mairieLoray } from "../samples";
 

--- a/test/tools/geocode.test.ts
+++ b/test/tools/geocode.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import GeocodeTool from "../../src/tools/GeocodeTool";
 
 describe("Test GeocodeTool",() => {

--- a/test/tools/strict-input.test.ts
+++ b/test/tools/strict-input.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import AdminexpressTool from "../../src/tools/AdminexpressTool";
 import AltitudeTool from "../../src/tools/AltitudeTool";
 import AssietteSupTool from "../../src/tools/AssietteSupTool";

--- a/test/tools/urbanisme.test.ts
+++ b/test/tools/urbanisme.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import AssietteSupTool from "../../src/tools/AssietteSupTool";
 import UrbanismeTool from "../../src/tools/UrbanismeTool";
 import { chamonix, mairieLoray } from "../samples";

--- a/test/tools/wfs/describeType.test.ts
+++ b/test/tools/wfs/describeType.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import type { Collection } from "@ignfab/gpf-schema-store";
 
 import GpfWfsDescribeTypeTool from "../../../src/tools/GpfWfsDescribeTypeTool";

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -1,5 +1,6 @@
+import { vi, describe, it, expect, afterEach } from "vitest";
+
 import type { Collection } from "@ignfab/gpf-schema-store";
-import { vi } from "vitest";
 import { ServiceResponseError } from "../../../src/helpers/http.js";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<Collection>>();

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -1,5 +1,6 @@
+import { vi, describe, it, expect, afterEach } from "vitest";
+
 import type { Collection } from "@ignfab/gpf-schema-store";
-import { vi } from "vitest";
 import { ServiceResponseError } from "../../../src/helpers/http.js";
 
 const mockGetFeatureType = vi.fn<(typename: string) => Promise<Collection>>();

--- a/test/tools/wfs/searchTypes.test.ts
+++ b/test/tools/wfs/searchTypes.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 import GpfWfsSearchTypesTool from "../../../src/tools/GpfWfsSearchTypesTool";
 
 describe("Test GpfWfsSearchTypesTool",() => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,7 +12,8 @@
   },
   "include": [
     "./src/**/*",
-    "./test/**/*"
+    "./test/**/*",
+    "./vitest*.mts"
   ],
   "exclude": [
     "node_modules",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
     ],
   },
   test: {
-    globals: true,
+    globals: false,
     environment: "node",
     include: ["test/**/*.test.ts"],
     exclude: ["test/integration/**/*"],

--- a/vitest.e2e.config.mts
+++ b/vitest.e2e.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
     ],
   },
   test: {
-    globals: true,
+    globals: false,
     environment: "node",
     include: ["test/integration/level2-agent/**/*.test.ts"],
     testTimeout: 120 * MILLISECONDS,

--- a/vitest.integration.config.mts
+++ b/vitest.integration.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
     ],
   },
   test: {
-    globals: true,
+    globals: false,
     environment: "node",
     include: ["test/integration/level1-protocol/**/*.test.ts"],
     testTimeout: 60 * MILLISECONDS,


### PR DESCRIPTION
Closes #108 

This PR enforces TypeScript type-checking for the test suite as part of the standard validation flow.

It keeps application and test type-checking as separate commands (`typecheck` and `typecheck:test`), adds test type-checking to `verify:fast`, and updates CI/release workflows to run that validation path. It also extends `tsconfig.test.json` to cover both `test/**/*` and the Vitest config files, so test code and test tooling are checked earlier and more consistently during refactors.