### PR TITLE
Add `geometry_keep` to WfsGetFeatures and WfsGetFeaturesById

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
 
 jobs:
   build:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1099,8 +1099,9 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POS
 | Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `feature_id` | string | oui | Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
-| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Quand `result_type="http_post_request"` ou `result_type="http_get_url"`, la géométrie est automatiquement ajoutée. |
+| `geometry_keep` | array | non | Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_keep` en guise de géométrie. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
+| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
 | `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
 
 <details>
@@ -1128,7 +1129,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POS
         "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."
+      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_keep` en guise de géométrie. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise."
     },
     "select": {
       "type": "array",
@@ -1137,7 +1138,19 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête WFS POS
         "minLength": 1
       },
       "minItems": 1,
-      "description": "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée."
+      "description": "Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."
+    },
+    "geometry_keep": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "centroid",
+          "bbox"
+        ]
+      },
+      "default": [],
+      "description": "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
     }
   },
   "required": [
@@ -1194,11 +1207,12 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
 | --- | --- | --- | --- |
 | `bbox_filter` | object | non | Filtre spatial par boîte englobante. Exclusif avec les autres filtres spatiaux. |
 | `dwithin_point_filter` | object | non | Filtre spatial par distance à un point. Exclusif avec les autres filtres spatiaux. |
+| `geometry_keep` | array | non | Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
 | `intersects_feature_filter` | object | non | Filtre spatial par intersection avec un feature WFS de référence. Exclusif avec les autres filtres spatiaux. |
 | `intersects_point_filter` | object | non | Filtre spatial par intersection avec un point. Exclusif avec les autres filtres spatiaux. |
 | `limit` | integer | non | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Valeur par défaut : 100. |
 | `order_by` | array | non | Liste ordonnée des critères de tri. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique. Valeurs : results, hits, http_post_request, http_get_url. Valeur par défaut : results. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires et le choix de `geometry_keep` en guise de géométrie . `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise. Valeurs : results, hits, http_post_request, http_get_url. Valeur par défaut : results. |
 | `select` | array | non | Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
 | `travel_time_filter` | object | non | Filtre spatial par temps de trajet depuis un point (`profile` voiture ou piéton). Exclusif avec les autres filtres spatiaux. |
 | `typename` | string | oui | Nom exact du type WFS à interroger, par exemple `BDTOPO_V3:batiment`. Utiliser `gpf_wfs_search_types` pour trouver un `typename` valide. |
@@ -1232,7 +1246,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
         "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."
+      "description": "`results` renvoie une FeatureCollection avec les propriétés attributaires et le choix de `geometry_keep` en guise de géométrie . `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise."
     },
     "select": {
       "type": "array",
@@ -1242,6 +1256,18 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
       },
       "minItems": 1,
       "description": "Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."
+    },
+    "geometry_keep": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "centroid",
+          "bbox"
+        ]
+      },
+      "default": [],
+      "description": "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
     },
     "order_by": {
       "type": "array",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@ignfab/gpf-schema-store": "^0.1.5",
         "@rgrove/parse-xml": "^4.2.0",
+        "@turf/bbox": "^7.3.5",
+        "@turf/centroid": "^7.3.5",
         "@turf/distance": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "jsts": "^2.12.1",
@@ -391,9 +393,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.47",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.47.tgz",
-      "integrity": "sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==",
+      "version": "1.1.49",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.49.tgz",
+      "integrity": "sha512-7wkN3Qv/qZqsY0p3h48CNu6E6y5GMYatYxj+JrX4uVNBiqIVQm1Z528QrmayJWVW9SQTQicqRNoyTCzl+K9F8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -426,23 +428,22 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.2.tgz",
+      "integrity": "sha512-ivhYwbEKW4i/x2JfHcrTrToEE9EXZnwr4dPj7GC5974xEYeLgHYzii3GAYo1kgU5A0ZAd7rIxTpMOfcbycxliQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.2",
-        "@langchain/langgraph-sdk": "~1.9.4",
-        "@langchain/protocol": "^0.0.15",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "@langchain/langgraph-checkpoint": "^1.1.1",
+        "@langchain/langgraph-sdk": "~1.9.22",
+        "@langchain/protocol": "^0.0.16",
+        "@standard-schema/spec": "1.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -453,36 +454,32 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.1.tgz",
+      "integrity": "sha512-gHqhO6e2dyZ7TTfyaFy25yjcRsavURc9XMGT4q+LUBTc0hT4JxKe3qvrMX2OFTzW8W/0kjV59haHmSRFZIGkvg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^10.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44"
+        "@langchain/core": "^1.1.48"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.4.tgz",
-      "integrity": "sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==",
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.22.tgz",
+      "integrity": "sha512-DBKs9R2SGivlGqK/ZRTOUu39Q7Z+yRrG4PoTYLIWn7pqrLNhyZ4yZI/tEEEi/J0inpCuKfg/eydSwnRmPV/q3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/protocol": "^0.0.15",
+        "@langchain/protocol": "^0.0.16",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
-        "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "p-retry": "^7.1.1"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
@@ -540,20 +537,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/@langchain/mcp-adapters": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.3.tgz",
@@ -601,9 +584,9 @@
       }
     },
     "node_modules/@langchain/protocol": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -842,14 +825,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -874,9 +857,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1891,9 +1874,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1908,9 +1891,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1925,9 +1908,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1942,9 +1925,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1959,9 +1942,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1976,9 +1959,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1996,9 +1979,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -2016,9 +1999,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2036,9 +2019,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2056,9 +2039,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2076,9 +2059,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2096,9 +2079,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2113,9 +2096,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2132,9 +2115,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2149,9 +2132,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2242,6 +2225,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.5.tgz",
+      "integrity": "sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/distance": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
@@ -2274,6 +2287,20 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
       "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
       "license": "MIT",
       "dependencies": {
         "@turf/helpers": "7.3.5",
@@ -3532,12 +3559,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3713,17 +3740,17 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3977,9 +4004,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3989,9 +4016,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4078,9 +4105,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4312,9 +4339,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5568,9 +5605,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5588,7 +5625,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5658,9 +5695,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5874,13 +5911,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.130.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -5890,21 +5927,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -6509,9 +6546,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6745,21 +6782,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6777,17 +6799,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7101,9 +7123,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   "dependencies": {
     "@ignfab/gpf-schema-store": "^0.1.5",
     "@rgrove/parse-xml": "^4.2.0",
+    "@turf/bbox": "^7.3.5",
+    "@turf/centroid": "^7.3.5",
     "@turf/distance": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "jsts": "^2.12.1",

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -125,7 +125,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       // not the actual by-id WFS result.
       const featureType = await wfsClient.getFeatureType(input.typename);
       const propertyName = buildPropertyName(featureType, {
-        includeGeometry: input.geometrykind != 'omit',
+        includeGeometry: input.geometrykind.size != 0,
         select: input.select,
       });
       const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -125,7 +125,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       // not the actual by-id WFS result.
       const featureType = await wfsClient.getFeatureType(input.typename);
       const propertyName = buildPropertyName(featureType, {
-        includeGeometry: true,
+        includeGeometry: input.geometrykind != 'omit',
         select: input.select,
       });
       const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);
@@ -138,6 +138,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       typename: input.typename,
       feature_id: input.feature_id,
       select: input.select,
+      geometrykind: input.geometrykind,
     });
   }
 }

--- a/src/tools/GpfWfsGetFeatureByIdTool.ts
+++ b/src/tools/GpfWfsGetFeatureByIdTool.ts
@@ -19,6 +19,7 @@ import {
 import {
   gpfWfsGetFeatureByIdHttpGetUrlOutputSchema,
   gpfWfsGetFeatureByIdHttpPostRequestOutputSchema,
+  gpfWfsGetFeatureByIdInputObjectSchema,
   gpfWfsGetFeatureByIdInputSchema,
   type GpfWfsGetFeatureByIdInput,
   gpfWfsGetFeatureByIdPublishedInputSchema,
@@ -40,7 +41,10 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
 
   // `schema` remains the runtime validation source, while `inputSchema`
   // publishes the MCP-facing variant expected by clients.
-  schema = gpfWfsGetFeatureByIdInputSchema;
+  // The framework requires a plain Zod object here to publish a compatible
+  // input schema. Cross-field runtime validation is applied in `execute`.
+  schema = gpfWfsGetFeatureByIdInputObjectSchema;
+  
 
   /**
    * Exposes an input schema variant that stays compatible with most MCP integrations.
@@ -116,20 +120,21 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
    * @returns Either an HTTP preview payload or a transformed FeatureCollection containing one feature.
    */
   async execute(input: GpfWfsGetFeatureByIdInput) {
+    const validatedInput = gpfWfsGetFeatureByIdInputSchema.parse(input);
     logger.info(`[tool] execute ${this.name} ...`, {
-      input: input
+      input: validatedInput
     });
 
-    if (input.result_type === "http_post_request" || input.result_type === "http_get_url") {
+    if (validatedInput.result_type === "http_post_request" || validatedInput.result_type === "http_get_url") {
       // HTTP preview modes are handled here because they return a preview payload,
       // not the actual by-id WFS result.
-      const featureType = await wfsClient.getFeatureType(input.typename);
+      const featureType = await wfsClient.getFeatureType(validatedInput.typename);
       const propertyName = buildPropertyName(featureType, {
-        includeGeometry: input.geometrykind.size != 0,
-        select: input.select,
+        includeGeometry: true,
+        select: validatedInput.select,
       });
-      const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);
-      return input.result_type === "http_post_request"
+      const request = buildGetFeatureByIdRequest(validatedInput.typename, validatedInput.feature_id, propertyName);
+      return validatedInput.result_type === "http_post_request"
         ? toWfsHttpPostRequestPayload(request)
         : toWfsHttpGetUrlPayload(request);
     }
@@ -138,7 +143,7 @@ class GpfWfsGetFeatureByIdTool extends BaseTool<GpfWfsGetFeatureByIdInput> {
       typename: input.typename,
       feature_id: input.feature_id,
       select: input.select,
-      geometrykind: input.geometrykind,
+      geometry_keep: input.geometry_keep,
     });
   }
 }

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -27,7 +27,7 @@ export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
-  geometry_keep: string[];
+  geometry_keep?: string[];
 };
 
 // --- Internal Types ---
@@ -156,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: input.geometry_keep.length != 0,
+    includeGeometry: (input.geometry_keep ?? []).length != 0,
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -27,7 +27,7 @@ export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
-  geometrykind: string;
+  geometrykind: Set<string>;
 };
 
 // --- Internal Types ---
@@ -156,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: input.geometrykind != 'omit',
+    includeGeometry: input.geometrykind.size != 0,
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -27,7 +27,7 @@ export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
-  geometrykind: Set<string>;
+  geometry_keep: string[];
 };
 
 // --- Internal Types ---
@@ -156,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: input.geometrykind.size != 0,
+    includeGeometry: input.geometry_keep.length != 0,
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({
@@ -174,5 +174,5 @@ export async function executeGetFeatureById(
     numberMatched: 1,
   };
 
-  return attachFeatureRefs(singleFeatureCollection, input.typename, input.geometrykind);
+  return attachFeatureRefs(singleFeatureCollection, input.typename, input.geometry_keep);
 }

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -27,6 +27,7 @@ export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
+  geometrykind: string;
 };
 
 // --- Internal Types ---
@@ -155,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: false,
+    includeGeometry: input.geometrykind != 'omit',
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({
@@ -173,5 +174,5 @@ export async function executeGetFeatureById(
     numberMatched: 1,
   };
 
-  return attachFeatureRefs(singleFeatureCollection, input.typename);
+  return attachFeatureRefs(singleFeatureCollection, input.typename, input.geometrykind);
 }

--- a/src/wfs/features.ts
+++ b/src/wfs/features.ts
@@ -251,5 +251,5 @@ export async function executeGetFeatures(input: GpfWfsGetFeaturesInput) {
     };
   }
 
-  return attachFeatureRefs(featureCollection, input.typename, input.geometrykind);
+  return attachFeatureRefs(featureCollection, input.typename, input.geometry_keep);
 }

--- a/src/wfs/features.ts
+++ b/src/wfs/features.ts
@@ -251,5 +251,5 @@ export async function executeGetFeatures(input: GpfWfsGetFeaturesInput) {
     };
   }
 
-  return attachFeatureRefs(featureCollection, input.typename);
+  return attachFeatureRefs(featureCollection, input.typename, input.geometrykind);
 }

--- a/src/wfs/properties.ts
+++ b/src/wfs/properties.ts
@@ -130,6 +130,10 @@ export function buildSelectList(
   geometryProperty: CollectionProperty,
   input: GpfWfsGetFeaturesInput,
 ) {
+  const shouldIncludeGeometry =
+    (input.result_type === "http_post_request" || input.result_type === "http_get_url") ||
+    (input.result_type === "results" && (input.geometry_keep ?? []).length > 0);
+
   // If `select` is specified, only the requested properties are returned
   // after validation against the embedded catalog.
   if (input.select && input.select.length > 0) {
@@ -137,9 +141,8 @@ export function buildSelectList(
       validateSelectProperty(featureType, geometryProperty, propertyName),
     );
 
-    // For HTTP preview modes, also include the geometry column so the compiled
-    // request stays directly usable for mapping/debugging.
-    if (input.result_type === "http_post_request" || input.result_type === "http_get_url") {
+    // Include geometry when requested by output mode or by geometry_keep.
+    if (shouldIncludeGeometry) {
       return [...selectedProperties, geometryProperty.name];
     }
 
@@ -149,9 +152,15 @@ export function buildSelectList(
   // If `select` is omitted and `result_type="results"`, return every
   // non-geometric property from the feature type.
   if (input.result_type === "results") {
-    return featureType.properties
+    const nonGeometryProperties = featureType.properties
       .filter((property: CollectionProperty) => !property.defaultCrs)
       .map((property: CollectionProperty) => property.name);
+
+    if ((input.geometry_keep ?? []).length > 0) {
+      return [...nonGeometryProperties, geometryProperty.name];
+    }
+
+    return nonGeometryProperties;
   }
 
   // If `select` is omitted and `result_type` is `hits` or an HTTP preview mode,

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -7,6 +7,38 @@
  */
 
 import type { WfsFeatureCollectionResponse } from "./types.js";
+import * as turf from "@turf/turf"
+
+function isGeoJson(value: unknown): value is turf.AllGeoJSON {
+  return typeof value === "object" && value !== null;
+}
+
+function deriveGeometry(geometry: unknown, geometrykind: string): unknown {
+  if (!isGeoJson(geometry)) {
+    return null;
+  }
+
+  try {
+    if (geometrykind === "centroid") {
+      const centroid = turf.centroid(geometry).geometry.coordinates
+      return {
+        centroid: {
+          lon: centroid[0],
+          lat: centroid[1],
+        }
+      };
+    }
+    if (geometrykind === "bbox") {
+      return {
+        bbox: turf.bbox(geometry),
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
 
 // --- Response Types ---
 
@@ -80,6 +112,7 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
  */
 export function transformFeatureCollectionResponse(
   featureCollection: GenericFeatureCollection,
+  geometrykind: string,
 ): TransformedFeatureCollection {
   if (!Array.isArray(featureCollection.features)) {
     return featureCollection;
@@ -90,7 +123,7 @@ export function transformFeatureCollectionResponse(
 
     const nextFeature: Record<string, unknown> = {
       ...rest,
-      geometry: null,
+      geometry: deriveGeometry(_geometry, geometrykind),
     };
 
     if (typeof feature.id === "string") {
@@ -116,8 +149,8 @@ export function transformFeatureCollectionResponse(
  * @param typename Typename of the queried layer.
  * @returns A transformed FeatureCollection whose `feature_ref` objects carry the exact typename.
  */
-export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string) {
-  const transformed = transformFeatureCollectionResponse(featureCollection);
+export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometrykind: string) {
+  const transformed = transformFeatureCollectionResponse(featureCollection, geometrykind);
   if (!Array.isArray(transformed.features)) {
     return transformed;
   }

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -13,25 +13,23 @@ function isGeoJson(value: unknown): value is turf.AllGeoJSON {
   return typeof value === "object" && value !== null;
 }
 
-function deriveGeometry(geometry: unknown, geometrykind: Set<string>): unknown {
-  const ret: Record<string, unknown> = {}
-
-  if (!isGeoJson(geometry)) {
-    return ret;
+function deriveGeometry(geometry: unknown, geometry_keep: string[]): null | GeoJSON.Point | GeoJSON.GeometryCollection {
+  if (geometry_keep.length == 0 || !isGeoJson(geometry)) {
+    return null;
   }
 
-  
-  if (geometrykind.has("centroid")) {
+  let ret: GeoJSON.Point | GeoJSON.GeometryCollection = {
+    type: "GeometryCollection",
+    geometries: []
+  };
+
+  if (geometry_keep.includes("centroid")) {
     try {
-      const centroid = turf.centroid(geometry).geometry.coordinates
-      ret.centroid = {
-        lon: centroid[0],
-        lat: centroid[1],
-      };
+      ret = turf.centroid(geometry).geometry;
     } catch {}
   }
 
-  if (geometrykind.has("bbox")) {
+  if (geometry_keep.includes("bbox")) {
     try {
       ret.bbox = turf.bbox(geometry);
     } catch {}
@@ -104,15 +102,15 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
 // --- Response Transformation ---
 
 /**
- * Removes raw geometry payloads from a FeatureCollection, keeps GeoJSON validity by forcing
- * `geometry: null`, and exposes lightweight `feature_ref` objects reusable by follow-up requests.
+ *  Replaces raw geometry payloads from a FeatureCollection by the kind specified by `geometry_keep`
+ * and exposes lightweight `feature_ref` objects reusable by follow-up requests.
  *
  * @param featureCollection Raw FeatureCollection returned by the WFS endpoint.
- * @returns A transformed FeatureCollection with raw geometry fields removed, `geometry: null`, and optional `feature_ref` metadata.
+ * @returns A transformed FeatureCollection with raw geometry fields removed and optional `feature_ref` metadata.
  */
 export function transformFeatureCollectionResponse(
   featureCollection: GenericFeatureCollection,
-  geometrykind: Set<string>,
+  geometry_keep: string[] = [],
 ): TransformedFeatureCollection {
   if (!Array.isArray(featureCollection.features)) {
     return featureCollection;
@@ -123,7 +121,7 @@ export function transformFeatureCollectionResponse(
 
     const nextFeature: Record<string, unknown> = {
       ...rest,
-      geometry: deriveGeometry(_geometry, geometrykind),
+      geometry: deriveGeometry(_geometry, geometry_keep),
     };
 
     if (typeof feature.id === "string") {
@@ -149,8 +147,8 @@ export function transformFeatureCollectionResponse(
  * @param typename Typename of the queried layer.
  * @returns A transformed FeatureCollection whose `feature_ref` objects carry the exact typename.
  */
-export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometrykind: Set<string>) {
-  const transformed = transformFeatureCollectionResponse(featureCollection, geometrykind);
+export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometry_keep: string[] = []) {
+  const transformed = transformFeatureCollectionResponse(featureCollection, geometry_keep);
   if (!Array.isArray(transformed.features)) {
     return transformed;
   }

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -7,9 +7,12 @@
  */
 
 import type { WfsFeatureCollectionResponse } from "./types.js";
-import * as turf from "@turf/turf"
+import { centroid } from "@turf/centroid";
+import { bbox } from "@turf/bbox";
+import { AllGeoJSON } from "@turf/helpers";
 
-function isGeoJson(value: unknown): value is turf.AllGeoJSON {
+
+function isGeoJson(value: unknown): value is AllGeoJSON {
   return typeof value === "object" && value !== null;
 }
 
@@ -25,13 +28,13 @@ function deriveGeometry(geometry: unknown, geometry_keep: string[] = []): null |
 
   if (geometry_keep.includes("centroid")) {
     try {
-      ret = turf.centroid(geometry).geometry;
+      ret = centroid(geometry).geometry;
     } catch {}
   }
 
   if (geometry_keep.includes("bbox")) {
     try {
-      ret.bbox = turf.bbox(geometry);
+      ret.bbox = bbox(geometry);
     } catch {}
   }
 

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -13,7 +13,7 @@ function isGeoJson(value: unknown): value is turf.AllGeoJSON {
   return typeof value === "object" && value !== null;
 }
 
-function deriveGeometry(geometry: unknown, geometry_keep: string[]): null | GeoJSON.Point | GeoJSON.GeometryCollection {
+function deriveGeometry(geometry: unknown, geometry_keep: string[] = []): null | GeoJSON.Point | GeoJSON.GeometryCollection {
   if (geometry_keep.length == 0 || !isGeoJson(geometry)) {
     return null;
   }

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -13,31 +13,31 @@ function isGeoJson(value: unknown): value is turf.AllGeoJSON {
   return typeof value === "object" && value !== null;
 }
 
-function deriveGeometry(geometry: unknown, geometrykind: string): unknown {
+function deriveGeometry(geometry: unknown, geometrykind: Set<string>): unknown {
+  const ret: Record<string, unknown> = {}
+
   if (!isGeoJson(geometry)) {
-    return null;
+    return ret;
   }
 
-  try {
-    if (geometrykind === "centroid") {
+  
+  if (geometrykind.has("centroid")) {
+    try {
       const centroid = turf.centroid(geometry).geometry.coordinates
-      return {
-        centroid: {
-          lon: centroid[0],
-          lat: centroid[1],
-        }
+      ret.centroid = {
+        lon: centroid[0],
+        lat: centroid[1],
       };
-    }
-    if (geometrykind === "bbox") {
-      return {
-        bbox: turf.bbox(geometry),
-      };
-    }
-  } catch {
-    return null;
+    } catch {}
   }
 
-  return null;
+  if (geometrykind.has("bbox")) {
+    try {
+      ret.bbox = turf.bbox(geometry);
+    } catch {}
+  }
+
+  return ret;
 }
 
 // --- Response Types ---
@@ -112,7 +112,7 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
  */
 export function transformFeatureCollectionResponse(
   featureCollection: GenericFeatureCollection,
-  geometrykind: string,
+  geometrykind: Set<string>,
 ): TransformedFeatureCollection {
   if (!Array.isArray(featureCollection.features)) {
     return featureCollection;
@@ -149,7 +149,7 @@ export function transformFeatureCollectionResponse(
  * @param typename Typename of the queried layer.
  * @returns A transformed FeatureCollection whose `feature_ref` objects carry the exact typename.
  */
-export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometrykind: string) {
+export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometrykind: Set<string>) {
   const transformed = transformFeatureCollectionResponse(featureCollection, geometrykind);
   if (!Array.isArray(transformed.features)) {
     return transformed;

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -134,6 +134,7 @@ export const gpfWfsGetFeaturesInputObjectSchema = z.object({
     .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KEEP))
     .default([])
     .transform((val) => [...new Set(val)])
+    .optional()
     .describe("Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."),
   order_by: z
     .array(orderBySchema)
@@ -173,7 +174,7 @@ export const gpfWfsGetFeaturesInputSchema = gpfWfsGetFeaturesInputObjectSchema.s
     });
   }
 
-  if (input.geometry_keep.length > 0 && input.result_type != "results") {
+  if ((input.geometry_keep ?? []).length > 0 && input.result_type != "results") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["geometry_keep"],
@@ -229,13 +230,14 @@ export const gpfWfsGetFeatureByIdInputObjectSchema = z.object({
     .describe("Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."),
   geometry_keep: z
     .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KEEP))
-    .default([])
+    .optional()
     .transform((val) => [...new Set(val)])
+    .default([])
     .describe("Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."),
 }).strict();
 
 export const gpfWfsGetFeatureByIdInputSchema = gpfWfsGetFeatureByIdInputObjectSchema.superRefine((input, ctx) => {
-  if (input.geometry_keep.length > 0 && input.result_type != "results") {
+  if ((input.geometry_keep ?? []).length > 0 && input.result_type != "results") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["geometry_keep"],

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -26,7 +26,7 @@ export const GPF_WFS_GET_FEATURES_SPATIAL_FILTER_KEYS = [
   "intersects_feature_filter",
   "travel_time_filter",
 ] as const;
-export const GPF_WFS_GET_FEATURES_GEOMETRY_KIND = [
+export const GPF_WFS_GET_FEATURES_GEOMETRY_KEEP = [
   "centroid",
   "bbox"
 ] as const;
@@ -124,17 +124,17 @@ export const gpfWfsGetFeaturesInputObjectSchema = z.object({
   result_type: z
     .enum(["results", "hits", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires et le choix de `geometrykind` en guise de géométrie . `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."),
+    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires et le choix de `geometry_keep` en guise de géométrie . `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
     .optional()
     .describe("Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."),
-  geometrykind: z
-    .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND))
+  geometry_keep: z
+    .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KEEP))
     .default([])
-    .transform((val) => new Set(val))
-    .describe("Type(s) de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucune par défaut."),
+    .transform((val) => [...new Set(val)])
+    .describe("Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."),
   order_by: z
     .array(orderBySchema)
     .min(1)
@@ -172,6 +172,14 @@ export const gpfWfsGetFeaturesInputSchema = gpfWfsGetFeaturesInputObjectSchema.s
       message: `Un seul filtre spatial est autorisé (${usedSpatialFilters.join(", ")} fournis).`,
     });
   }
+
+  if (input.geometry_keep.length > 0 && input.result_type != "results") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["geometry_keep"],
+      message: "`geometry_keep` ne peut être utilisé qu'avec `result_type=results`. Si `result_type=hits`, aucune géométrie n'est renvoyée et dans cas `http_post_request` et `http_get_url`, la géométrie complète est renvoyée par la requête."
+    })
+  }
 });
 
 // --- `gpf_wfs_get_features` Types ---
@@ -199,7 +207,7 @@ export const gpfWfsGetFeaturesPublishedInputSchema = generatePublishedInputSchem
 
 // --- `gpf_wfs_get_feature_by_id` ---
 
-export const gpfWfsGetFeatureByIdInputSchema = z.object({
+export const gpfWfsGetFeatureByIdInputObjectSchema = z.object({
   typename: z
     .string()
     .trim()
@@ -213,18 +221,28 @@ export const gpfWfsGetFeatureByIdInputSchema = z.object({
   result_type: z
     .enum(["results", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."),
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_keep` en guise de géométrie. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
     .optional()
-    .describe("Liste des propriétés non géométriques à renvoyer."),
-  geometrykind: z
-    .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND))
+    .describe("Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."),
+  geometry_keep: z
+    .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KEEP))
     .default([])
-    .transform((val) => new Set(val))
-    .describe("Type(s) de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucune par défaut."),
+    .transform((val) => [...new Set(val)])
+    .describe("Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."),
 }).strict();
+
+export const gpfWfsGetFeatureByIdInputSchema = gpfWfsGetFeatureByIdInputObjectSchema.superRefine((input, ctx) => {
+  if (input.geometry_keep.length > 0 && input.result_type != "results") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["geometry_keep"],
+      message: "`geometry_keep` ne peut être utilisé qu'avec `result_type=results`. Dans les autres cas, la géométrie complète est toujours renvoyée par la requête."
+    })
+  }
+});
 
 // --- `gpf_wfs_get_feature_by_id` Types ---
 

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -27,7 +27,6 @@ export const GPF_WFS_GET_FEATURES_SPATIAL_FILTER_KEYS = [
   "travel_time_filter",
 ] as const;
 export const GPF_WFS_GET_FEATURES_GEOMETRY_KIND = [
-  "omit",
   "centroid",
   "bbox"
 ] as const;
@@ -132,9 +131,10 @@ export const gpfWfsGetFeaturesInputObjectSchema = z.object({
     .optional()
     .describe("Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."),
   geometrykind: z
-    .enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND)
-    .default("omit")
-    .describe("Type de géométrie à renvoyer pour `result_type=results`: `omit` aucune (par défaut), `centroid` le centroïde, `bbox` la bounding box"),
+    .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND))
+    .default([])
+    .transform((val) => new Set(val))
+    .describe("Type(s) de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucune par défaut."),
   order_by: z
     .array(orderBySchema)
     .min(1)
@@ -220,9 +220,10 @@ export const gpfWfsGetFeatureByIdInputSchema = z.object({
     .optional()
     .describe("Liste des propriétés non géométriques à renvoyer."),
   geometrykind: z
-    .enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND)
-    .default("omit")
-    .describe("Type de géométrie à renvoyer pour `result_type=results`: `omit` aucune (par défaut), `centroid` le centroïde, `bbox` la bounding box"),
+    .array(z.enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND))
+    .default([])
+    .transform((val) => new Set(val))
+    .describe("Type(s) de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucune par défaut."),
 }).strict();
 
 // --- `gpf_wfs_get_feature_by_id` Types ---

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -26,6 +26,11 @@ export const GPF_WFS_GET_FEATURES_SPATIAL_FILTER_KEYS = [
   "intersects_feature_filter",
   "travel_time_filter",
 ] as const;
+export const GPF_WFS_GET_FEATURES_GEOMETRY_KIND = [
+  "omit",
+  "centroid",
+  "bbox"
+] as const;
 
 // --- Shared Clauses ---
 
@@ -120,12 +125,16 @@ export const gpfWfsGetFeaturesInputObjectSchema = z.object({
   result_type: z
     .enum(["results", "hits", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."),
+    .describe("`results` renvoie une FeatureCollection avec les propriétés attributaires et le choix de `geometrykind` en guise de géométrie . `hits` renvoie uniquement le nombre total d'objets correspondant à la requête. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
     .optional()
     .describe("Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."),
+  geometrykind: z
+    .enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND)
+    .default("omit")
+    .describe("Type de géométrie à renvoyer pour `result_type=results`: `omit` aucune (par défaut), `centroid` le centroïde, `bbox` la bounding box"),
   order_by: z
     .array(orderBySchema)
     .min(1)
@@ -209,7 +218,11 @@ export const gpfWfsGetFeatureByIdInputSchema = z.object({
     .array(z.string().trim().min(1))
     .min(1)
     .optional()
-    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée."),
+    .describe("Liste des propriétés non géométriques à renvoyer."),
+  geometrykind: z
+    .enum(GPF_WFS_GET_FEATURES_GEOMETRY_KIND)
+    .default("omit")
+    .describe("Type de géométrie à renvoyer pour `result_type=results`: `omit` aucune (par défaut), `centroid` le centroïde, `bbox` la bounding box"),
 }).strict();
 
 // --- `gpf_wfs_get_feature_by_id` Types ---

--- a/test/integration/level1-protocol/wfs-getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/wfs-getfeaturebyid.test.ts
@@ -35,7 +35,7 @@ interface GetFeatureByIdResult {
     type: string;
     id: string;
     properties: Record<string, unknown>;
-    geometry: unknown;
+    geometry: null | GeoJSON.Point | GeoJSON.GeometryCollection;
     feature_ref?: {
       typename: string;
       feature_id: string;
@@ -75,11 +75,38 @@ describe("WFS GetFeatureById (integration)", () => {
     expect(result.features[0].geometry).toBeDefined();
   }, INTEGRATION_CONFIG.timeout);
 
+  it("should retrieve a centroid and a bbox", async () => {
+    const result = await callTool<GetFeatureByIdResult>(getHandle().client, "gpf_wfs_get_feature_by_id", {
+      typename: featureRef.typename,
+      feature_id: featureRef.feature_id,
+      geometry_keep: ["centroid", "bbox"]
+    });
+
+    expectFeatureCollectionWithFeatures(result, 1);
+    expect(result.features.length).toBe(1);
+    expect(result.features[0].id).toBeDefined();
+    expect(result.features[0].properties).toBeDefined();
+    expect(result.features[0].geometry).toBeDefined();
+    expect(result.features[0].geometry?.type).toBe("Point");
+    expect(result.features[0].geometry?.bbox).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
   it("should return an error for invalid typename", async () => {
     await expectToolCallToThrow(
       callTool(getHandle().client, "gpf_wfs_get_feature_by_id", {
         typename: "INVALID:type",
         feature_id: "nonexistent",
+      }),
+    );
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for when trying to combine `geometry_keep` with a `result_type` other than `request`", async () => {
+    await expectToolCallToThrow(
+      callTool(getHandle().client, "gpf_wfs_get_feature_by_id", {
+        typename: featureRef.typename,
+        feature_id: featureRef.feature_id,
+        geometry_keep: ["centroid"],
+        result_type: "http_post_request"
       }),
     );
   }, INTEGRATION_CONFIG.timeout);

--- a/test/integration/level1-protocol/wfs-getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/wfs-getfeaturebyid.test.ts
@@ -35,7 +35,7 @@ interface GetFeatureByIdResult {
     type: string;
     id: string;
     properties: Record<string, unknown>;
-    geometry?: unknown;
+    geometry: unknown;
     feature_ref?: {
       typename: string;
       feature_id: string;
@@ -72,6 +72,7 @@ describe("WFS GetFeatureById (integration)", () => {
     expect(result.features.length).toBe(1);
     expect(result.features[0].id).toBeDefined();
     expect(result.features[0].properties).toBeDefined();
+    expect(result.features[0].geometry).toBeDefined();
   }, INTEGRATION_CONFIG.timeout);
 
   it("should return an error for invalid typename", async () => {

--- a/test/integration/level1-protocol/wfs-getfeatures.test.ts
+++ b/test/integration/level1-protocol/wfs-getfeatures.test.ts
@@ -55,4 +55,26 @@ describe("WFS GetFeatures (integration)", () => {
       }),
     );
   }, INTEGRATION_CONFIG.timeout);
+
+  it("should return bbox-only geometry when geometry_keep includes bbox", async () => {
+    const result = await callTool<GetFeaturesResult>(getHandle().client, "gpf_wfs_get_features", {
+      typename: "BDTOPO_V3:commune",
+      where: [{ property: "code_insee", operator: "eq", value: "75056" }],
+      select: ["code_insee", "nom_officiel"],
+      geometry_keep: ["bbox"],
+      limit: 1,
+    });
+
+    expectFeatureCollectionWithFeatures(result);
+
+    const first = result.features[0];
+    expect(first.geometry).toBeDefined();
+    expect(first.geometry).toMatchObject({
+      type: "GeometryCollection",
+      geometries: [],
+      bbox: expect.any(Array),
+    });
+    const geometry = first.geometry as GeoJSON.GeometryCollection;
+    expect(geometry.bbox).toHaveLength(4);
+  }, INTEGRATION_CONFIG.timeout);
 });

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -225,6 +225,64 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
     expect(results.features[0].geometry_name).toBeUndefined();
   });
 
+  it("should keep bbox-only geometry as a valid GeometryCollection in results mode", async () => {
+    const tool = new GpfWfsGetFeatureByIdTool();
+    const requests: Array<{ url: string; query: Record<string, string> }> = [];
+    mockGetFeatureType.mockResolvedValue(polygonFeatureType);
+    mockFetchJSONPost.mockImplementation(async (url, _body) => {
+      const [baseUrl, queryString = ""] = url.split("?");
+      requests.push({
+        url: baseUrl,
+        query: Object.fromEntries(new URLSearchParams(queryString).entries()),
+      });
+
+      return {
+        type: "FeatureCollection",
+        totalFeatures: 1,
+        features: [
+          {
+            type: "Feature",
+            id: "commune.1",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+            },
+            geometry_name: "geometrie",
+            properties: {
+              code_insee: "01001",
+            },
+          },
+        ],
+      };
+    });
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          select: ["code_insee"],
+          geometry_keep: ["bbox"],
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query.propertyName).toEqual("code_insee,geometrie");
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const results = JSON.parse(textContent.text);
+    expect(results.features[0].geometry).toMatchObject({
+      type: "GeometryCollection",
+      geometries: [],
+      bbox: [2.3, 48.8, 2.4, 48.9],
+    });
+  });
+
   it("should fail clearly when the feature is missing", async () => {
     const tool = new GpfWfsGetFeatureByIdTool();
     mockGetFeatureType.mockResolvedValue(polygonFeatureType);
@@ -369,6 +427,38 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
           name: "result_type",
           code: "invalid_enum_value",
           detail: expect.stringContaining("http_post_request"),
+        }),
+      ]),
+    });
+  });
+
+  it("should reject geometry_keep with http_get_url result_type", async () => {
+    const tool = new GpfWfsGetFeatureByIdTool();
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          geometry_keep: ["bbox"],
+          result_type: "http_get_url",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("geometry_keep");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "geometry_keep",
+          code: "custom",
         }),
       ]),
     });

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -66,11 +66,20 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
           minLength: 1,
           description: "Identifiant WFS exact de l'objet à récupérer, par exemple `commune.8952`.",
         },
+        geometry_keep: {
+          type: "array",
+          items: {
+            enum: ["centroid", "bbox"],
+            type: "string",
+          },
+          default: [],
+          description: "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut.",
+        },
         result_type: {
           type: "string",
           enum: ["results", "http_post_request", "http_get_url"],
           default: "results",
-          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant.",
+          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_keep` en guise de géométrie. `http_post_request` renvoie une requête POST WFS robuste à exécuter directement. `http_get_url` renvoie l'URL GET WFS équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie complète est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique ; sinon, elle est omise.",
         },
         select: {
           type: "array",
@@ -79,7 +88,7 @@ describe("Test GpfWfsGetFeatureByIdTool", () => {
             minLength: 1,
           },
           minItems: 1,
-          description: "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée.",
+          description: "Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`.",
         },
       },
       required: ["typename", "feature_id"],

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -437,6 +437,38 @@ describe("Test GpfWfsGetFeaturesTool", () => {
     });
   });
 
+  it("should reject geometry_keep with hits result_type", async () => {
+    const tool = new GpfWfsGetFeaturesTool();
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          result_type: "hits",
+          geometry_keep: ["bbox"],
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("geometry_keep");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "geometry_keep",
+          code: "custom",
+        }),
+      ]),
+    });
+    expect(mockGetFeatureType).not.toHaveBeenCalled();
+    expect(mockFetchJSONPost).not.toHaveBeenCalled();
+  });
+
   it("should reject multiple spatial filters as invalid tool parameters", async () => {
     const tool = new GpfWfsGetFeaturesTool();
     const response = await tool.toolCall({
@@ -735,6 +767,57 @@ describe("Test GpfWfsGetFeaturesTool", () => {
       feature_id: "commune.1",
     });
     expect(results.features[0].geometry_name).toBeUndefined();
+  });
+
+  it("should keep bbox-only geometry as a valid GeometryCollection in results mode", async () => {
+    const tool = new GpfWfsGetFeaturesTool();
+    mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
+    const requests = captureRequests({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "commune.1",
+          geometry: {
+            type: "Polygon",
+            coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+          },
+          geometry_name: "geometrie",
+          properties: { code_insee: "01001" },
+        },
+      ],
+      totalFeatures: 1,
+    });
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_wfs_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          select: ["code_insee"],
+          geometry_keep: ["bbox"],
+          limit: 1,
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query.propertyName).toEqual("code_insee,geometrie");
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const results = JSON.parse(textContent.text);
+    expect(results.features[0].geometry).toMatchObject({
+      type: "GeometryCollection",
+      geometries: [],
+      bbox: [2.3, 48.8, 2.4, 48.9],
+    });
+    expect(results.features[0].feature_ref).toEqual({
+      typename: "ADMINEXPRESS-COG.LATEST:commune",
+      feature_id: "commune.1",
+    });
   });
 
   it("should set point geometry to null and keep feature_ref", async () => {

--- a/test/wfs/response.test.ts
+++ b/test/wfs/response.test.ts
@@ -65,6 +65,57 @@ describe("wfs_engine/response", () => {
         geometry: null,
       });
     });
+
+    it("should return a GeometryCollection with bbox when only bbox is requested", () => {
+      const result = transformFeatureCollectionResponse({
+        type: "FeatureCollection",
+        features: [
+          {
+            id: "commune.1",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+            },
+            geometry_name: "geometrie",
+            properties: { code_insee: "94080" },
+          },
+        ],
+      }, ["bbox"]);
+
+      const features = getFeatures(result);
+
+      expect(features[0].geometry).toMatchObject({
+        type: "GeometryCollection",
+        geometries: [],
+        bbox: [2.3, 48.8, 2.4, 48.9],
+      });
+    });
+
+    it("should return a Point with bbox when centroid and bbox are requested", () => {
+      const result = transformFeatureCollectionResponse({
+        type: "FeatureCollection",
+        features: [
+          {
+            id: "commune.1",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+            },
+            geometry_name: "geometrie",
+            properties: { code_insee: "94080" },
+          },
+        ],
+      }, ["centroid", "bbox"]);
+
+      const features = getFeatures(result);
+      expect(features[0].geometry).toMatchObject({
+        type: "Point",
+        bbox: [2.3, 48.8, 2.4, 48.9],
+      });
+      const point = features[0].geometry as GeoJSON.Point;
+      expect(point.coordinates[0]).toBeCloseTo(2.35);
+      expect(point.coordinates[1]).toBeCloseTo(48.85);
+    });
   });
 
   // --- attachFeatureRefs ---


### PR DESCRIPTION
Implement the easy parts of #137.

This new option only works in conjunction with `result_type="request"`, since the other cases necessarily return either the full geometry (the two `"http_..."` modes) or no geometry (`"hits"`).

I propose implementing `geometry_keep` as a list of options that can be toggled, instead of a monolithic `geometry_mode` that can only return either the `bbox` or the `centroid` for example. So far, only these two options are implemented, with the following output:
- if `geometry_keep` is undefined or empty, the returned `geometry` field is `null` **<- that's the current state on master**
- if `geometry_keep=["centroid"]`, then `geometry` will be a `GeoJSON.Point` with the centroid.
- if `geometry_keep=["centroid", "bbox"]`, then `geometry` will be a `GeoJSON.Point` with the centroid and the optional `bbox` field filled accordingly.
- finally, if `geometry_keep=["bbox"]`, then `geometry` will be an empty `GeoJSON.GeometryCollection` with the optional `bbox` field filled.

The tests were generated by Copilot, then reviewed.