### PR TITLE
feat: add responseMode option for transport configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ function buildTransport(transportType: TransportType): TransportConfig {
     options: {
       port: port,
       endpoint,
+      responseMode: "stream",
       cors: {
         allowOrigin: "*",
         allowedOrigins: getCorsAllowedOrigins(),


### PR DESCRIPTION
Closes #17

This pull request introduces a small change to the `buildTransport` function in `src/index.ts`, setting the `responseMode` option to `"stream"`.