### PR TITLE
feat: Enhance MCP documentation generation and tool definitions

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
-# MCP Tool Reference
+# Référence des tools MCP
 
-Generated from runtime `toolDefinition` metadata for `@ignfab/geocontext` v0.9.8.
+Ce document est généré automatiquement à partir des définitions de tools exposées par la méthode `tools/list` du protocole MCP pour `@ignfab/geocontext` dans sa version v0.9.8. Pour le mettre à jour, lancer `npm run docs:mcp`.
 
 ## Contrat d’erreur MCP
 
@@ -13,29 +13,24 @@ Exemple complet généré automatiquement à partir d'un appel de tool invalide 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": "adminexpress:invalid-input-example",
+  "id": "geocode:invalid-input-example",
   "result": {
     "isError": true,
     "content": [
       {
         "type": "text",
-        "text": "Paramètres invalides : Le paramètre 'lon' est requis. Le paramètre 'lat' est requis."
+        "text": "Paramètres invalides : Le paramètre 'text' est requis."
       }
     ],
     "structuredContent": {
       "type": "urn:geocontext:problem:invalid-tool-params",
       "title": "Paramètres d’outil invalides",
-      "detail": "Paramètres invalides : Le paramètre 'lon' est requis. Le paramètre 'lat' est requis.",
+      "detail": "Paramètres invalides : Le paramètre 'text' est requis.",
       "errors": [
         {
           "code": "invalid_type",
-          "detail": "Le paramètre 'lon' est requis.",
-          "name": "lon"
-        },
-        {
-          "code": "invalid_type",
-          "detail": "Le paramètre 'lat' est requis.",
-          "name": "lat"
+          "detail": "Le paramètre 'text' est requis.",
+          "name": "text"
         }
       ]
     }
@@ -43,42 +38,170 @@ Exemple complet généré automatiquement à partir d'un appel de tool invalide 
 }
 ```
 
-## Index
+## Annotations MCP
 
-- [`adminexpress`](#adminexpress)
-- [`altitude`](#altitude)
-- [`assiette_sup`](#assiette_sup)
-- [`cadastre`](#cadastre)
+Tous les tools exposent les mêmes annotations MCP dans leur définition `tools/list` :
+
+| Annotation | Valeur | Signification |
+| --- | --- | --- |
+| `readOnlyHint` | oui | Le tool consulte des données sans modifier d'état côté serveur. |
+| `destructiveHint` | non | Le tool n'est pas signalé comme destructif. |
+| `idempotentHint` | oui | Répéter le même appel ne déclenche pas d'effet de bord supplémentaire attendu. |
+| `openWorldHint` | oui | Le tool interroge des sources externes ou ouvertes, dont le contenu peut évoluer. |
+
+## Liste des tools
+
 - [`geocode`](#geocode)
+- [`altitude`](#altitude)
+- [`adminexpress`](#adminexpress)
+- [`cadastre`](#cadastre)
+- [`urbanisme`](#urbanisme)
+- [`assiette_sup`](#assiette_sup)
+- [`gpf_wfs_search_types`](#gpf_wfs_search_types)
 - [`gpf_wfs_describe_type`](#gpf_wfs_describe_type)
 - [`gpf_wfs_get_feature_by_id`](#gpf_wfs_get_feature_by_id)
 - [`gpf_wfs_get_features`](#gpf_wfs_get_features)
-- [`gpf_wfs_search_types`](#gpf_wfs_search_types)
-- [`urbanisme`](#urbanisme)
 
-## `adminexpress`
+## `geocode`
 
-Source: [src/tools/AdminexpressTool.ts](../src/tools/AdminexpressTool.ts)
+Code Source : [src/tools/GeocodeTool.ts](../src/tools/GeocodeTool.ts)
 
-Title: Unités administratives
+### Titre
+
+Géocodage de lieux et d’adresses
 
 ### Description du tool
 
-- Renvoie, pour un point donné par sa `longitude` et sa `latitude`, la liste des unités administratives (arrondissement, arrondissement_municipal, canton, collectivite_territoriale, commune, commune_associee_ou_deleguee, departement, epci, region) qui le couvrent, sous forme d'objets typés contenant leurs propriétés administratives.
-- Les résultats incluent un `feature_ref` WFS réutilisable. Les propriétés incluent notamment le code INSEE.
-- Le `feature_ref` de chaque unité administrative est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator="intersects_feature"` pour interroger d'autres données sur cette emprise.
-- Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
-- (source : Géoplateforme (WFS, ADMINEXPRESS-COG.LATEST)).
+```
+Renvoie des résultats d'autocomplétion géocodés à partir d'un texte libre (lieu, adresse, POI), avec coordonnées, libellé complet et informations de localisation (`kind`, `city`, `zipcode`).
+Les coordonnées `lon/lat` retournées sont directement réutilisables dans tous les autres tools. Le champ `kind` indique le type de résultat (ex : `monument`, `street`, `city`, `locality`).
+(source : Géoplateforme (service d'autocomplétion)).
+```
 
-### Input Schema
+### Schéma d’entrée
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `lat` | number | yes | La latitude du point. |
-| `lon` | number | yes | La longitude du point. |
+| `maximumResponses` | integer | non | Le nombre maximum de résultats à retourner (entre 1 et 10). Défaut : 3. |
+| `text` | string | oui | Le texte devant être complété et géocodé |
 
 <details>
-<summary>Raw input schema</summary>
+<summary>Schéma d’entrée brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string",
+      "description": "Le texte devant être complété et géocodé",
+      "minLength": 1
+    },
+    "maximumResponses": {
+      "type": "integer",
+      "description": "Le nombre maximum de résultats à retourner (entre 1 et 10). Défaut : 3.",
+      "minimum": 1,
+      "maximum": 10
+    }
+  },
+  "required": [
+    "text"
+  ]
+}
+```
+
+</details>
+
+### Schéma de sortie
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `results` | array | oui | La liste ordonnée des résultats géocodés. |
+
+<details>
+<summary>Schéma de sortie brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "description": "La liste ordonnée des résultats géocodés.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "lon": {
+            "type": "number",
+            "description": "La longitude du résultat."
+          },
+          "lat": {
+            "type": "number",
+            "description": "La latitude du résultat."
+          },
+          "fulltext": {
+            "type": "string",
+            "description": "Le libellé complet du résultat."
+          },
+          "kind": {
+            "type": "string",
+            "description": "La nature du résultat géocodé."
+          },
+          "city": {
+            "type": "string",
+            "description": "La commune du résultat."
+          },
+          "zipcode": {
+            "type": "string",
+            "description": "Le code postal du résultat."
+          }
+        },
+        "required": [
+          "lon",
+          "lat",
+          "fulltext"
+        ]
+      }
+    }
+  },
+  "required": [
+    "results"
+  ]
+}
+```
+
+</details>
+
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
+
+## `altitude`
+
+Code Source : [src/tools/AltitudeTool.ts](../src/tools/AltitudeTool.ts)
+
+### Titre
+
+Altitude d'une position
+
+### Description du tool
+
+```
+Renvoie l'altitude (en mètres) et la précision de la mesure (accuracy) d'un point géographique à partir de sa longitude et de sa latitude. (source : Géoplateforme (altimétrie)).
+```
+
+### Schéma d’entrée
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `lat` | number | oui | La latitude du point. |
+| `lon` | number | oui | La longitude du point. |
+
+<details>
+<summary>Schéma d’entrée brut</summary>
 
 ```json
 {
@@ -106,14 +229,119 @@ Title: Unités administratives
 
 </details>
 
-### Output Schema
+### Schéma de sortie
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `results` | array | yes | La liste des unités administratives couvrant le point demandé. |
+| `accuracy` | string | oui | L'information de précision associée à l'altitude. |
+| `altitude` | number | oui | L'altitude du point. |
+| `lat` | number | oui | La latitude du point. |
+| `lon` | number | oui | La longitude du point. |
 
 <details>
-<summary>Raw output schema</summary>
+<summary>Schéma de sortie brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "type": "number",
+      "description": "La longitude du point."
+    },
+    "lat": {
+      "type": "number",
+      "description": "La latitude du point."
+    },
+    "altitude": {
+      "type": "number",
+      "description": "L'altitude du point."
+    },
+    "accuracy": {
+      "type": "string",
+      "description": "L'information de précision associée à l'altitude."
+    }
+  },
+  "required": [
+    "lon",
+    "lat",
+    "altitude",
+    "accuracy"
+  ]
+}
+```
+
+</details>
+
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
+
+## `adminexpress`
+
+Code Source : [src/tools/AdminexpressTool.ts](../src/tools/AdminexpressTool.ts)
+
+### Titre
+
+Unités administratives
+
+### Description du tool
+
+```
+Renvoie, pour un point donné par sa `longitude` et sa `latitude`, la liste des unités administratives (arrondissement, arrondissement_municipal, canton, collectivite_territoriale, commune, commune_associee_ou_deleguee, departement, epci, region) qui le couvrent, sous forme d'objets typés contenant leurs propriétés administratives.
+Les résultats incluent un `feature_ref` WFS réutilisable. Les propriétés incluent notamment le code INSEE.
+Le `feature_ref` de chaque unité administrative est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator="intersects_feature"` pour interroger d'autres données sur cette emprise.
+Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
+(source : Géoplateforme (WFS, ADMINEXPRESS-COG.LATEST)).
+```
+
+### Schéma d’entrée
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `lat` | number | oui | La latitude du point. |
+| `lon` | number | oui | La longitude du point. |
+
+<details>
+<summary>Schéma d’entrée brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "type": "number",
+      "description": "La longitude du point.",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "lat": {
+      "type": "number",
+      "description": "La latitude du point.",
+      "minimum": -90,
+      "maximum": 90
+    }
+  },
+  "required": [
+    "lon",
+    "lat"
+  ]
+}
+```
+
+</details>
+
+### Schéma de sortie
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `results` | array | oui | La liste des unités administratives couvrant le point demandé. |
+
+<details>
+<summary>Schéma de sortie brut</summary>
 
 ```json
 {
@@ -175,243 +403,41 @@ Title: Unités administratives
 
 </details>
 
-## `altitude`
+### Réponse MCP
 
-Source: [src/tools/AltitudeTool.ts](../src/tools/AltitudeTool.ts)
-
-Title: Altitude d'une position
-
-### Description du tool
-
-Renvoie l'altitude (en mètres) et la précision de la mesure (accuracy) d'un point géographique à partir de sa longitude et de sa latitude. (source : Géoplateforme (altimétrie)).
-
-### Input Schema
-
-| Field | Type | Required | Description |
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
 | --- | --- | --- | --- |
-| `lat` | number | yes | La latitude du point. |
-| `lon` | number | yes | La longitude du point. |
-
-<details>
-<summary>Raw input schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "lon": {
-      "type": "number",
-      "description": "La longitude du point.",
-      "minimum": -180,
-      "maximum": 180
-    },
-    "lat": {
-      "type": "number",
-      "description": "La latitude du point.",
-      "minimum": -90,
-      "maximum": 90
-    }
-  },
-  "required": [
-    "lon",
-    "lat"
-  ]
-}
-```
-
-</details>
-
-### Output Schema
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `accuracy` | string | yes | L'information de précision associée à l'altitude. |
-| `altitude` | number | yes | L'altitude du point. |
-| `lat` | number | yes | La latitude du point. |
-| `lon` | number | yes | La longitude du point. |
-
-<details>
-<summary>Raw output schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "lon": {
-      "type": "number",
-      "description": "La longitude du point."
-    },
-    "lat": {
-      "type": "number",
-      "description": "La latitude du point."
-    },
-    "altitude": {
-      "type": "number",
-      "description": "L'altitude du point."
-    },
-    "accuracy": {
-      "type": "string",
-      "description": "L'information de précision associée à l'altitude."
-    }
-  },
-  "required": [
-    "lon",
-    "lat",
-    "altitude",
-    "accuracy"
-  ]
-}
-```
-
-</details>
-
-## `assiette_sup`
-
-Source: [src/tools/AssietteSupTool.ts](../src/tools/AssietteSupTool.ts)
-
-Title: Servitudes d’utilité publique
-
-### Description du tool
-
-- Renvoie, pour un point donné par sa longitude et sa latitude, la liste des assiettes de servitudes d'utilité publique (SUP) pertinentes à proximité, avec leurs propriétés associées.
-- Une SUP est une contrainte légale sur l'usage du sol liée à un équipement ou une infrastructure publique (ex : AC pour patrimoine, EL pour voirie, PT pour télécoms, I pour installations classées...).
-- Les résultats peuvent inclure des assiettes ponctuelles, linéaires ou surfaciques et exposent un `feature_ref` WFS réutilisable quand il est disponible.
-- Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
-- (source : Géoplateforme - (WFS Géoportail de l'Urbanisme)).
-
-### Input Schema
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `lat` | number | yes | La latitude du point. |
-| `lon` | number | yes | La longitude du point. |
-
-<details>
-<summary>Raw input schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "lon": {
-      "type": "number",
-      "description": "La longitude du point.",
-      "minimum": -180,
-      "maximum": 180
-    },
-    "lat": {
-      "type": "number",
-      "description": "La latitude du point.",
-      "minimum": -90,
-      "maximum": 90
-    }
-  },
-  "required": [
-    "lon",
-    "lat"
-  ]
-}
-```
-
-</details>
-
-### Output Schema
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `results` | array | yes | La liste des assiettes de servitudes d'utilité publique pertinentes pour le point demandé. |
-
-<details>
-<summary>Raw output schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "results": {
-      "type": "array",
-      "description": "La liste des assiettes de servitudes d'utilité publique pertinentes pour le point demandé.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Le type d'assiette de servitude d'utilité publique renvoyé."
-          },
-          "id": {
-            "type": "string",
-            "description": "L'identifiant de l'assiette."
-          },
-          "bbox": {
-            "type": "array",
-            "description": "La boîte englobante de l'assiette.",
-            "items": {
-              "type": "number"
-            }
-          },
-          "feature_ref": {
-            "type": "object",
-            "description": "Référence WFS réutilisable, notamment avec `gpf_wfs_get_features` et `spatial_operator = \"intersects_feature\"`.",
-            "properties": {
-              "typename": {
-                "type": "string",
-                "description": "Le `typename` WFS réutilisable pour une requête ultérieure."
-              },
-              "feature_id": {
-                "type": "string",
-                "description": "L'identifiant WFS réutilisable du feature."
-              }
-            },
-            "required": [
-              "typename",
-              "feature_id"
-            ]
-          },
-          "distance": {
-            "type": "number",
-            "description": "La distance en mètres entre le point demandé et l'assiette retenue."
-          }
-        },
-        "required": [
-          "type",
-          "id",
-          "distance"
-        ]
-      }
-    }
-  },
-  "required": [
-    "results"
-  ]
-}
-```
-
-</details>
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
 
 ## `cadastre`
 
-Source: [src/tools/CadastreTool.ts](../src/tools/CadastreTool.ts)
+Code Source : [src/tools/CadastreTool.ts](../src/tools/CadastreTool.ts)
 
-Title: Informations cadastrales
+### Titre
+
+Informations cadastrales
 
 ### Description du tool
 
-- Renvoie, pour un point donné par sa `longitude` et sa `latitude`, la liste des objets cadastraux (arrondissement, commune, feuille, parcelle, subdivision_fiscale, localisant) les plus proches, avec leurs informations associées.
-- Les résultats sont retournés au plus une fois par type lorsqu'ils sont disponibles et incluent un `feature_ref` WFS réutilisable.
-- Le `feature_ref` est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator="intersects_feature"`.
-- La distance de recherche est fixée à 10 mètres.  Si aucun objet n'est trouvé dans les 10 mètres, le résultat est vide.
-- Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
-- (source : Géoplateforme (WFS, CADASTRALPARCELS.PARCELLAIRE_EXPRESS)).
+```
+Renvoie, pour un point donné par sa `longitude` et sa `latitude`, la liste des objets cadastraux (arrondissement, commune, feuille, parcelle, subdivision_fiscale, localisant) les plus proches, avec leurs informations associées.
+Les résultats sont retournés au plus une fois par type lorsqu'ils sont disponibles et incluent un `feature_ref` WFS réutilisable.
+Le `feature_ref` est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator="intersects_feature"`.
+La distance de recherche est fixée à 10 mètres. Si aucun objet n'est trouvé dans les 10 mètres, le résultat est vide.
+Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
+(source : Géoplateforme (WFS, CADASTRALPARCELS.PARCELLAIRE_EXPRESS)).
+```
 
-### Input Schema
+### Schéma d’entrée
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `lat` | number | yes | La latitude du point. |
-| `lon` | number | yes | La longitude du point. |
+| `lat` | number | oui | La latitude du point. |
+| `lon` | number | oui | La longitude du point. |
 
 <details>
-<summary>Raw input schema</summary>
+<summary>Schéma d’entrée brut</summary>
 
 ```json
 {
@@ -439,14 +465,14 @@ Title: Informations cadastrales
 
 </details>
 
-### Output Schema
+### Schéma de sortie
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `results` | array | yes | La liste des objets cadastraux les plus proches du point demandé. |
+| `results` | array | oui | La liste des objets cadastraux les plus proches du point demandé. |
 
 <details>
-<summary>Raw output schema</summary>
+<summary>Schéma de sortie brut</summary>
 
 ```json
 {
@@ -518,60 +544,79 @@ Title: Informations cadastrales
 
 </details>
 
-## `geocode`
+### Réponse MCP
 
-Source: [src/tools/GeocodeTool.ts](../src/tools/GeocodeTool.ts)
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
 
-Title: Géocodage de lieux et d’adresses
+## `urbanisme`
+
+Code Source : [src/tools/UrbanismeTool.ts](../src/tools/UrbanismeTool.ts)
+
+### Titre
+
+Informations d’urbanisme
 
 ### Description du tool
 
-- Renvoie des résultats d'autocomplétion géocodés à partir d'un texte libre (lieu, adresse, POI), avec coordonnées, libellé complet et informations de localisation (`kind`, `city`, `zipcode`).
-- Les coordonnées `lon/lat` retournées sont directement réutilisables dans tous les autres tools. Le champ `kind` indique le type de résultat (ex : `monument`, `street`, `city`, `locality`).
-- (source : Géoplateforme (service d'autocomplétion)).
+```
+Renvoie, pour un point donné par sa `longitude` et sa `latitude`, la liste des objets d'urbanisme pertinents du Géoportail de l'Urbanisme (document, zones, prescriptions, informations, etc.), avec leurs propriétés associées. (source : Géoplateforme - (WFS Géoportail de l'Urbanisme)).
+Les résultats peuvent notamment inclure le document d'urbanisme applicable ainsi que des éléments réglementaires associés à proximité du point.
+Quand un objet correspond à une couche WFS réutilisable, il expose aussi un `feature_ref` compatible avec `gpf_wfs_get_features` et `spatial_operator="intersects_feature"`.
+Le zonage PLU (zone U, AU, A, N...) est inclus dans les zones retournées et constitue souvent l'information principale recherchée.
+Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
+Modèles d'URL Géoportail de l'Urbanisme :
+- fiche document: https://www.geoportail-urbanisme.gouv.fr/document/by-id/{gpu_doc_id}
+- carte: https://www.geoportail-urbanisme.gouv.fr/map/?documentId={gpu_doc_id}
+- fichier: https://www.geoportail-urbanisme.gouv.fr/api/document/{gpu_doc_id}/files/{nomfic}
+```
 
-### Input Schema
+### Schéma d’entrée
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `maximumResponses` | integer | no | Le nombre maximum de résultats à retourner (entre 1 et 10). Défaut : 3. |
-| `text` | string | yes | Le texte devant être completé et géocodé |
+| `lat` | number | oui | La latitude du point. |
+| `lon` | number | oui | La longitude du point. |
 
 <details>
-<summary>Raw input schema</summary>
+<summary>Schéma d’entrée brut</summary>
 
 ```json
 {
   "type": "object",
   "properties": {
-    "text": {
-      "type": "string",
-      "description": "Le texte devant être completé et géocodé",
-      "minLength": 1
+    "lon": {
+      "type": "number",
+      "description": "La longitude du point.",
+      "minimum": -180,
+      "maximum": 180
     },
-    "maximumResponses": {
-      "type": "integer",
-      "description": "Le nombre maximum de résultats à retourner (entre 1 et 10). Défaut : 3.",
-      "minimum": 1,
-      "maximum": 10
+    "lat": {
+      "type": "number",
+      "description": "La latitude du point.",
+      "minimum": -90,
+      "maximum": 90
     }
   },
   "required": [
-    "text"
+    "lon",
+    "lat"
   ]
 }
 ```
 
 </details>
 
-### Output Schema
+### Schéma de sortie
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `results` | array | yes | La liste ordonnée des résultats géocodés. |
+| `results` | array | oui | La liste des objets d'urbanisme pertinents pour le point demandé. |
 
 <details>
-<summary>Raw output schema</summary>
+<summary>Schéma de sortie brut</summary>
 
 ```json
 {
@@ -579,39 +624,52 @@ Title: Géocodage de lieux et d’adresses
   "properties": {
     "results": {
       "type": "array",
-      "description": "La liste ordonnée des résultats géocodés.",
+      "description": "La liste des objets d'urbanisme pertinents pour le point demandé.",
       "items": {
         "type": "object",
         "properties": {
-          "lon": {
+          "type": {
+            "type": "string",
+            "description": "Le type d'objet d'urbanisme renvoyé."
+          },
+          "id": {
+            "type": "string",
+            "description": "L'identifiant de l'objet d'urbanisme."
+          },
+          "bbox": {
+            "type": "array",
+            "description": "La boîte englobante de l'objet d'urbanisme.",
+            "items": {
+              "type": "number"
+            }
+          },
+          "feature_ref": {
+            "type": "object",
+            "description": "Référence WFS réutilisable, notamment avec `gpf_wfs_get_features` et `spatial_operator = \"intersects_feature\"`.",
+            "properties": {
+              "typename": {
+                "type": "string",
+                "description": "Le `typename` WFS réutilisable pour une requête ultérieure."
+              },
+              "feature_id": {
+                "type": "string",
+                "description": "L'identifiant WFS réutilisable du feature."
+              }
+            },
+            "required": [
+              "typename",
+              "feature_id"
+            ]
+          },
+          "distance": {
             "type": "number",
-            "description": "La longitude du résultat."
-          },
-          "lat": {
-            "type": "number",
-            "description": "La latitude du résultat."
-          },
-          "fulltext": {
-            "type": "string",
-            "description": "Le libellé complet du résultat."
-          },
-          "kind": {
-            "type": "string",
-            "description": "La nature du résultat géocodé."
-          },
-          "city": {
-            "type": "string",
-            "description": "La commune du résultat."
-          },
-          "zipcode": {
-            "type": "string",
-            "description": "Le code postal du résultat."
+            "description": "La distance en mètres entre le point demandé et l'objet d'urbanisme retenu."
           }
         },
         "required": [
-          "lon",
-          "lat",
-          "fulltext"
+          "type",
+          "id",
+          "distance"
         ]
       }
     }
@@ -624,27 +682,283 @@ Title: Géocodage de lieux et d’adresses
 
 </details>
 
-## `gpf_wfs_describe_type`
+### Réponse MCP
 
-Source: [src/tools/GpfWfsDescribeTypeTool.ts](../src/tools/GpfWfsDescribeTypeTool.ts)
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
 
-Title: Description d’un type WFS
+## `assiette_sup`
+
+Code Source : [src/tools/AssietteSupTool.ts](../src/tools/AssietteSupTool.ts)
+
+### Titre
+
+Servitudes d’utilité publique
 
 ### Description du tool
 
-- Renvoie le schéma détaillé d'un type WFS à partir de son identifiant (`typename`) : identifiants, description et liste des propriétés.
-- Utiliser ce tool après `gpf_wfs_search_types` pour inspecter les propriétés disponibles avant d'appeler `gpf_wfs_get_features`.
-- La sortie inclut notamment le type des propriétés, leur description, leurs valeurs possibles (`enum`) lorsqu'elles existent
-- **IMPORTANT: Appel fortement recommandé si les noms exacts des propriétés ne sont pas connus : un nom de propriété incorrect provoque une erreur**.
+```
+Renvoie, pour un point donné par sa longitude et sa latitude, la liste des assiettes de servitudes d'utilité publique (SUP) pertinentes à proximité, avec leurs propriétés associées.
+Une SUP est une contrainte légale sur l'usage du sol liée à un équipement ou une infrastructure publique (ex : AC pour patrimoine, EL pour voirie, PT pour télécoms, I pour installations classées...).
+Les résultats peuvent inclure des assiettes ponctuelles, linéaires ou surfaciques et exposent un `feature_ref` WFS réutilisable quand il est disponible.
+Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
+(source : Géoplateforme - (WFS Géoportail de l'Urbanisme)).
+```
 
-### Input Schema
+### Schéma d’entrée
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `typename` | string | yes | Le nom du type (ex : BDTOPO_V3:batiment) |
+| `lat` | number | oui | La latitude du point. |
+| `lon` | number | oui | La longitude du point. |
 
 <details>
-<summary>Raw input schema</summary>
+<summary>Schéma d’entrée brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "lon": {
+      "type": "number",
+      "description": "La longitude du point.",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "lat": {
+      "type": "number",
+      "description": "La latitude du point.",
+      "minimum": -90,
+      "maximum": 90
+    }
+  },
+  "required": [
+    "lon",
+    "lat"
+  ]
+}
+```
+
+</details>
+
+### Schéma de sortie
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `results` | array | oui | La liste des assiettes de servitudes d'utilité publique pertinentes pour le point demandé. |
+
+<details>
+<summary>Schéma de sortie brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "description": "La liste des assiettes de servitudes d'utilité publique pertinentes pour le point demandé.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Le type d'assiette de servitude d'utilité publique renvoyé."
+          },
+          "id": {
+            "type": "string",
+            "description": "L'identifiant de l'assiette."
+          },
+          "bbox": {
+            "type": "array",
+            "description": "La boîte englobante de l'assiette.",
+            "items": {
+              "type": "number"
+            }
+          },
+          "feature_ref": {
+            "type": "object",
+            "description": "Référence WFS réutilisable, notamment avec `gpf_wfs_get_features` et `spatial_operator = \"intersects_feature\"`.",
+            "properties": {
+              "typename": {
+                "type": "string",
+                "description": "Le `typename` WFS réutilisable pour une requête ultérieure."
+              },
+              "feature_id": {
+                "type": "string",
+                "description": "L'identifiant WFS réutilisable du feature."
+              }
+            },
+            "required": [
+              "typename",
+              "feature_id"
+            ]
+          },
+          "distance": {
+            "type": "number",
+            "description": "La distance en mètres entre le point demandé et l'assiette retenue."
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "distance"
+        ]
+      }
+    }
+  },
+  "required": [
+    "results"
+  ]
+}
+```
+
+</details>
+
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
+
+## `gpf_wfs_search_types`
+
+Code Source : [src/tools/GpfWfsSearchTypesTool.ts](../src/tools/GpfWfsSearchTypesTool.ts)
+
+### Titre
+
+Recherche de types WFS
+
+### Description du tool
+
+```
+Recherche des types WFS de la Géoplateforme (GPF) à partir de mots-clés afin de trouver un identifiant de type (`typename`) valide.
+La recherche est textuelle (mini-search) et retourne une liste ordonnée de candidats avec leur identifiant, leur titre, leur description et un score de pertinence éventuel.
+Le paramètre `max_results` permet d'élargir le nombre de candidats retournés (10 par défaut).
+**Important** : Utiliser ce tool avant `gpf_wfs_describe_type` ou `gpf_wfs_get_features` lorsque le nom exact du type n'est pas connu.
+**Important** : Privilégier des termes métier en français pour la recherche.
+```
+
+### Schéma d’entrée
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `max_results` | integer | non | Le nombre maximum de résultats à retourner (entre 1 et 50). Défaut : 10. |
+| `query` | string | oui | La requête de recherche |
+
+<details>
+<summary>Schéma d’entrée brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "La requête de recherche",
+      "minLength": 1
+    },
+    "max_results": {
+      "type": "integer",
+      "description": "Le nombre maximum de résultats à retourner (entre 1 et 50). Défaut : 10.",
+      "minimum": 1,
+      "maximum": 50
+    }
+  },
+  "required": [
+    "query"
+  ]
+}
+```
+
+</details>
+
+### Schéma de sortie
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `results` | array | oui | La liste ordonnée des types WFS trouvés. |
+
+<details>
+<summary>Schéma de sortie brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "description": "La liste ordonnée des types WFS trouvés.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "L'identifiant complet du type WFS."
+          },
+          "title": {
+            "type": "string",
+            "description": "Le titre lisible du type WFS."
+          },
+          "description": {
+            "type": "string",
+            "description": "La description du type WFS."
+          },
+          "score": {
+            "type": "number",
+            "description": "Le score de pertinence de la recherche."
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "description"
+        ]
+      }
+    }
+  },
+  "required": [
+    "results"
+  ]
+}
+```
+
+</details>
+
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
+
+## `gpf_wfs_describe_type`
+
+Code Source : [src/tools/GpfWfsDescribeTypeTool.ts](../src/tools/GpfWfsDescribeTypeTool.ts)
+
+### Titre
+
+Description d’un type WFS
+
+### Description du tool
+
+```
+Renvoie le schéma détaillé d'un type WFS à partir de son identifiant (`typename`) : identifiants, description et liste des propriétés.
+Utiliser ce tool après `gpf_wfs_search_types` pour inspecter les propriétés disponibles avant d'appeler `gpf_wfs_get_features`.
+La sortie inclut notamment le type des propriétés, leur description, leurs valeurs possibles (`enum`) lorsqu'elles existent
+**IMPORTANT : Appel fortement recommandé si les noms exacts des propriétés ne sont pas connus : un nom de propriété incorrect provoque une erreur**.
+```
+
+### Schéma d’entrée
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `typename` | string | oui | Le nom du type (ex : BDTOPO_V3:batiment) |
+
+<details>
+<summary>Schéma d’entrée brut</summary>
 
 ```json
 {
@@ -664,19 +978,19 @@ Title: Description d’un type WFS
 
 </details>
 
-### Output Schema
+### Schéma de sortie
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `description` | string | yes | La description du type WFS. |
-| `id` | string | yes | L'identifiant complet du type WFS. |
-| `name` | string | yes | Le nom court du type WFS. |
-| `namespace` | string | yes | L'espace de nommage du type WFS. |
-| `properties` | array | yes | La liste des propriétés du type WFS. |
-| `title` | string | yes | Le titre lisible du type WFS. |
+| `description` | string | oui | La description du type WFS. |
+| `id` | string | oui | L'identifiant complet du type WFS. |
+| `name` | string | oui | Le nom court du type WFS. |
+| `namespace` | string | oui | L'espace de nommage du type WFS. |
+| `properties` | array | oui | La liste des propriétés du type WFS. |
+| `title` | string | oui | Le titre lisible du type WFS. |
 
 <details>
-<summary>Raw output schema</summary>
+<summary>Schéma de sortie brut</summary>
 
 ```json
 {
@@ -756,30 +1070,41 @@ Title: Description d’un type WFS
 
 </details>
 
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
+
 ## `gpf_wfs_get_feature_by_id`
 
-Source: [src/tools/GpfWfsGetFeatureByIdTool.ts](../src/tools/GpfWfsGetFeatureByIdTool.ts)
+Code Source : [src/tools/GpfWfsGetFeatureByIdTool.ts](../src/tools/GpfWfsGetFeatureByIdTool.ts)
 
-Title: Lecture d’un objet WFS par identifiant
+### Titre
+
+Lecture d’un objet WFS par identifiant
 
 ### Description du tool
 
-- Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.
-- Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).
-- Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.
-- Utiliser `result_type="request"` pour récupérer la requête WFS compilée (avec `get_url`) et l'utiliser ou la visualiser ailleurs.
+```
+Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.
+Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).
+Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.
+Utiliser `result_type="request"` pour récupérer la requête WFS compilée (avec `get_url`) et l'utiliser ou la visualiser ailleurs.
+```
 
-### Input Schema
+### Schéma d’entrée
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `feature_id` | string | yes | Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`. |
-| `result_type` | string | no | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer. Values: results, request. Default: results. |
-| `select` | array | no | Liste des propriétés non géométriques à renvoyer. Quand `result_type="request"`, la géométrie est automatiquement ajoutée. |
-| `typename` | string | yes | Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
+| `feature_id` | string | oui | Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer. Valeurs : results, request. Valeur par défaut : results. |
+| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Quand `result_type="request"`, la géométrie est automatiquement ajoutée. |
+| `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
 
 <details>
-<summary>Raw input schema</summary>
+<summary>Schéma d’entrée brut</summary>
 
 ```json
 {
@@ -825,54 +1150,66 @@ Title: Lecture d’un objet WFS par identifiant
 
 </details>
 
-### Output
+### Sortie
 
-No single `outputSchema` is exposed. Output depends on `result_type` (`results`, `request`).
+Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`results`, `request`).
+
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès `result_type="results"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Succès `result_type="request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
 
 ## `gpf_wfs_get_features`
 
-Source: [src/tools/GpfWfsGetFeaturesTool.ts](../src/tools/GpfWfsGetFeaturesTool.ts)
+Code Source : [src/tools/GpfWfsGetFeaturesTool.ts](../src/tools/GpfWfsGetFeaturesTool.ts)
 
-Title: Lecture d’objets WFS
+### Titre
+
+Lecture d’objets WFS
 
 ### Description du tool
 
-- Interroge un type WFS et renvoie des résultats structurés sans demander au modèle d'écrire du CQL ou du WFS.
-- Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et `spatial_operator` avec ses paramètres dédiés pour le spatial. Avec `result_type="request"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.
-- Exemple attributaire : `where=[{ property: "code_insee", operator: "eq", value: "75056" }]`.
-- Exemple bbox : `spatial_operator="bbox"` avec `bbox_west`, `bbox_south`, `bbox_east`, `bbox_north` en `lon/lat`.
-- Exemple point dans géométrie : `spatial_operator="intersects_point"` avec `intersects_lon` et `intersects_lat`.
-- Exemple distance : `spatial_operator="dwithin_point"` avec `dwithin_lon`, `dwithin_lat`, `dwithin_distance_m`.
-- Exemple réutilisation : `spatial_operator="intersects_feature"` avec `intersects_feature_typename` et `intersects_feature_id` issus d'une `feature_ref`.
-- ⚠️ Quand `typename` et `intersects_feature_typename` sont identiques, utiliser `gpf_wfs_get_feature_by_id` pour récupérer exactement l'objet ciblé.
-- **OBLIGATOIRE : toujours appeler `gpf_wfs_describe_type` avant ce tool, sauf si `gpf_wfs_describe_type` a déjà été appelé pour ce même typename dans la conversation en cours.**
-- Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiques à chaque typename et diffèrent systématiquement des conventions habituelles (ex : pas de nom_officiel, navigabilite sans accent, etc.). Toute tentative sans appel préalable à `gpf_wfs_describe_type` **provoquera une erreur.**
+```
+Interroge un type WFS et renvoie des résultats structurés sans demander au modèle d'écrire du CQL ou du WFS.
+Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et `spatial_operator` avec ses paramètres dédiés pour le spatial. Avec `result_type="request"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.
+Exemple attributaire : `where=[{ property: "code_insee", operator: "eq", value: "75056" }]`.
+Exemple bbox : `spatial_operator="bbox"` avec `bbox_west`, `bbox_south`, `bbox_east`, `bbox_north` en `lon/lat`.
+Exemple point dans géométrie : `spatial_operator="intersects_point"` avec `intersects_lon` et `intersects_lat`.
+Exemple distance : `spatial_operator="dwithin_point"` avec `dwithin_lon`, `dwithin_lat`, `dwithin_distance_m`.
+Exemple réutilisation : `spatial_operator="intersects_feature"` avec `intersects_feature_typename` et `intersects_feature_id` issus d'une `feature_ref`.
+⚠️ Quand `typename` et `intersects_feature_typename` sont identiques, utiliser `gpf_wfs_get_feature_by_id` pour récupérer exactement l'objet ciblé.
+**OBLIGATOIRE : toujours appeler `gpf_wfs_describe_type` avant ce tool, sauf si `gpf_wfs_describe_type` a déjà été appelé pour ce même typename dans la conversation en cours.**
+Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiques à chaque typename et diffèrent systématiquement des conventions habituelles (ex : pas de nom_officiel, navigabilite sans accent, etc.). Toute tentative sans appel préalable à `gpf_wfs_describe_type` **provoquera une erreur.**
+```
 
-### Input Schema
+### Schéma d’entrée
 
-| Field | Type | Required | Description |
+| Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `bbox_east` | number | no | Longitude est en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
-| `bbox_north` | number | no | Latitude nord en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
-| `bbox_south` | number | no | Latitude sud en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
-| `bbox_west` | number | no | Longitude ouest en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
-| `dwithin_distance_m` | number | no | Distance en mètres, utilisée avec `spatial_operator = "dwithin_point"`. |
-| `dwithin_lat` | number | no | Latitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "dwithin_point"`. |
-| `dwithin_lon` | number | no | Longitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "dwithin_point"`. |
-| `intersects_feature_id` | string | no | Identifiant du feature de référence, utilisé avec `spatial_operator = "intersects_feature"`. |
-| `intersects_feature_typename` | string | no | Type WFS du feature de référence, utilisé avec `spatial_operator = "intersects_feature"`. |
-| `intersects_lat` | number | no | Latitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "intersects_point"`. |
-| `intersects_lon` | number | no | Longitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "intersects_point"`. |
-| `limit` | integer | no | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Default: 100. |
-| `order_by` | array | no | Liste ordonnée des critères de tri. |
-| `result_type` | string | no | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `request` renvoie l'URL WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer la requête générée. **La géométrie est automatiquement ajoutée aux propriétés du `select`** pour garantir l'affichage cartographique. Values: results, hits, request. Default: results. |
-| `select` | array | no | Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
-| `spatial_operator` | string | no | Type optionnel de filtre spatial. Values: bbox, intersects_point, dwithin_point, intersects_feature. |
-| `typename` | string | yes | Nom exact du type WFS à interroger, par exemple `BDTOPO_V3:batiment`. Utiliser `gpf_wfs_search_types` pour trouver un `typename` valide. |
-| `where` | array | no | Clauses de filtre attributaire, combinées avec `AND`. |
+| `bbox_east` | number | non | Longitude est en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
+| `bbox_north` | number | non | Latitude nord en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
+| `bbox_south` | number | non | Latitude sud en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
+| `bbox_west` | number | non | Longitude ouest en WGS84 `lon/lat`, utilisée avec `spatial_operator = "bbox"`. |
+| `dwithin_distance_m` | number | non | Distance en mètres, utilisée avec `spatial_operator = "dwithin_point"`. |
+| `dwithin_lat` | number | non | Latitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "dwithin_point"`. |
+| `dwithin_lon` | number | non | Longitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "dwithin_point"`. |
+| `intersects_feature_id` | string | non | Identifiant du feature de référence, utilisé avec `spatial_operator = "intersects_feature"`. |
+| `intersects_feature_typename` | string | non | Type WFS du feature de référence, utilisé avec `spatial_operator = "intersects_feature"`. |
+| `intersects_lat` | number | non | Latitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "intersects_point"`. |
+| `intersects_lon` | number | non | Longitude du point en WGS84 `lon/lat`, utilisée avec `spatial_operator = "intersects_point"`. |
+| `limit` | integer | non | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Valeur par défaut : 100. |
+| `order_by` | array | non | Liste ordonnée des critères de tri. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `request` renvoie l'URL WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer la requête générée. **La géométrie est automatiquement ajoutée aux propriétés du `select`** pour garantir l'affichage cartographique. Valeurs : results, hits, request. Valeur par défaut : results. |
+| `select` | array | non | Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
+| `spatial_operator` | string (enum) | non | Type optionnel de filtre spatial. Valeurs : bbox, intersects_point, dwithin_point, intersects_feature. |
+| `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `BDTOPO_V3:batiment`. Utiliser `gpf_wfs_search_types` pour trouver un `typename` valide. |
+| `where` | array | non | Clauses de filtre attributaire, combinées avec `AND`. |
 
 <details>
-<summary>Raw input schema</summary>
+<summary>Schéma d’entrée brut</summary>
 
 ```json
 {
@@ -1069,233 +1406,15 @@ Title: Lecture d’objets WFS
 
 </details>
 
-### Output
+### Sortie
 
-No single `outputSchema` is exposed. Output depends on `result_type` (`results`, `hits`, `request`).
+Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`results`, `hits`, `request`).
 
-## `gpf_wfs_search_types`
+### Réponse MCP
 
-Source: [src/tools/GpfWfsSearchTypesTool.ts](../src/tools/GpfWfsSearchTypesTool.ts)
-
-Title: Recherche de types WFS
-
-### Description du tool
-
-- Recherche des types WFS de la Géoplateforme (GPF) à partir de mots-clés afin de trouver un identifiant de type (`typename`) valide.
-- La recherche est textuelle (mini-search) et retourne une liste ordonnée de candidats avec leur identifiant, leur titre, leur description et un score de pertinence éventuel.
-- Le paramètre `max_results` permet d'élargir le nombre de candidats retournés (10 par défaut).
-- **Important** : Utiliser ce tool avant `gpf_wfs_describe_type` ou `gpf_wfs_get_features` lorsque le nom exact du type n'est pas connu.
-- **Important** : Privilégier des termes métier en français pour la recherche.
-
-### Input Schema
-
-| Field | Type | Required | Description |
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
 | --- | --- | --- | --- |
-| `max_results` | integer | no | Le nombre maximum de résultats à retourner (entre 1 et 50). Défaut : 10. |
-| `query` | string | yes | La requête de recherche |
-
-<details>
-<summary>Raw input schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "query": {
-      "type": "string",
-      "description": "La requête de recherche",
-      "minLength": 1
-    },
-    "max_results": {
-      "type": "integer",
-      "description": "Le nombre maximum de résultats à retourner (entre 1 et 50). Défaut : 10.",
-      "minimum": 1,
-      "maximum": 50
-    }
-  },
-  "required": [
-    "query"
-  ]
-}
-```
-
-</details>
-
-### Output Schema
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `results` | array | yes | La liste ordonnée des types WFS trouvés. |
-
-<details>
-<summary>Raw output schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "results": {
-      "type": "array",
-      "description": "La liste ordonnée des types WFS trouvés.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "L'identifiant complet du type WFS."
-          },
-          "title": {
-            "type": "string",
-            "description": "Le titre lisible du type WFS."
-          },
-          "description": {
-            "type": "string",
-            "description": "La description du type WFS."
-          },
-          "score": {
-            "type": "number",
-            "description": "Le score de pertinence de la recherche."
-          }
-        },
-        "required": [
-          "id",
-          "title",
-          "description"
-        ]
-      }
-    }
-  },
-  "required": [
-    "results"
-  ]
-}
-```
-
-</details>
-
-## `urbanisme`
-
-Source: [src/tools/UrbanismeTool.ts](../src/tools/UrbanismeTool.ts)
-
-Title: Informations d’urbanisme
-
-### Description du tool
-
-- Renvoie, pour un point donné par sa `longitude` et sa `latitude`, la liste des objets d'urbanisme pertinents du Géoportail de l'Urbanisme (document, zones, prescriptions, informations, etc.), avec leurs propriétés associées. (source : Géoplateforme - (WFS Géoportail de l'Urbanisme)).
-- Les résultats peuvent notamment inclure le document d'urbanisme applicable ainsi que des éléments réglementaires associés à proximité du point.
-- Quand un objet correspond à une couche WFS réutilisable, il expose aussi un `feature_ref` compatible avec `gpf_wfs_get_features` et `spatial_operator="intersects_feature"`.
-- Le zonage PLU (zone U, AU, A, N...) est inclus dans les zones retournées et constitue souvent l'information principale recherchée.
-- Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.
-- Modèles d'URL Géoportail de l'Urbanisme :
-- - fiche document: https://www.geoportail-urbanisme.gouv.fr/document/by-id/{gpu_doc_id}
-- - carte: https://www.geoportail-urbanisme.gouv.fr/map/?documentId={gpu_doc_id}
-- - fichier: https://www.geoportail-urbanisme.gouv.fr/api/document/{gpu_doc_id}/files/{nomfic}
-
-### Input Schema
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `lat` | number | yes | La latitude du point. |
-| `lon` | number | yes | La longitude du point. |
-
-<details>
-<summary>Raw input schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "lon": {
-      "type": "number",
-      "description": "La longitude du point.",
-      "minimum": -180,
-      "maximum": 180
-    },
-    "lat": {
-      "type": "number",
-      "description": "La latitude du point.",
-      "minimum": -90,
-      "maximum": 90
-    }
-  },
-  "required": [
-    "lon",
-    "lat"
-  ]
-}
-```
-
-</details>
-
-### Output Schema
-
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `results` | array | yes | La liste des objets d'urbanisme pertinents pour le point demandé. |
-
-<details>
-<summary>Raw output schema</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "results": {
-      "type": "array",
-      "description": "La liste des objets d'urbanisme pertinents pour le point demandé.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Le type d'objet d'urbanisme renvoyé."
-          },
-          "id": {
-            "type": "string",
-            "description": "L'identifiant de l'objet d'urbanisme."
-          },
-          "bbox": {
-            "type": "array",
-            "description": "La boîte englobante de l'objet d'urbanisme.",
-            "items": {
-              "type": "number"
-            }
-          },
-          "feature_ref": {
-            "type": "object",
-            "description": "Référence WFS réutilisable, notamment avec `gpf_wfs_get_features` et `spatial_operator = \"intersects_feature\"`.",
-            "properties": {
-              "typename": {
-                "type": "string",
-                "description": "Le `typename` WFS réutilisable pour une requête ultérieure."
-              },
-              "feature_id": {
-                "type": "string",
-                "description": "L'identifiant WFS réutilisable du feature."
-              }
-            },
-            "required": [
-              "typename",
-              "feature_id"
-            ]
-          },
-          "distance": {
-            "type": "number",
-            "description": "La distance en mètres entre le point demandé et l'objet d'urbanisme retenu."
-          }
-        },
-        "required": [
-          "type",
-          "id",
-          "distance"
-        ]
-      }
-    }
-  },
-  "required": [
-    "results"
-  ]
-}
-```
-
-</details>
+| Succès `result_type="results"` | oui | non | `content[0].text` est la FeatureCollection stringifiée ; aucun `structuredContent` n'est ajouté dans ce mode. |
+| Succès `result_type="hits"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Succès `result_type="request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |

--- a/scripts/generate-mcp-docs.mjs
+++ b/scripts/generate-mcp-docs.mjs
@@ -9,6 +9,18 @@ const repoRoot = resolve(__dirname, "..");
 const compiledToolsDir = join(repoRoot, "dist", "tools");
 const outputPath = join(repoRoot, "docs", "mcp-tools.md");
 const miniSearchOptionsEnv = "GPF_WFS_MINISEARCH_OPTIONS";
+const toolDisplayOrder = [
+  "geocode",
+  "altitude",
+  "adminexpress",
+  "cadastre",
+  "urbanisme",
+  "assiette_sup",
+  "gpf_wfs_search_types",
+  "gpf_wfs_describe_type",
+  "gpf_wfs_get_feature_by_id",
+  "gpf_wfs_get_features",
+];
 
 /**
  * @typedef {object} JsonSchema
@@ -29,6 +41,7 @@ const miniSearchOptionsEnv = "GPF_WFS_MINISEARCH_OPTIONS";
  * @property {string} name
  * @property {string=} title
  * @property {string=} description
+ * @property {Record<string, boolean>=} annotations
  * @property {JsonSchema=} inputSchema
  * @property {JsonSchema=} outputSchema
  */
@@ -54,19 +67,18 @@ function escapeCell(value) {
  */
 export function renderDescription(description) {
   if (!description || description.trim() === "") {
-    return "_No description provided._";
+    return "_Aucune description fournie._";
   }
 
-  const lines = description
+  const normalizedDescription = description
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+    .filter((line) => line.length > 0)
+    .join("\n");
 
-  if (lines.length <= 1) {
-    return lines[0] ?? "_No description provided._";
-  }
-
-  return lines.map((line) => `- ${line}`).join("\n");
+  return normalizedDescription
+    ? `\`\`\`\n${normalizedDescription}\n\`\`\``
+    : "_Aucune description fournie._";
 }
 
 /**
@@ -93,10 +105,11 @@ export function schemaType(schema) {
     return "";
   }
   if (Array.isArray(schema.type)) {
-    return schema.type.join(" | ");
+    const type = schema.type.join(" | ");
+    return schema.enum?.length ? `${type} (enum)` : type;
   }
   if (schema.type) {
-    return schema.type;
+    return schema.enum?.length ? `${schema.type} (enum)` : schema.type;
   }
   if (schema.enum?.length) {
     return "enum";
@@ -120,7 +133,7 @@ export function schemaType(schema) {
 export function renderPropertyTable(schema) {
   const properties = schema?.properties;
   if (!properties || Object.keys(properties).length === 0) {
-    return "_No top-level properties documented._";
+    return "_Aucune propriété de premier niveau documentée._";
   }
 
   const required = new Set(schema?.required ?? []);
@@ -129,19 +142,19 @@ export function renderPropertyTable(schema) {
     .map(([name, propertySchema]) => {
       const type = schemaType(propertySchema);
       const enumValues = propertySchema.enum?.length
-        ? ` Values: ${propertySchema.enum.map(formatInline).join(", ")}.`
+        ? ` Valeurs : ${propertySchema.enum.map(formatInline).join(", ")}.`
         : "";
       const defaultValue =
         propertySchema.default !== undefined
-          ? ` Default: ${formatInline(propertySchema.default)}.`
+          ? ` Valeur par défaut : ${formatInline(propertySchema.default)}.`
           : "";
       const description = `${propertySchema.description ?? ""}${enumValues}${defaultValue}`.trim();
 
-      return `| \`${escapeCell(name)}\` | ${escapeCell(type || " ")} | ${required.has(name) ? "yes" : "no"} | ${escapeCell(description || " ")} |`;
+      return `| \`${escapeCell(name)}\` | ${escapeCell(type || " ")} | ${required.has(name) ? "oui" : "non"} | ${escapeCell(description || " ")} |`;
     });
 
   return [
-    "| Field | Type | Required | Description |",
+    "| Champ | Type | Requis | Description |",
     "| --- | --- | --- | --- |",
     ...rows,
   ].join("\n");
@@ -153,10 +166,97 @@ export function renderPropertyTable(schema) {
  */
 export function renderSchemaBlock(schema) {
   if (!schema) {
-    return "_No JSON Schema exposed by this tool definition._";
+    return "_Aucun JSON Schema exposé par cette définition de tool._";
   }
 
   return `\`\`\`json\n${JSON.stringify(schema, null, 2)}\n\`\`\``;
+}
+
+function renderResponseContractTable(rows) {
+  return [
+    "| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |",
+    "| --- | --- | --- | --- |",
+    ...rows.map((row) => `| ${row.caseName} | ${row.content} | ${row.structuredContent} | ${row.relation} |`),
+  ].join("\n");
+}
+
+/**
+ * @param {ToolDefinition} definition
+ * @returns {string}
+ */
+export function renderResponseContractSection(definition) {
+  const errorRow = {
+    caseName: "Erreur",
+    content: "oui",
+    structuredContent: "oui",
+    relation: "`content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`.",
+  };
+
+  if (definition.name === "gpf_wfs_get_features") {
+    return [
+      "### Réponse MCP",
+      "",
+      renderResponseContractTable([
+        {
+          caseName: 'Succès `result_type="results"`',
+          content: "oui",
+          structuredContent: "non",
+          relation: "`content[0].text` est la FeatureCollection stringifiée ; aucun `structuredContent` n'est ajouté dans ce mode.",
+        },
+        {
+          caseName: 'Succès `result_type="hits"`',
+          content: "oui",
+          structuredContent: "oui",
+          relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
+        },
+        {
+          caseName: 'Succès `result_type="request"`',
+          content: "oui",
+          structuredContent: "oui",
+          relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
+        },
+        errorRow,
+      ]),
+    ].join("\n");
+  }
+
+  if (definition.name === "gpf_wfs_get_feature_by_id") {
+    return [
+      "### Réponse MCP",
+      "",
+      renderResponseContractTable([
+        {
+          caseName: 'Succès `result_type="results"`',
+          content: "oui",
+          structuredContent: "oui",
+          relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
+        },
+        {
+          caseName: 'Succès `result_type="request"`',
+          content: "oui",
+          structuredContent: "oui",
+          relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
+        },
+        errorRow,
+      ]),
+    ].join("\n");
+  }
+
+  return [
+    "### Réponse MCP",
+    "",
+    renderResponseContractTable([
+      {
+        caseName: "Succès",
+        content: "oui",
+        structuredContent: definition.outputSchema ? "oui" : "non",
+        relation: definition.outputSchema
+          ? "`content[0].text` est `JSON.stringify(structuredContent)`."
+          : "`content[0].text` contient la réponse stringifiée ; aucun `structuredContent` n'est ajouté.",
+      },
+      errorRow,
+    ]),
+  ].join("\n");
 }
 
 /**
@@ -166,12 +266,12 @@ export function renderSchemaBlock(schema) {
 export function renderOutputSection(definition) {
   if (definition.outputSchema) {
     return [
-      "### Output Schema",
+      "### Schéma de sortie",
       "",
       renderPropertyTable(definition.outputSchema),
       "",
       "<details>",
-      "<summary>Raw output schema</summary>",
+      "<summary>Schéma de sortie brut</summary>",
       "",
       renderSchemaBlock(definition.outputSchema),
       "",
@@ -184,10 +284,10 @@ export function renderOutputSection(definition) {
     [];
 
   const note = modes.length
-    ? `No single \`outputSchema\` is exposed. Output depends on \`result_type\` (${modes.join(", ")}).`
-    : "No single `outputSchema` is exposed. Output is handled by the framework default serialization or custom response formatting.";
+    ? `Aucun \`outputSchema\` unique n'est exposé. La sortie dépend de \`result_type\` (${modes.join(", ")}).`
+    : "Aucun `outputSchema` unique n'est exposé. La sortie est gérée par la sérialisation par défaut du framework ou par un formatage de réponse spécifique.";
 
-  return ["### Output", "", note].join("\n");
+  return ["### Sortie", "", note].join("\n");
 }
 
 async function loadPackageMetadata() {
@@ -245,6 +345,26 @@ function sourcePathForCompiledTool(filename) {
   return `src/tools/${filename.replace(/\.js$/, ".ts")}`;
 }
 
+export function sortToolDefinitions(definitions) {
+  const order = new Map(toolDisplayOrder.map((name, index) => [name, index]));
+
+  return definitions.sort((left, right) => {
+    const leftOrder = order.get(left.name);
+    const rightOrder = order.get(right.name);
+
+    if (leftOrder !== undefined && rightOrder !== undefined) {
+      return leftOrder - rightOrder;
+    }
+    if (leftOrder !== undefined) {
+      return -1;
+    }
+    if (rightOrder !== undefined) {
+      return 1;
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
+
 async function loadToolDefinitions() {
   await ensureCompiledToolsExist();
   normalizePotentiallyInvalidEnv();
@@ -289,7 +409,7 @@ async function loadToolDefinitions() {
     );
   }
 
-  return definitions.sort((left, right) => left.name.localeCompare(right.name));
+  return sortToolDefinitions(definitions);
 }
 
 function normalizeErrorResponse(response) {
@@ -452,15 +572,41 @@ async function buildErrorContractSection(tools) {
   ];
 }
 
+export function buildAnnotationsSection(tools) {
+  const annotations = tools.map((tool) => tool.annotations);
+  const hasSharedAnnotations =
+    annotations.length > 0 &&
+    annotations.every((annotation) => JSON.stringify(annotation) === JSON.stringify(annotations[0]));
+
+  if (!hasSharedAnnotations || !annotations[0]) {
+    return [];
+  }
+
+  return [
+    "## Annotations MCP",
+    "",
+    "Tous les tools exposent les mêmes annotations MCP dans leur définition `tools/list` :",
+    "",
+    "| Annotation | Valeur | Signification |",
+    "| --- | --- | --- |",
+    `| \`readOnlyHint\` | ${annotations[0].readOnlyHint ? "oui" : "non"} | Le tool consulte des données sans modifier d'état côté serveur. |`,
+    `| \`destructiveHint\` | ${annotations[0].destructiveHint ? "oui" : "non"} | Le tool n'est pas signalé comme destructif. |`,
+    `| \`idempotentHint\` | ${annotations[0].idempotentHint ? "oui" : "non"} | Répéter le même appel ne déclenche pas d'effet de bord supplémentaire attendu. |`,
+    `| \`openWorldHint\` | ${annotations[0].openWorldHint ? "oui" : "non"} | Le tool interroge des sources externes ou ouvertes, dont le contenu peut évoluer. |`,
+  ];
+}
+
 async function buildDocumentLines(pkg, tools) {
   const errorContractSection = await buildErrorContractSection(tools);
+  const annotationsSection = buildAnnotationsSection(tools);
   const lines = [
-    "# MCP Tool Reference",
+    "# Référence des tools MCP",
     "",
-    `Generated from runtime \`toolDefinition\` metadata for \`${pkg.name}\` v${pkg.version}.`,
+    `Ce document est généré automatiquement à partir des définitions de tools exposées par la méthode \`tools/list\` du protocole MCP pour \`${pkg.name}\` dans sa version v${pkg.version}. Pour le mettre à jour, lancer \`npm run docs:mcp\`.`,
     ...(errorContractSection.length > 0 ? ["", ...errorContractSection] : []),
+    ...(annotationsSection.length > 0 ? ["", ...annotationsSection] : []),
     "",
-    "## Index",
+    "## Liste des tools",
     "",
     ...tools.map((tool) => `- [\`${tool.name}\`](#${toAnchorSlug(tool.name)})`),
   ];
@@ -470,26 +616,30 @@ async function buildDocumentLines(pkg, tools) {
       "",
       `## \`${tool.name}\``,
       "",
-      `Source: [${tool.source}](../${tool.source})`,
+      `Code Source : [${tool.source}](../${tool.source})`,
       "",
-      `Title: ${tool.title ?? ""}`,
+      "### Titre",
+      "",
+      tool.title ?? "",
       "",
       "### Description du tool",
       "",
       renderDescription(tool.description),
       "",
-      "### Input Schema",
+      "### Schéma d’entrée",
       "",
       renderPropertyTable(tool.inputSchema),
       "",
       "<details>",
-      "<summary>Raw input schema</summary>",
+      "<summary>Schéma d’entrée brut</summary>",
       "",
       renderSchemaBlock(tool.inputSchema),
       "",
       "</details>",
       "",
       renderOutputSection(tool),
+      "",
+      renderResponseContractSection(tool),
     );
   }
 

--- a/src/tools/CadastreTool.ts
+++ b/src/tools/CadastreTool.ts
@@ -46,7 +46,7 @@ class CadastreTool extends BaseTool<CadastreInput> {
     `Renvoie, pour un point donné par sa \`longitude\` et sa \`latitude\`, la liste des objets cadastraux (${PARCELLAIRE_EXPRESS_TYPES.join(", ")}) les plus proches, avec leurs informations associées.`,
     "Les résultats sont retournés au plus une fois par type lorsqu'ils sont disponibles et incluent un `feature_ref` WFS réutilisable.",
     "Le `feature_ref` est directement réutilisable dans `gpf_wfs_get_features` avec `spatial_operator=\"intersects_feature\"`.",
-    "La distance de recherche est fixée à 10 mètres.  Si aucun objet n'est trouvé dans les 10 mètres, le résultat est vide.",
+    "La distance de recherche est fixée à 10 mètres. Si aucun objet n'est trouvé dans les 10 mètres, le résultat est vide.",
     "Pour récupérer exactement l'objet correspondant au `feature_ref`, utiliser `gpf_wfs_get_feature_by_id`.",
     `(source : ${PARCELLAIRE_EXPRESS_SOURCE}).`
   ].join("\n");

--- a/src/tools/GeocodeTool.ts
+++ b/src/tools/GeocodeTool.ts
@@ -16,7 +16,7 @@ const geocodeInputSchema = z.object({
     .string()
     .trim()
     .min(1, "le texte ne doit pas être vide")
-    .describe("Le texte devant être completé et géocodé"),
+    .describe("Le texte devant être complété et géocodé"),
   maximumResponses: z
     .number()
     .int()

--- a/src/tools/GpfWfsDescribeTypeTool.ts
+++ b/src/tools/GpfWfsDescribeTypeTool.ts
@@ -52,7 +52,7 @@ class GpfWfsDescribeTypeTool extends BaseTool<GpfWfsDescribeTypeInput> {
     "Renvoie le schéma détaillé d'un type WFS à partir de son identifiant (`typename`) : identifiants, description et liste des propriétés.",
     "Utiliser ce tool après `gpf_wfs_search_types` pour inspecter les propriétés disponibles avant d'appeler `gpf_wfs_get_features`.",
     "La sortie inclut notamment le type des propriétés, leur description, leurs valeurs possibles (`enum`) lorsqu'elles existent",
-    "**IMPORTANT: Appel fortement recommandé si les noms exacts des propriétés ne sont pas connus : un nom de propriété incorrect provoque une erreur**."
+    "**IMPORTANT : Appel fortement recommandé si les noms exacts des propriétés ne sont pas connus : un nom de propriété incorrect provoque une erreur**."
   ].join("\n");
   protected outputSchemaShape = gpfWfsDescribeTypeOutputSchema;
 

--- a/test/scripts/generate-mcp-docs.test.ts
+++ b/test/scripts/generate-mcp-docs.test.ts
@@ -8,6 +8,9 @@ type DocsHelpersModule = {
   schemaType: (schema: unknown) => string;
   renderPropertyTable: (schema: unknown) => string;
   renderDescription: (description: string | undefined) => string;
+  renderResponseContractSection: (definition: { name: string; outputSchema?: unknown }) => string;
+  buildAnnotationsSection: (tools: Array<{ annotations?: Record<string, boolean> }>) => string[];
+  sortToolDefinitions: <T extends { name: string }>(definitions: T[]) => T[];
   buildValidationErrorExampleForTool: (
     tool: unknown,
     normalizeToolError: (error: unknown) => Record<string, unknown>,
@@ -48,10 +51,31 @@ describe("generate-mcp-docs helpers", () => {
     expect(schemaType(undefined)).toEqual("");
     expect(schemaType({ type: "number" })).toEqual("number");
     expect(schemaType({ type: ["string", "null"] })).toEqual("string | null");
+    expect(schemaType({ type: "string", enum: ["a", "b"] })).toEqual("string (enum)");
     expect(schemaType({ enum: ["a", "b"] })).toEqual("enum");
     expect(schemaType({ oneOf: [{ type: "string" }] })).toEqual("oneOf");
     expect(schemaType({ anyOf: [{ type: "string" }] })).toEqual("anyOf");
     expect(schemaType({ allOf: [{ type: "string" }] })).toEqual("allOf");
+  });
+
+  it("should sort tools in documentation reading order", async () => {
+    const { sortToolDefinitions } = await loadDocsHelpers();
+
+    const sorted = sortToolDefinitions([
+      { name: "gpf_wfs_get_features" },
+      { name: "adminexpress" },
+      { name: "geocode" },
+      { name: "unknown_custom_tool" },
+      { name: "altitude" },
+    ]);
+
+    expect(sorted.map((tool) => tool.name)).toEqual([
+      "geocode",
+      "altitude",
+      "adminexpress",
+      "gpf_wfs_get_features",
+      "unknown_custom_tool",
+    ]);
   });
 
   it("should render a markdown table sorted by property name", async () => {
@@ -69,8 +93,9 @@ describe("generate-mcp-docs helpers", () => {
       required: ["alpha"],
     });
 
-    expect(markdown).toContain("| `alpha` | number | yes | Primary value Default: 3. |");
-    expect(markdown).toContain("| `zeta` | string | no |   |");
+    expect(markdown).toContain("| Champ | Type | Requis | Description |");
+    expect(markdown).toContain("| `alpha` | number | oui | Primary value Valeur par défaut : 3. |");
+    expect(markdown).toContain("| `zeta` | string | non |   |");
 
     const alphaIndex = markdown.indexOf("`alpha`");
     const zetaIndex = markdown.indexOf("`zeta`");
@@ -78,12 +103,73 @@ describe("generate-mcp-docs helpers", () => {
     expect(zetaIndex).toBeGreaterThan(alphaIndex);
   });
 
-  it("should preserve multiline descriptions as bullet lists", async () => {
+  it("should preserve multiline descriptions as technical text blocks", async () => {
     const { renderDescription } = await loadDocsHelpers();
 
     const markdown = renderDescription("Line one\nLine two\n\nLine three");
-    expect(markdown).toEqual("- Line one\n- Line two\n- Line three");
-    expect(renderDescription("Single line")).toEqual("Single line");
+    expect(markdown).toEqual("```\nLine one\nLine two\nLine three\n```");
+    expect(renderDescription("Single line")).toEqual("```\nSingle line\n```");
+  });
+
+  it("should document the default MCP response contract", async () => {
+    const { renderResponseContractSection } = await loadDocsHelpers();
+
+    const markdown = renderResponseContractSection({
+      name: "altitude",
+      outputSchema: { type: "object" },
+    });
+
+    expect(markdown).toContain("### Réponse MCP");
+    expect(markdown).toContain("| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |");
+    expect(markdown).toContain("| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |");
+  });
+
+  it("should document the WFS get features response modes", async () => {
+    const { renderResponseContractSection } = await loadDocsHelpers();
+
+    const markdown = renderResponseContractSection({
+      name: "gpf_wfs_get_features",
+    });
+
+    expect(markdown).toContain('| Succès `result_type="results"` | oui | non | `content[0].text` est la FeatureCollection stringifiée ; aucun `structuredContent` n\'est ajouté dans ce mode. |');
+    expect(markdown).toContain('| Succès `result_type="hits"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |');
+    expect(markdown).toContain('| Succès `result_type="request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |');
+  });
+
+  it("should document shared MCP annotations", async () => {
+    const { buildAnnotationsSection } = await loadDocsHelpers();
+
+    const section = buildAnnotationsSection([
+      {
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      {
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+    ]);
+
+    const markdown = section.join("\n");
+    expect(markdown).toContain("## Annotations MCP");
+    expect(markdown).toContain("Tous les tools exposent les mêmes annotations MCP");
+    expect(markdown).toContain("| `readOnlyHint` | oui |");
+    expect(markdown).toContain("| `destructiveHint` | non |");
+    expect(markdown).toContain("| `idempotentHint` | oui |");
+    expect(markdown).toContain("| `openWorldHint` | oui |");
+
+    expect(buildAnnotationsSection([
+      { annotations: { readOnlyHint: true } },
+      { annotations: { readOnlyHint: false } },
+    ])).toEqual([]);
   });
 
   it("should build a validation example without executing the tool", async () => {


### PR DESCRIPTION
- Introduced a display order for tools in the documentation.
- Added support for annotations in tool definitions and generated documentation.
- Improved the rendering of descriptions to use code blocks for multiline text.
- Updated French translations for various sections in the documentation.
- Implemented sorting of tool definitions based on a predefined order.
- Added tests for new features including response contract documentation and annotations.
- Fixed minor typos and formatting issues in tool descriptions.