### PR TITLE
log tool calls and review helpers logging 

### DIFF
--- a/src/gpf/adminexpress.ts
+++ b/src/gpf/adminexpress.ts
@@ -46,7 +46,7 @@ const ADMINEXPRESS_TYPENAMES = ADMINEXPRESS_TYPES.map((type) => `ADMINEXPRESS-CO
  * @returns Administrative units covering the requested point.
  */
 export async function getAdminUnits(lon: number, lat: number): Promise<AdminUnit[]> {
-    logger.info(`[adminexpress] getAdminUnits(${lon},${lat})...`);
+    logger.debug(`[gpf:adminexpress] getAdminUnits(${lon},${lat})...`);
 
     const spatialFilter: SpatialFilter = { operator: "intersects_point", lon, lat };
 

--- a/src/gpf/altitude.ts
+++ b/src/gpf/altitude.ts
@@ -32,7 +32,7 @@ type AltitudeResult = {
  * @returns {Promise<AltitudeResult>}
  */
 export async function getAltitudeByLocation(lon: number, lat: number, fetcher: JsonFetcher<RawAltitudeResponse> = fetchJSONGet): Promise<AltitudeResult> {
-    logger.info(`getAltitudeByLocation(${lon},${lat})...`);
+    logger.debug(`[gpf:altitude] getAltitudeByLocation(${lon},${lat})...`);
     
     const url = `https://data.geopf.fr/altimetrie/1.0/calcul/alti/rest/elevation.json?lon=${lon}&lat=${lat}&resource=ign_rge_alti_wld`;
 

--- a/src/gpf/geocode.ts
+++ b/src/gpf/geocode.ts
@@ -44,7 +44,7 @@ export async function geocode(text: string, maximumResponses = 3, fetcher: JsonF
       return [];
     }
 
-    logger.info(`geocode(${JSON.stringify(normalizedText)}, ${maximumResponses})...`);
+    logger.debug(`[gpf:geocode] geocode(${JSON.stringify(normalizedText)}, ${maximumResponses})...`);
     
     const url = 'https://data.geopf.fr/geocodage/completion/?' + new URLSearchParams({
       text: normalizedText,

--- a/src/gpf/parcellaire-express.ts
+++ b/src/gpf/parcellaire-express.ts
@@ -70,7 +70,7 @@ function filterByDistance(items: ParcellaireExpressItem[]): ParcellaireExpressIt
  * @returns The nearest cadastral objects, at most one per cadastral type.
  */
 export async function getParcellaireExpress(lon: number, lat: number): Promise<ParcellaireExpressItem[]> {
-    logger.info(`getParcellaireExpress(${lon},${lat}) ...`);
+    logger.debug(`[gpf:parcellaire-express] getParcellaireExpress(${lon},${lat}) ...`);
 
     const spatialFilter: SpatialFilter = {
         operator: "dwithin_point",

--- a/src/gpf/urbanisme.ts
+++ b/src/gpf/urbanisme.ts
@@ -63,7 +63,7 @@ function sanitizeUrbanismeItem(item: UrbanismeItem): Record<string, unknown> {
  * @returns Urban planning objects relevant to the requested point.
  */
 export async function getUrbanisme(lon: number, lat: number): Promise<Record<string, unknown>[]> {
-    logger.info(`getUrbanisme(${lon},${lat})...`);
+    logger.debug(`[gpf:urbanisme] getUrbanisme(${lon},${lat})...`);
 
     const spatialFilter: SpatialFilter = {
         operator: "dwithin_point",
@@ -115,7 +115,7 @@ const ASSIETTES_SUP_TYPES = [
  * @returns SUP footprints relevant to the requested point.
  */
 export async function getAssiettesServitudes(lon: number, lat: number): Promise<UrbanismeItem[]> {
-    logger.info(`getAssiettesServitudes(${lon},${lat})...`);
+    logger.debug(`[gpf:urbanisme] getAssiettesServitudes(${lon},${lat})...`);
 
     const spatialFilter: SpatialFilter = {
         operator: "dwithin_point",

--- a/src/helpers/wfs_engine/features.ts
+++ b/src/helpers/wfs_engine/features.ts
@@ -180,7 +180,7 @@ export async function executeGetFeatures(input: GpfWfsGetFeaturesInput) {
   let featureCollection: WfsFeatureCollectionResponse;
 
   try {
-    logger.info(
+    logger.debug(
       `[gpf_wfs_get_features] POST ${request.url}?${new URLSearchParams(request.query).toString()}`,
     );
     featureCollection = await fetchFeatureCollection(request);

--- a/src/tools/AdminexpressTool.ts
+++ b/src/tools/AdminexpressTool.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { getAdminUnits, ADMINEXPRESS_TYPES, ADMINEXPRESS_SOURCE } from "../gpf/adminexpress.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -57,6 +58,10 @@ class AdminexpressTool extends BaseTool<AdminexpressInput> {
    * @returns The matching administrative units enriched with reusable `feature_ref` metadata.
    */
   async execute(input: AdminexpressInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     return {
       results: await getAdminUnits(input.lon, input.lat),
     };

--- a/src/tools/AltitudeTool.ts
+++ b/src/tools/AltitudeTool.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { ALTITUDE_SOURCE, getAltitudeByLocation } from "../gpf/altitude.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { lonSchema, latSchema } from "../helpers/schemas.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -47,6 +48,10 @@ class AltitudeTool extends BaseTool<AltitudeInput> {
    * @returns The altitude payload returned by the upstream service.
    */
   async execute(input: AltitudeInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     return await getAltitudeByLocation(input.lon, input.lat);
   }
 }

--- a/src/tools/AssietteSupTool.ts
+++ b/src/tools/AssietteSupTool.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { getAssiettesServitudes, URBANISME_SOURCE } from "../gpf/urbanisme.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -58,6 +59,10 @@ class AssietteSupTool extends BaseTool<AssietteSupInput> {
    * @returns The list of nearby assiettes with optional reusable `feature_ref` metadata.
    */
   async execute(input: AssietteSupInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+  
     return {
       results: await getAssiettesServitudes(input.lon, input.lat),
     };

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -1,10 +1,44 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { MCPTool } from "mcp-framework";
 
 import { normalizeToolError } from "../helpers/errors/toolError.js";
+import logger from "../logger.js";
+
+const toolInputStorage = new AsyncLocalStorage<Record<string, unknown>>();
 
 export default abstract class BaseTool<TInput extends Record<string, any> = any> extends MCPTool<TInput> {
+  async toolCall(request: {
+    params: {
+      name: string;
+      arguments?: Record<string, unknown>;
+    };
+  }) {
+    return toolInputStorage.run(request.params.arguments || {}, () => super.toolCall(request));
+  }
+
   protected createErrorResponse(error: unknown) {
     const payload = normalizeToolError(error);
+    const metadata: Record<string, unknown> = {
+      tool: this.name,
+      problem_type: payload.type,
+      problem_title: payload.title,
+      error_codes: payload.errors.map((item) => item.code),
+    };
+
+    const toolInput = toolInputStorage.getStore();
+    if (toolInput !== undefined) {
+      metadata.input = toolInput;
+    }
+
+    if (payload.upstream?.status !== undefined) {
+      metadata.upstream_status = payload.upstream.status;
+    }
+
+    if (error instanceof Error && error.name && error.name !== "Error") {
+      metadata.error_name = error.name;
+    }
+
+    logger.error(`[tool] failed ${this.name}: ${payload.detail}`, metadata);
 
     return {
       content: [

--- a/src/tools/CadastreTool.ts
+++ b/src/tools/CadastreTool.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { getParcellaireExpress, PARCELLAIRE_EXPRESS_TYPES, PARCELLAIRE_EXPRESS_SOURCE } from "../gpf/parcellaire-express.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -60,6 +61,10 @@ class CadastreTool extends BaseTool<CadastreInput> {
    * @returns The nearest cadastral objects, at most one per cadastral type.
    */
   async execute(input: CadastreInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     return {
       results: await getParcellaireExpress(input.lon, input.lat),
     };

--- a/src/tools/GeocodeTool.ts
+++ b/src/tools/GeocodeTool.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { geocode, GEOCODE_SOURCE } from "../gpf/geocode.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -64,6 +65,10 @@ class GeocodeTool extends BaseTool<GeocodeInput> {
    * @returns The ordered list of geocoded candidates.
    */
   async execute(input: GeocodeInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+  
     return {
       results: await geocode(input.text, input.maximumResponses),
     };

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -8,6 +8,7 @@ import type { Collection } from "@ignfab/gpf-schema-store";
 
 import { wfsClient } from "../gpf/wfs-schema-catalog.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -64,6 +65,10 @@ class GpfWfsDescribeTypeTool extends BaseTool<GpfWfsDescribeTypeInput> {
    * @returns The detailed feature type description from the embedded catalog.
    */
   async execute(input: GpfWfsDescribeTypeInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     try {
       const featureType: Collection = await wfsClient.getFeatureType(input.typename);
       return featureType;

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -21,6 +21,7 @@ import {
   gpfWfsGetFeatureByIdPublishedInputSchema,
   gpfWfsGetFeatureByIdRequestOutputSchema,
 } from "../helpers/wfs_engine/schema.js";
+import logger from "../logger.js";
 
 // --- Tool ---
 
@@ -97,6 +98,10 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
    * @returns Either a compiled request or a transformed FeatureCollection containing one feature.
    */
   async execute(input: GpfWfsGetFeatureByIdInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     if (input.result_type === "request") {
       // The `request` mode is handled here because it returns a preview payload,
       // not the actual by-id WFS result.

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -13,6 +13,7 @@ import {
   gpfWfsGetFeaturesPublishedInputSchema,
   gpfWfsGetFeaturesRequestOutputSchema,
 } from "../helpers/wfs_engine/schema.js";
+import logger from "../logger.js";
 
 /**
  * MCP tool exposing structured WFS feature search.
@@ -102,6 +103,10 @@ class GpfWfsGetFeaturesTool extends BaseTool<GpfWfsGetFeaturesInput> {
    * @returns Either a compiled request, a hit count, or a transformed FeatureCollection.
    */
   async execute(input: GpfWfsGetFeaturesInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     if (input.result_type === "request") {
       const { request } = await prepareGetFeaturesRequest(input);
       return toWfsRequestPayload(request);

--- a/src/tools/GpfWfsSearchTypesTool.ts
+++ b/src/tools/GpfWfsSearchTypesTool.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { wfsClient } from "../gpf/wfs-schema-catalog.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -64,6 +65,10 @@ class GpfWfsSearchTypesTool extends BaseTool<GpfWfsSearchTypesInput> {
    * @returns The ordered search results, optionally enriched with relevance scores.
    */
   async execute(input: GpfWfsSearchTypesInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     const maxResults = input.max_results || 10;
     const featureTypes = await wfsClient.searchFeatureTypesWithScores(input.query, maxResults);
     return {

--- a/src/tools/UrbanismeTool.ts
+++ b/src/tools/UrbanismeTool.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { getUrbanisme, URBANISME_SOURCE } from "../gpf/urbanisme.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { featureRefSchema, lonSchema, latSchema } from "../helpers/schemas.js";
+import logger from "../logger.js";
 
 // --- Schema ---
 
@@ -64,6 +65,10 @@ class UrbanismeTool extends BaseTool<UrbanismeInput> {
    * @returns The relevant urban planning objects, including reusable `feature_ref` metadata when available.
    */
   async execute(input: UrbanismeInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
     return {
       results: await getUrbanisme(input.lon, input.lat),
     };

--- a/test/tools/base-tool-error.test.ts
+++ b/test/tools/base-tool-error.test.ts
@@ -1,20 +1,36 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { z } from "zod";
 
+import logger from "../../src/logger.js";
 import BaseTool from "../../src/tools/BaseTool.js";
 
 describe("Test BaseTool error response", () => {
-  class DummyTool extends BaseTool<{ lon: number }> {
+  let loggerErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    loggerErrorSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  class DummyTool extends BaseTool<{ lon: number; delayMs?: number }> {
     name = "dummy_error_tool";
     title = "Dummy Error Tool";
     description = "Dummy tool used to test BaseTool error normalization.";
     schema = z.object({
       lon: z.number().max(180),
+      delayMs: z.number().int().min(0).optional(),
     }).strict();
 
-    async execute() {
-      throw new Error("runtime failure");
+    async execute(input: { lon: number; delayMs?: number }) {
+      if (input.delayMs !== undefined) {
+        await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+      }
+
+      throw new Error(`runtime failure for lon=${input.lon}`);
     }
   }
 
@@ -30,6 +46,16 @@ describe("Test BaseTool error response", () => {
       },
     });
 
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[tool] failed dummy_error_tool: Paramètres invalides"),
+      expect.objectContaining({
+        tool: "dummy_error_tool",
+        input: {
+          lon: 600,
+        },
+        error_codes: expect.arrayContaining(["too_big"]),
+      }),
+    );
     expect(response.isError).toBe(true);
     expect(response.content[0]).toMatchObject({
       type: "text",
@@ -58,20 +84,78 @@ describe("Test BaseTool error response", () => {
       },
     });
 
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      "[tool] failed dummy_error_tool: runtime failure for lon=2.3",
+      expect.objectContaining({
+        tool: "dummy_error_tool",
+        input: {
+          lon: 2.3,
+        },
+        error_codes: ["execution_error"],
+      }),
+    );
     expect(response.isError).toBe(true);
     expect(response.content[0]).toMatchObject({
       type: "text",
-      text: "runtime failure",
+      text: "runtime failure for lon=2.3",
     });
     expect(response.structuredContent).toMatchObject({
       type: "urn:geocontext:problem:execution-error",
-      detail: "runtime failure",
+      detail: "runtime failure for lon=2.3",
       errors: [
         {
           code: "execution_error",
-          detail: "runtime failure",
+          detail: "runtime failure for lon=2.3",
         },
       ],
     });
+  });
+
+  it("should keep the matching input in concurrent runtime error logs", async () => {
+    const tool = new DummyTool();
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      tool.toolCall({
+        params: {
+          name: "dummy_error_tool",
+          arguments: {
+            lon: 12.34,
+            delayMs: 30,
+          },
+        },
+      }),
+      tool.toolCall({
+        params: {
+          name: "dummy_error_tool",
+          arguments: {
+            lon: 56.78,
+            delayMs: 0,
+          },
+        },
+      }),
+    ]);
+
+    expect(firstResponse.isError).toBe(true);
+    expect(secondResponse.isError).toBe(true);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      "[tool] failed dummy_error_tool: runtime failure for lon=56.78",
+      expect.objectContaining({
+        tool: "dummy_error_tool",
+        input: {
+          lon: 56.78,
+          delayMs: 0,
+        },
+      }),
+    );
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      "[tool] failed dummy_error_tool: runtime failure for lon=12.34",
+      expect.objectContaining({
+        tool: "dummy_error_tool",
+        input: {
+          lon: 12.34,
+          delayMs: 30,
+        },
+      }),
+    );
   });
 });


### PR DESCRIPTION
(closes #116)

This PR improves logging consistency and observability around tool execution.

It introduces a clear logging split:
- **Tool entry points** now log execution at `info` level with the tool name and input payload.
- **Internal provider/helper calls** (GPF and WFS internals) are moved to `debug` level and use standardized log prefixes.

This helps keep production logs concise while preserving detailed traces for debugging.

### What Changed
- Added `logger` imports in all MCP tool classes and logged each `execute(...)` call with:
  - tool name (`this.name`)
  - input payload
- Updated internal logs from `info` to `debug` in several GPF/WFS modules:
  - `adminexpress`
  - `altitude`
  - `geocode`
  - `parcellaire-express`
  - `urbanisme` / `assiettes servitudes`
  - WFS feature execution helper
- Standardized debug log prefixes (e.g. `[gpf:...]`) for easier filtering.

### Why
- Improve **operator visibility** of actual tool invocations.
- Reduce noise in default logs by moving low-level internals to `debug`.
- Make troubleshooting easier with consistent, grep-friendly log tags.

### Impact
- No functional behavior change to tool outputs or APIs.
- Logging behavior changes only:
  - More explicit top-level tool execution logs at `info`.
  - More detailed internals available at `debug`.

### Testing
- Existing unit tests pass (no schema or business logic changes expected).
- Change is primarily operational/observability-focused.

