### PR TITLE
fix(ci): update workflow to trigger on release branches

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the Node.js CI workflow configuration to ensure that CI runs not only on the `main` branch but also on any branches matching the `release/**` pattern.

- **CI Workflow Coverage:**
  * Updated `.github/workflows/node.js.yml` so that the Node.js CI workflow is triggered for pushes and pull requests to both `main` and any `release/**` branches.