### PR TITLE
feat(wfs): split request output into explicit HTTP modes

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1091,7 +1091,7 @@ Lecture d’un objet WFS par identifiant
 Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.
 Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).
 Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.
-Utiliser `result_type="request"` pour récupérer la requête WFS compilée (avec `get_url`) et l'utiliser ou la visualiser ailleurs.
+Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POST robuste, ou `result_type="http_get_url"` pour récupérer l'URL GET WFS équivalente utilisable comme `layers[].data_url` dans `mcp-carte-ign`.
 ```
 
 ### Schéma d’entrée
@@ -1099,8 +1099,8 @@ Utiliser `result_type="request"` pour récupérer la requête WFS compilée (ave
 | Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `feature_id` | string | oui | Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer. Valeurs : results, request. Valeur par défaut : results. |
-| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Quand `result_type="request"`, la géométrie est automatiquement ajoutée. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
+| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Quand `result_type="http_post_request"` ou `result_type="http_get_url"`, la géométrie est automatiquement ajoutée. |
 | `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
 
 <details>
@@ -1124,10 +1124,11 @@ Utiliser `result_type="request"` pour récupérer la requête WFS compilée (ave
       "type": "string",
       "enum": [
         "results",
-        "request"
+        "http_post_request",
+        "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer."
+      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first."
     },
     "select": {
       "type": "array",
@@ -1136,7 +1137,7 @@ Utiliser `result_type="request"` pour récupérer la requête WFS compilée (ave
         "minLength": 1
       },
       "minItems": 1,
-      "description": "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée."
+      "description": "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée."
     }
   },
   "required": [
@@ -1152,14 +1153,15 @@ Utiliser `result_type="request"` pour récupérer la requête WFS compilée (ave
 
 ### Sortie
 
-Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`results`, `request`).
+Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`results`, `http_post_request`, `http_get_url`).
 
 ### Réponse MCP
 
 | Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
 | --- | --- | --- | --- |
 | Succès `result_type="results"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
-| Succès `result_type="request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Succès `result_type="http_post_request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Succès `result_type="http_get_url"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
 | Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
 
 ## `gpf_wfs_get_features`
@@ -1174,7 +1176,7 @@ Lecture d’objets WFS
 
 ```
 Interroge un type WFS et renvoie des résultats structurés sans demander au modèle d'écrire du CQL ou du WFS.
-Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et un filtre spatial dédié (`bbox_filter`, `intersects_point_filter`, `dwithin_point_filter`, `intersects_feature_filter` ou `travel_time_filter`) pour le spatial. Avec `result_type="request"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.
+Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et un filtre spatial dédié (`bbox_filter`, `intersects_point_filter`, `dwithin_point_filter`, `intersects_feature_filter` ou `travel_time_filter`) pour le spatial. Avec `result_type="http_post_request"` ou `result_type="http_get_url"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.
 Exemple attributaire : `where=[{ property: "code_insee", operator: "eq", value: "75056" }]`.
 Exemple bbox : `bbox_filter={ west: 2.1, south: 48.7, east: 2.5, north: 48.9 }`.
 Exemple point dans géométrie : `intersects_point_filter={ lon: 2.35, lat: 48.85 }`.
@@ -1196,7 +1198,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
 | `intersects_point_filter` | object | non | Filtre spatial par intersection avec un point. Exclusif avec les autres filtres spatiaux. |
 | `limit` | integer | non | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Valeur par défaut : 100. |
 | `order_by` | array | non | Liste ordonnée des critères de tri. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `request` renvoie l'URL WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer la requête générée. **La géométrie est automatiquement ajoutée aux propriétés du `select`** pour garantir l'affichage cartographique. Valeurs : results, hits, request. Valeur par défaut : results. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique. Valeurs : results, hits, http_post_request, http_get_url. Valeur par défaut : results. |
 | `select` | array | non | Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
 | `travel_time_filter` | object | non | Filtre spatial par temps de trajet depuis un point (`profile` voiture ou piéton). Exclusif avec les autres filtres spatiaux. |
 | `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `BDTOPO_V3:batiment`. Utiliser `gpf_wfs_search_types` pour trouver un `typename` valide. |
@@ -1226,10 +1228,11 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
       "enum": [
         "results",
         "hits",
-        "request"
+        "http_post_request",
+        "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `request` renvoie l'URL WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer la requête générée. **La géométrie est automatiquement ajoutée aux propriétés du `select`** pour garantir l'affichage cartographique."
+      "description": "`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."
     },
     "select": {
       "type": "array",
@@ -1478,7 +1481,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
 
 ### Sortie
 
-Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`results`, `hits`, `request`).
+Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`results`, `hits`, `http_post_request`, `http_get_url`).
 
 ### Réponse MCP
 
@@ -1486,5 +1489,6 @@ Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`
 | --- | --- | --- | --- |
 | Succès `result_type="results"` | oui | non | `content[0].text` est la FeatureCollection stringifiée ; aucun `structuredContent` n'est ajouté dans ce mode. |
 | Succès `result_type="hits"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
-| Succès `result_type="request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Succès `result_type="http_post_request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Succès `result_type="http_get_url"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
 | Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1091,7 +1091,7 @@ Lecture d’un objet WFS par identifiant
 Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.
 Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).
 Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.
-Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POST robuste, ou `result_type="http_get_url"` pour récupérer l'URL GET WFS équivalente utilisable comme `layers[].data_url` dans `mcp-carte-ign`.
+Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POST robuste, ou `result_type="http_get_url"` pour récupérer l'URL GET WFS équivalente et l'utiliser ou la visualiser dans un outil la supportant.
 ```
 
 ### Schéma d’entrée
@@ -1099,7 +1099,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POS
 | Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `feature_id` | string | oui | Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
 | `select` | array | non | Liste des propriétés non géométriques à renvoyer. Quand `result_type="http_post_request"` ou `result_type="http_get_url"`, la géométrie est automatiquement ajoutée. |
 | `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
 
@@ -1128,7 +1128,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POS
         "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first."
+      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."
     },
     "select": {
       "type": "array",
@@ -1198,7 +1198,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
 | `intersects_point_filter` | object | non | Filtre spatial par intersection avec un point. Exclusif avec les autres filtres spatiaux. |
 | `limit` | integer | non | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Valeur par défaut : 100. |
 | `order_by` | array | non | Liste ordonnée des critères de tri. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique. Valeurs : results, hits, http_post_request, http_get_url. Valeur par défaut : results. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique. Valeurs : results, hits, http_post_request, http_get_url. Valeur par défaut : results. |
 | `select` | array | non | Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
 | `travel_time_filter` | object | non | Filtre spatial par temps de trajet depuis un point (`profile` voiture ou piéton). Exclusif avec les autres filtres spatiaux. |
 | `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `BDTOPO_V3:batiment`. Utiliser `gpf_wfs_search_types` pour trouver un `typename` valide. |
@@ -1232,7 +1232,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
         "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."
+      "description": "`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."
     },
     "select": {
       "type": "array",

--- a/scripts/generate-mcp-docs.mjs
+++ b/scripts/generate-mcp-docs.mjs
@@ -210,7 +210,13 @@ export function renderResponseContractSection(definition) {
           relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
         },
         {
-          caseName: 'Succès `result_type="request"`',
+          caseName: 'Succès `result_type="http_post_request"`',
+          content: "oui",
+          structuredContent: "oui",
+          relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
+        },
+        {
+          caseName: 'Succès `result_type="http_get_url"`',
           content: "oui",
           structuredContent: "oui",
           relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
@@ -232,7 +238,13 @@ export function renderResponseContractSection(definition) {
           relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
         },
         {
-          caseName: 'Succès `result_type="request"`',
+          caseName: 'Succès `result_type="http_post_request"`',
+          content: "oui",
+          structuredContent: "oui",
+          relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",
+        },
+        {
+          caseName: 'Succès `result_type="http_get_url"`',
           content: "oui",
           structuredContent: "oui",
           relation: "`content[0].text` est `JSON.stringify(structuredContent)`.",

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -13,13 +13,15 @@ import { buildPropertyName, executeGetFeatureById } from "../wfs/byId.js";
 import { wfsClient } from "../wfs/execution.js";
 import {
   buildGetFeatureByIdRequest,
-  toWfsRequestPayload,
+  toWfsHttpGetUrlPayload,
+  toWfsHttpPostRequestPayload,
 } from "../wfs/request.js";
 import {
+  gpfWfsGetFeatureByIdHttpGetUrlOutputSchema,
+  gpfWfsGetFeatureByIdHttpPostRequestOutputSchema,
   gpfWfsGetFeatureByIdInputSchema,
   type GpfWfsGetFeatureByIdInput,
   gpfWfsGetFeatureByIdPublishedInputSchema,
-  gpfWfsGetFeatureByIdRequestOutputSchema,
 } from "../wfs/schema.js";
 import logger from "../logger.js";
 
@@ -33,7 +35,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
     "Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.",
     "Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).",
     "Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.",
-    "Utiliser `result_type=\"request\"` pour récupérer la requête WFS compilée (avec `get_url`) et l'utiliser ou la visualiser ailleurs."
+    "Utiliser `result_type=\"http_post_request\"` pour récupérer une requête WFS POST robuste, ou `result_type=\"http_get_url\"` pour récupérer l'URL GET WFS équivalente utilisable comme `layers[].data_url` dans `mcp-carte-ign`."
   ].join("\n");
 
   // `schema` remains the runtime validation source, while `inputSchema`
@@ -50,12 +52,12 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
   }
 
   /**
-   * Formats compact responses (`request`, `results`) into `structuredContent`.
+   * Formats compact responses (`http_post_request`, `http_get_url`, `results`) into `structuredContent`.
    *
    * We intentionally do not expose a single `outputSchemaShape` for the tool as
    * a whole: the `results` path returns a generic FeatureCollection whose
-   * feature properties depend on the queried WFS layer, while `request` has a
-   * compact, closed shape that is worth validating explicitly.
+   * feature properties depend on the queried WFS layer, while HTTP preview
+   * modes have compact, closed shapes that are worth validating explicitly.
    *
    * @param data Raw execution result returned by the tool implementation.
    * @returns An MCP success response, optionally enriched with structured content.
@@ -65,11 +67,27 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       typeof data === "object" &&
       data !== null &&
       "result_type" in data &&
-      data.result_type === "request"
+      data.result_type === "http_post_request"
     ) {
+      const payload = gpfWfsGetFeatureByIdHttpPostRequestOutputSchema.parse(data);
+
       return {
-        content: [{ type: "text" as const, text: JSON.stringify(data) }],
-        structuredContent: gpfWfsGetFeatureByIdRequestOutputSchema.parse(data),
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
+      };
+    }
+
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "result_type" in data &&
+      data.result_type === "http_get_url"
+    ) {
+      const payload = gpfWfsGetFeatureByIdHttpGetUrlOutputSchema.parse(data);
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
       };
     }
 
@@ -86,24 +104,24 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
     }
 
     throw new Error(
-      "Réponse interne inattendue pour gpf_wfs_get_feature_by_id : le résultat devrait être une requête WFS ou une FeatureCollection.",
+      "Réponse interne inattendue pour gpf_wfs_get_feature_by_id : le résultat devrait être une requête HTTP WFS, une URL GET WFS ou une FeatureCollection.",
     );
   }
 
   /**
    * Orchestrates the by-id execution flow:
-   * schema lookup -> request compilation -> optional request output -> WFS execution -> cardinality validation.
+   * schema lookup -> request compilation -> optional HTTP preview output -> WFS execution -> cardinality validation.
    *
    * @param input Normalized tool input.
-   * @returns Either a compiled request or a transformed FeatureCollection containing one feature.
+   * @returns Either an HTTP preview payload or a transformed FeatureCollection containing one feature.
    */
   async execute(input: GpfWfsGetFeatureByIdInput) {
     logger.info(`[tool] execute ${this.name} ...`, {
       input: input
     });
 
-    if (input.result_type === "request") {
-      // The `request` mode is handled here because it returns a preview payload,
+    if (input.result_type === "http_post_request" || input.result_type === "http_get_url") {
+      // HTTP preview modes are handled here because they return a preview payload,
       // not the actual by-id WFS result.
       const featureType = await wfsClient.getFeatureType(input.typename);
       const propertyName = buildPropertyName(featureType, {
@@ -111,7 +129,9 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
         select: input.select,
       });
       const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);
-      return toWfsRequestPayload(request);
+      return input.result_type === "http_post_request"
+        ? toWfsHttpPostRequestPayload(request)
+        : toWfsHttpGetUrlPayload(request);
     }
 
     return executeGetFeatureById({

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -35,7 +35,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
     "Récupère exactement un objet WFS à partir de `typename` et `feature_id`, sans filtre attributaire ni spatial.",
     "Ce tool est le chemin robuste quand vous disposez déjà d'une `feature_ref { typename, feature_id }` issue d'un autre tool (`adminexpress`, `cadastre`, `urbanisme`, `assiette_sup`, `gpf_wfs_get_features`).",
     "Le contrat garantit une cardinalité stricte : 0 résultat ou plusieurs résultats provoquent une erreur explicite.",
-    "Utiliser `result_type=\"http_post_request\"` pour récupérer une requête WFS POST robuste, ou `result_type=\"http_get_url\"` pour récupérer l'URL GET WFS équivalente utilisable comme `layers[].data_url` dans `mcp-carte-ign`."
+    "Utiliser `result_type=\"http_post_request\"` pour récupérer une requête WFS POST robuste, ou `result_type=\"http_get_url\"` pour récupérer l'URL GET WFS équivalente et l'utiliser ou la visualiser dans un outil la supportant."
   ].join("\n");
 
   // `schema` remains the runtime validation source, while `inputSchema`

--- a/src/tools/GpfWfsGetFeaturesTool.ts
+++ b/src/tools/GpfWfsGetFeaturesTool.ts
@@ -5,14 +5,18 @@ import {
   executeGetFeatures,
   prepareGetFeaturesRequest,
 } from "../wfs/features.js";
-import { toWfsRequestPayload } from "../wfs/request.js";
+import {
+  toWfsHttpGetUrlPayload,
+  toWfsHttpPostRequestPayload,
+} from "../wfs/request.js";
 import {
   gpfWfsGetFeaturesHitsOutputSchema,
+  gpfWfsGetFeaturesHttpGetUrlOutputSchema,
+  gpfWfsGetFeaturesHttpPostRequestOutputSchema,
   gpfWfsGetFeaturesInputSchema,
   gpfWfsGetFeaturesInputObjectSchema,
   type GpfWfsGetFeaturesInput,
   gpfWfsGetFeaturesPublishedInputSchema,
-  gpfWfsGetFeaturesRequestOutputSchema,
 } from "../wfs/schema.js";
 import logger from "../logger.js";
 
@@ -31,7 +35,7 @@ class GpfWfsGetFeaturesTool extends BaseTool<GpfWfsGetFeaturesInput> {
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;
   description = [
     "Interroge un type WFS et renvoie des résultats structurés sans demander au modèle d'écrire du CQL ou du WFS.",
-    "Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et un filtre spatial dédié (`bbox_filter`, `intersects_point_filter`, `dwithin_point_filter`, `intersects_feature_filter` ou `travel_time_filter`) pour le spatial. Avec `result_type=\"request\"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.",
+    "Utiliser `select` pour choisir les propriétés, `where` pour filtrer, `order_by` pour trier et un filtre spatial dédié (`bbox_filter`, `intersects_point_filter`, `dwithin_point_filter`, `intersects_feature_filter` ou `travel_time_filter`) pour le spatial. Avec `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée aux propriétés sélectionnées pour garantir une requête cartographiable.",
     "Exemple attributaire : `where=[{ property: \"code_insee\", operator: \"eq\", value: \"75056\" }]`.",
     "Exemple bbox : `bbox_filter={ west: 2.1, south: 48.7, east: 2.5, north: 48.9 }`.",
     "Exemple point dans géométrie : `intersects_point_filter={ lon: 2.35, lat: 48.85 }`.",
@@ -57,7 +61,7 @@ class GpfWfsGetFeaturesTool extends BaseTool<GpfWfsGetFeaturesInput> {
   }
 
   /**
-   * Formats compact responses (`hits`, `request`) into `structuredContent`.
+   * Formats compact responses (`hits`, `http_post_request`, `http_get_url`) into `structuredContent`.
    * Full result sets are still delegated to the framework default behavior.
    *
    * @param data Raw execution result returned by the tool implementation.
@@ -84,11 +88,27 @@ class GpfWfsGetFeaturesTool extends BaseTool<GpfWfsGetFeaturesInput> {
       typeof data === "object" &&
       data !== null &&
       "result_type" in data &&
-      data.result_type === "request"
+      data.result_type === "http_post_request"
     ) {
+      const payload = gpfWfsGetFeaturesHttpPostRequestOutputSchema.parse(data);
+
       return {
-        content: [{ type: "text" as const, text: JSON.stringify(data) }],
-        structuredContent: gpfWfsGetFeaturesRequestOutputSchema.parse(data),
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
+      };
+    }
+
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "result_type" in data &&
+      data.result_type === "http_get_url"
+    ) {
+      const payload = gpfWfsGetFeaturesHttpGetUrlOutputSchema.parse(data);
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
       };
     }
 
@@ -111,9 +131,11 @@ class GpfWfsGetFeaturesTool extends BaseTool<GpfWfsGetFeaturesInput> {
       input: validatedInput
     });
 
-    if (validatedInput.result_type === "request") {
+    if (validatedInput.result_type === "http_post_request" || validatedInput.result_type === "http_get_url") {
       const { request } = await prepareGetFeaturesRequest(validatedInput);
-      return toWfsRequestPayload(request);
+      return validatedInput.result_type === "http_post_request"
+        ? toWfsHttpPostRequestPayload(request)
+        : toWfsHttpGetUrlPayload(request);
     }
 
     return executeGetFeatures(validatedInput);

--- a/src/wfs/properties.ts
+++ b/src/wfs/properties.ts
@@ -118,7 +118,7 @@ export function validateSelectProperty(featureType: Collection, geometryProperty
  * Note that:
  * - when `select` is omitted and `result_type` is `results`, every non-geometric property is returned
  * - when `select` is provided, each property is validated against the embedded catalog
- * - when `result_type` is `request`, the geometry column is appended to the requested selection
+ * - when `result_type` is an HTTP preview mode, the geometry column is appended to the requested selection
  *
  * @param featureType Feature type definition loaded from the embedded catalog.
  * @param geometryProperty Geometry property already resolved for the feature type.
@@ -137,9 +137,9 @@ export function buildSelectList(
       validateSelectProperty(featureType, geometryProperty, propertyName),
     );
 
-    // For `result_type="request"`, also include the geometry column so the
-    // compiled request stays directly usable for mapping/debugging.
-    if (input.result_type === "request") {
+    // For HTTP preview modes, also include the geometry column so the compiled
+    // request stays directly usable for mapping/debugging.
+    if (input.result_type === "http_post_request" || input.result_type === "http_get_url") {
       return [...selectedProperties, geometryProperty.name];
     }
 
@@ -154,7 +154,7 @@ export function buildSelectList(
       .map((property: CollectionProperty) => property.name);
   }
 
-  // If `select` is omitted and `result_type` is `hits` or `request`,
+  // If `select` is omitted and `result_type` is `hits` or an HTTP preview mode,
   // do not send any `propertyName` selection.
   return [];
 }

--- a/src/wfs/request.ts
+++ b/src/wfs/request.ts
@@ -4,12 +4,11 @@
  * This module centralizes:
  * - the transport shape shared by compiled requests
  * - GET/POST request assembly helpers
- * - the compact request payload exposed by MCP `result_type="request"`
+ * - the compact HTTP payloads exposed by MCP WFS tools
  */
 
 import { GPF_WFS_URL } from "./catalog.js";
 import type { GpfWfsGetFeaturesInput } from "./schema.js";
-import { REQUEST_GET_URL_MAX_LENGTH } from "./schema.js";
 
 // --- Transport Types ---
 
@@ -21,30 +20,65 @@ type WfsRequestTransport = {
 };
 
 export type CompiledRequest = WfsRequestTransport & {
-  get_url?: string | null;
+  get_url: string;
 };
 
-export type WfsRequestPayload = WfsRequestTransport & {
-  result_type: "request";
-  get_url: string | null;
+export type WfsHttpPostRequestPayload = {
+  result_type: "http_post_request";
+  http_post_request: {
+    method: "POST";
+    url: string;
+    headers: { "Content-Type": "application/x-www-form-urlencoded" };
+    body: string;
+  };
+};
+
+export type WfsHttpGetUrlPayload = {
+  result_type: "http_get_url";
+  http_get_url: string;
 };
 
 // --- Request Payload Mapping ---
 
 /**
- * Maps a compiled WFS request to the compact MCP request payload.
+ * Builds a full URL from base endpoint and query parameters.
+ *
+ * @param url Base WFS endpoint URL.
+ * @param query Query-string parameters sent with the request.
+ * @returns URL with encoded query-string parameters.
+ */
+function buildUrlWithQuery(url: string, query: Record<string, string>) {
+  return `${url}?${new URLSearchParams(query).toString()}`;
+}
+
+/**
+ * Maps a compiled WFS request to the compact MCP POST payload.
  *
  * @param request Compiled request ready to be executed against the WFS service.
- * @returns A normalized request payload exposed by MCP tools.
+ * @returns A normalized POST payload exposed by MCP tools.
  */
-export function toWfsRequestPayload(request: CompiledRequest): WfsRequestPayload {
+export function toWfsHttpPostRequestPayload(request: CompiledRequest): WfsHttpPostRequestPayload {
   return {
-    result_type: "request",
-    method: request.method,
-    url: request.url,
-    query: request.query,
-    body: request.body,
-    get_url: request.get_url ?? null,
+    result_type: "http_post_request",
+    http_post_request: {
+      method: request.method,
+      url: buildUrlWithQuery(request.url, request.query),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: request.body,
+    },
+  };
+}
+
+/**
+ * Maps a compiled WFS request to the compact MCP GET URL payload.
+ *
+ * @param request Compiled request ready to be serialized as an equivalent GET URL.
+ * @returns A normalized GET URL payload exposed by MCP tools.
+ */
+export function toWfsHttpGetUrlPayload(request: CompiledRequest): WfsHttpGetUrlPayload {
+  return {
+    result_type: "http_get_url",
+    http_get_url: request.get_url,
   };
 }
 
@@ -64,26 +98,22 @@ function buildBody(cqlFilter?: string) {
 }
 
 /**
- * Builds a portable GET URL variant of the request when it stays below the configured limit.
+ * Builds the equivalent GET URL variant of the request.
  *
- * This helper is mainly used to populate `get_url` in request payloads
- * returned by `result_type="request"`.
+ * Consumers should prefer `http_post_request` for robust direct WFS execution
+ * when this URL is very long or contains a large `cql_filter`.
  *
  * @param url Base WFS endpoint URL.
  * @param query Query-string parameters sent with the request.
  * @param cqlFilter Optional CQL filter to append to the GET variant.
- * @returns A derived GET URL, or `null` when it would be too long to expose safely.
+ * @returns A derived GET URL.
  */
 export function buildGetUrl(url: string, query: Record<string, string>, cqlFilter?: string) {
   const params = new URLSearchParams(query);
   if (cqlFilter) {
     params.set("cql_filter", cqlFilter);
   }
-  const getUrl = `${url}?${params.toString()}`;
-  if (getUrl.length > REQUEST_GET_URL_MAX_LENGTH) {
-    return null;
-  }
-  return getUrl;
+  return `${url}?${params.toString()}`;
 }
 
 // --- Public Builders ---

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -4,7 +4,7 @@
  * This module centralizes:
  * - shared schema fragments reused by WFS tools
  * - public tool input schemas and inferred input types
- * - compact output schemas used for `hits` and `request` responses
+ * - compact output schemas used for `hits` and HTTP preview responses
  */
 
 import { z } from "zod";
@@ -17,7 +17,6 @@ import { TRAVEL_TIME_MAX_MINUTES, TRAVEL_TIME_PROFILES } from "../gpf/navigation
 
 export const DEFAULT_LIMIT = 100;
 export const MAX_LIMIT = 5000;
-export const REQUEST_GET_URL_MAX_LENGTH = 6000;
 export const WHERE_OPERATORS = ["eq", "ne", "lt", "lte", "gt", "gte", "in", "is_null"] as const;
 export const ORDER_DIRECTIONS = ["asc", "desc"] as const;
 export const GPF_WFS_GET_FEATURES_SPATIAL_FILTER_KEYS = [
@@ -81,17 +80,27 @@ const travelTimeFilterSchema = z.object({
 
 // --- Shared Compact Outputs ---
 
-const wfsRequestOutputSchema = z.object({
-  result_type: z.literal("request").describe("Indique que la réponse contient la requête WFS compilée (équivalent enrichi géométrie pour `create_map` et le débogage)."),
-  method: z.literal("POST").describe("Méthode HTTP réellement utilisée pour exécuter la requête."),
-  url: z.string().describe("URL de base appelée pour la requête POST."),
-  query: z.record(z.string()).describe("Paramètres WFS envoyés dans la query string."),
-  body: z.string().describe("Corps de la requête POST, encodé en `application/x-www-form-urlencoded`."),
-  get_url: z.string().nullable().optional().describe("URL GET dérivée quand la requête reste raisonnablement portable en GET."),
+const wfsHttpPostRequestOutputSchema = z.object({
+  result_type: z.literal("http_post_request").describe("Indique que la réponse contient une requête WFS POST robuste à exécuter par un client HTTP."),
+  http_post_request: z.object({
+    method: z.literal("POST").describe("Méthode HTTP à utiliser."),
+    url: z.string().url().describe("URL WFS avec les paramètres query standards, hors `cql_filter`."),
+    headers: z.object({
+      "Content-Type": z.literal("application/x-www-form-urlencoded").describe("Type de contenu du corps POST."),
+    }).strict().describe("En-têtes HTTP à envoyer avec la requête POST."),
+    body: z.string().describe("Corps de la requête POST, encodé en `application/x-www-form-urlencoded`; contient `cql_filter=...` quand un filtre existe."),
+  }).strict().describe("Requête HTTP POST complète à utiliser pour appeler directement le WFS."),
 });
 
-export const gpfWfsGetFeaturesRequestOutputSchema = wfsRequestOutputSchema;
-export const gpfWfsGetFeatureByIdRequestOutputSchema = wfsRequestOutputSchema;
+const wfsHttpGetUrlOutputSchema = z.object({
+  result_type: z.literal("http_get_url").describe("Indique que la réponse contient l'URL GET WFS équivalente."),
+  http_get_url: z.string().url().describe("URL GET WFS complète avec tous les paramètres, y compris `cql_filter`. Utile pour les consommateurs URL-first comme `mcp-carte-ign` via `layers[].data_url`; pour une exécution HTTP robuste, préférer `http_post_request`."),
+});
+
+export const gpfWfsGetFeaturesHttpPostRequestOutputSchema = wfsHttpPostRequestOutputSchema;
+export const gpfWfsGetFeaturesHttpGetUrlOutputSchema = wfsHttpGetUrlOutputSchema;
+export const gpfWfsGetFeatureByIdHttpPostRequestOutputSchema = wfsHttpPostRequestOutputSchema;
+export const gpfWfsGetFeatureByIdHttpGetUrlOutputSchema = wfsHttpGetUrlOutputSchema;
 
 // --- `gpf_wfs_get_features` ---
 
@@ -109,9 +118,9 @@ export const gpfWfsGetFeaturesInputObjectSchema = z.object({
     .default(DEFAULT_LIMIT)
     .describe(`Nombre maximum d'objets à renvoyer. Valeur par défaut : ${DEFAULT_LIMIT}. Maximum : ${MAX_LIMIT}.`),
   result_type: z
-    .enum(["results", "hits", "request"])
+    .enum(["results", "hits", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `request` renvoie l'URL WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer la requête générée. **La géométrie est automatiquement ajoutée aux propriétés du `select`** pour garantir l'affichage cartographique."),
+    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
@@ -193,14 +202,14 @@ export const gpfWfsGetFeatureByIdInputSchema = z.object({
     .min(1, "le feature_id ne doit pas être vide")
     .describe("Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`."),
   result_type: z
-    .enum(["results", "request"])
+    .enum(["results", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer."),
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
     .optional()
-    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée."),
+    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée."),
 }).strict();
 
 // --- `gpf_wfs_get_feature_by_id` Types ---

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -94,7 +94,7 @@ const wfsHttpPostRequestOutputSchema = z.object({
 
 const wfsHttpGetUrlOutputSchema = z.object({
   result_type: z.literal("http_get_url").describe("Indique que la réponse contient l'URL GET WFS équivalente."),
-  http_get_url: z.string().url().describe("URL GET WFS complète avec tous les paramètres, y compris `cql_filter`. Utile pour les consommateurs URL-first comme `mcp-carte-ign` via `layers[].data_url`; pour une exécution HTTP robuste, préférer `http_post_request`."),
+  http_get_url: z.string().url().describe("URL GET WFS complète avec tous les paramètres, y compris `cql_filter`. Utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant; pour une exécution HTTP robuste, préférer `http_post_request`."),
 });
 
 export const gpfWfsGetFeaturesHttpPostRequestOutputSchema = wfsHttpPostRequestOutputSchema;
@@ -120,7 +120,7 @@ export const gpfWfsGetFeaturesInputObjectSchema = z.object({
   result_type: z
     .enum(["results", "hits", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."),
+    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
@@ -204,7 +204,7 @@ export const gpfWfsGetFeatureByIdInputSchema = z.object({
   result_type: z
     .enum(["results", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first."),
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)

--- a/test/scripts/generate-mcp-docs.test.ts
+++ b/test/scripts/generate-mcp-docs.test.ts
@@ -133,7 +133,8 @@ describe("generate-mcp-docs helpers", () => {
 
     expect(markdown).toContain('| Succès `result_type="results"` | oui | non | `content[0].text` est la FeatureCollection stringifiée ; aucun `structuredContent` n\'est ajouté dans ce mode. |');
     expect(markdown).toContain('| Succès `result_type="hits"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |');
-    expect(markdown).toContain('| Succès `result_type="request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |');
+    expect(markdown).toContain('| Succès `result_type="http_post_request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |');
+    expect(markdown).toContain('| Succès `result_type="http_get_url"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |');
   });
 
   it("should document shared MCP annotations", async () => {

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -70,7 +70,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
           type: "string",
           enum: ["results", "http_post_request", "http_get_url"],
           default: "results",
-          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first.",
+          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant.",
         },
         select: {
           type: "array",

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -50,7 +50,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     mockFetchJSONPost.mockReset();
   });
 
-  it("should expose an MCP definition with `results|request` result_type only", () => {
+  it("should expose an MCP definition with explicit HTTP result types", () => {
     const tool = new GpfWfsGetFeatureByIdTool();
     expect(tool.toolDefinition.title).toEqual("Lecture d’un objet WFS par identifiant");
     expect(tool.toolDefinition.inputSchema).toEqual({
@@ -68,9 +68,9 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
         },
         result_type: {
           type: "string",
-          enum: ["results", "request"],
+          enum: ["results", "http_post_request", "http_get_url"],
           default: "results",
-          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `request` renvoie la requête WFS compilée (`get_url`) à destination de `create_map` via `geojson_url`, ou pour déboguer.",
+          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile comme `layers[].data_url` dans `mcp-carte-ign` ou pour les consommateurs URL-first.",
         },
         select: {
           type: "array",
@@ -79,7 +79,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
             minLength: 1,
           },
           minItems: 1,
-          description: "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"request\"`, la géométrie est automatiquement ajoutée.",
+          description: "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée.",
         },
       },
       required: ["typename", "feature_id"],
@@ -88,7 +88,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     });
   });
 
-  it("should return text content and structuredContent for request", async () => {
+  it("should return text content and structuredContent for http_post_request", async () => {
     const tool = new GpfWfsGetFeatureByIdTool();
     mockGetFeatureType.mockResolvedValue(polygonFeatureType);
 
@@ -98,7 +98,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
         arguments: {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
           feature_id: "commune.1",
-          result_type: "request",
+          result_type: "http_post_request",
           select: ["code_insee"],
         },
       },
@@ -109,17 +109,52 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    const request = JSON.parse(textContent.text);
-    expect(request.method).toEqual("POST");
-    expect(request.query.featureID).toEqual("commune.1");
-    expect(request.query.typeNames).toEqual("ADMINEXPRESS-COG.LATEST:commune");
-    expect(request.query.exceptions).toEqual("application/json");
-    expect(request.query.propertyName).toEqual("code_insee,geometrie");
-    expect(request.query.count).toEqual("2");
-    expect(response.structuredContent).toMatchObject({
-      result_type: "request",
+    const payload = JSON.parse(textContent.text);
+    expect(payload).toEqual(response.structuredContent);
+    expect(payload.result_type).toEqual("http_post_request");
+    expect(payload.http_get_url).toBeUndefined();
+    expect(payload.http_post_request).toMatchObject({
       method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "",
     });
+    const url = new URL(payload.http_post_request.url);
+    expect(url.searchParams.get("featureID")).toEqual("commune.1");
+    expect(url.searchParams.get("typeNames")).toEqual("ADMINEXPRESS-COG.LATEST:commune");
+    expect(url.searchParams.get("exceptions")).toEqual("application/json");
+    expect(url.searchParams.get("propertyName")).toEqual("code_insee,geometrie");
+    expect(url.searchParams.get("count")).toEqual("2");
+  });
+
+  it("should return text content and structuredContent for http_get_url", async () => {
+    const tool = new GpfWfsGetFeatureByIdTool();
+    mockGetFeatureType.mockResolvedValue(polygonFeatureType);
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          result_type: "http_get_url",
+          select: ["code_insee"],
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const payload = JSON.parse(textContent.text);
+    expect(payload).toEqual(response.structuredContent);
+    expect(payload.result_type).toEqual("http_get_url");
+    expect(payload.http_post_request).toBeUndefined();
+    const url = new URL(payload.http_get_url);
+    expect(url.searchParams.get("featureID")).toEqual("commune.1");
+    expect(url.searchParams.get("typeNames")).toEqual("ADMINEXPRESS-COG.LATEST:commune");
+    expect(url.searchParams.get("propertyName")).toEqual("code_insee,geometrie");
   });
 
   it("should return exactly one transformed feature for results", async () => {
@@ -299,6 +334,32 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
           name: "result_type",
           code: "invalid_enum_value",
           detail: expect.stringContaining("results"),
+        }),
+      ]),
+    });
+  });
+
+  it("should reject legacy request result_type", async () => {
+    const tool = new GpfWfsGetFeatureByIdTool();
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          result_type: "request",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "result_type",
+          code: "invalid_enum_value",
+          detail: expect.stringContaining("http_post_request"),
         }),
       ]),
     });

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -254,7 +254,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     });
   });
 
-  it("should return text content and structuredContent for request", async () => {
+  it("should return text content and structuredContent for http_post_request", async () => {
     const tool = new GpfWfsGetFeaturesTool();
     mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
 
@@ -263,7 +263,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
         name: "gpf_wfs_get_features",
         arguments: {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
-          result_type: "request",
+          result_type: "http_post_request",
           select: ["code_insee"],
           where: [
             {
@@ -284,17 +284,60 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    const request = JSON.parse(textContent.text);
-    expect(request.method).toEqual("POST");
-    expect(request.url).toContain("https://data.geopf.fr/wfs");
-    expect(request.query.service).toEqual("WFS");
-    expect(request.query.exceptions).toEqual("application/json");
-    expect(request.query.propertyName).toEqual("code_insee,geometrie");
-    expect(request.body).toContain("cql_filter=");
-    expect(response.structuredContent).toMatchObject({
-      result_type: "request",
+    const payload = JSON.parse(textContent.text);
+    expect(payload).toEqual(response.structuredContent);
+    expect(payload.result_type).toEqual("http_post_request");
+    expect(payload.http_get_url).toBeUndefined();
+    expect(payload.http_post_request).toMatchObject({
       method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: expect.stringContaining("cql_filter="),
     });
+    const url = new URL(payload.http_post_request.url);
+    expect(url.origin + url.pathname).toEqual("https://data.geopf.fr/wfs");
+    expect(url.searchParams.get("service")).toEqual("WFS");
+    expect(url.searchParams.get("exceptions")).toEqual("application/json");
+    expect(url.searchParams.get("propertyName")).toEqual("code_insee,geometrie");
+    expect(url.searchParams.get("cql_filter")).toBeNull();
+  });
+
+  it("should return text content and structuredContent for http_get_url", async () => {
+    const tool = new GpfWfsGetFeaturesTool();
+    mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          result_type: "http_get_url",
+          select: ["code_insee"],
+          where: [
+            {
+              property: "code_insee",
+              operator: "eq",
+              value: "01001",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const payload = JSON.parse(textContent.text);
+    expect(payload).toEqual(response.structuredContent);
+    expect(payload).toMatchObject({
+      result_type: "http_get_url",
+      http_get_url: expect.stringContaining("https://data.geopf.fr/wfs?"),
+    });
+    expect(payload.http_post_request).toBeUndefined();
+    const url = new URL(payload.http_get_url);
+    expect(url.searchParams.get("propertyName")).toEqual("code_insee,geometrie");
+    expect(url.searchParams.get("cql_filter")).toContain("code_insee = '01001'");
   });
 
   it("should compile travel_time_filter into a WFS request using an isochrone geometry", async () => {
@@ -307,7 +350,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
         name: "gpf_wfs_get_features",
         arguments: {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
-          result_type: "request",
+          result_type: "http_post_request",
           travel_time_filter: {
             lon: 2.337306,
             lat: 48.849319,
@@ -330,8 +373,8 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    const request = JSON.parse(textContent.text);
-    expect(new URLSearchParams(request.body).get("cql_filter")).toEqual(
+    const payload = JSON.parse(textContent.text);
+    expect(new URLSearchParams(payload.http_post_request.body).get("cql_filter")).toEqual(
       "INTERSECTS(geometrie,SRID=4326;POLYGON((2 48,2.2 48,2.2 48.2,2 48)))",
     );
     expect(mockFetchJSONPost).not.toHaveBeenCalled();
@@ -364,6 +407,31 @@ describe("Test GpfWfsGetFeaturesTool", () => {
           name: "typename",
           code: "too_small",
           detail: "le nom du type ne doit pas être vide",
+        }),
+      ]),
+    });
+  });
+
+  it("should reject legacy request result_type", async () => {
+    const tool = new GpfWfsGetFeaturesTool();
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          result_type: "request",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "result_type",
+          code: "invalid_enum_value",
+          detail: expect.stringContaining("http_post_request"),
         }),
       ]),
     });
@@ -739,7 +807,7 @@ describe("Test GpfWfsGetFeaturesTool", () => {
             typename: "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:localisant",
             feature_id: "localisant.1",
           },
-          result_type: "request",
+          result_type: "http_post_request",
         },
       },
     });
@@ -750,8 +818,8 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    const request = JSON.parse(textContent.text);
-    expect(request.body).toContain("MULTIPOINT");
+    const payload = JSON.parse(textContent.text);
+    expect(payload.http_post_request.body).toContain("MULTIPOINT");
   });
 
   it("should report missing reference features clearly for intersects_feature", async () => {

--- a/test/wfs/execution.test.ts
+++ b/test/wfs/execution.test.ts
@@ -135,6 +135,7 @@ describe("WfsClient", () => {
       url: "https://data.geopf.fr/wfs",
       query: { service: "WFS" },
       body: "",
+      get_url: "https://data.geopf.fr/wfs?service=WFS",
     })).resolves.toMatchObject({
       type: "FeatureCollection",
       features: [],

--- a/test/wfs/queryPreparation.test.ts
+++ b/test/wfs/queryPreparation.test.ts
@@ -114,10 +114,10 @@ describe("gpfWfsGetFeatures/queryPreparation", () => {
     }, featureType)).toThrow("`select` accepte uniquement");
   });
 
-  it("should append geometry to propertyName for request when select is provided", () => {
+  it("should append geometry to propertyName for HTTP preview modes when select is provided", () => {
     const compiled = compileQueryParts({
       ...baseInput,
-      result_type: "request",
+      result_type: "http_post_request",
       select: ["code_insee", "population"],
     }, featureType);
 

--- a/test/wfs/request.test.ts
+++ b/test/wfs/request.test.ts
@@ -84,12 +84,13 @@ describe("wfs_engine/request", () => {
     })).toThrow("`cqlFilter` et `cqlFilters`");
   });
 
-  it("should omit get_url when it exceeds the max length", () => {
+  it("should keep long get_url values for URL-first consumers", () => {
     const request = buildMultiTypenameRequest({
       typenames: ["ADMINEXPRESS-COG.LATEST:commune"],
       cqlFilter: `code_insee IN (${Array.from({ length: 900 }, (_, i) => `'${i}'`).join(",")})`,
     });
 
-    expect(request.get_url).toBeNull();
+    expect(request.get_url).toContain("cql_filter=");
+    expect(request.get_url.length).toBeGreaterThan(6000);
   });
 });

--- a/test/wfs/transport.test.ts
+++ b/test/wfs/transport.test.ts
@@ -28,6 +28,7 @@ describe("WfsTransport", () => {
       url: "https://data.geopf.fr/wfs",
       query: { service: "WFS", version: "2.0.0", request: "GetFeature" },
       body: "cql_filter=code_insee%3D'75056'",
+      get_url: "https://data.geopf.fr/wfs?service=WFS&version=2.0.0&request=GetFeature&cql_filter=code_insee%3D'75056'",
     };
 
     const result = await transport.post(request);
@@ -60,6 +61,7 @@ describe("WfsTransport", () => {
       url: "https://data.geopf.fr/wfs",
       query: { service: "WFS" },
       body: "",
+      get_url: "https://data.geopf.fr/wfs?service=WFS",
     };
 
     await transport.post(request);


### PR DESCRIPTION
Closes #133 

## Summary

- Replace the ambiguous WFS `request` result type with `http_post_request` and `http_get_url`
- Return compact, non-overlapping payloads for POST execution vs URL-first consumers
- Always expose the equivalent GET URL, including long URLs, for consumers such as `mcp-carte-ign`

## Details

`http_post_request` now returns a canonical POST payload for direct WFS execution, with query parameters in the URL and `cql_filter` in the body.

`http_get_url` returns the full equivalent GET URL, including `cql_filter`, without duplicating POST fields.

The legacy `request` result type is removed from the public schemas.

## Verification

- `npm run typecheck`
- `npm run typecheck:test`
- `npm run test:unit`
- `npm run docs:mcp`