### PR TITLE
Improve distance computation and add distance tool

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
 
 jobs:
   build:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -61,6 +61,7 @@ Tous les tools exposent les mêmes annotations MCP dans leur définition `tools/
 - [`gpf_wfs_describe_type`](#gpf_wfs_describe_type)
 - [`gpf_wfs_get_feature_by_id`](#gpf_wfs_get_feature_by_id)
 - [`gpf_wfs_get_features`](#gpf_wfs_get_features)
+- [`distance`](#distance)
 
 ## `geocode`
 
@@ -1491,4 +1492,130 @@ Aucun `outputSchema` unique n'est exposé. La sortie dépend de `result_type` (`
 | Succès `result_type="hits"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
 | Succès `result_type="http_post_request"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
 | Succès `result_type="http_get_url"` | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
+| Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |
+
+## `distance`
+
+Code Source : [src/tools/DistanceTool.ts](../src/tools/DistanceTool.ts)
+
+### Titre
+
+Distance entre deux points
+
+### Description du tool
+
+```
+Renvoie la distance (en mètres) entre deux points à partir de leur longitude et latitude.
+```
+
+### Schéma d’entrée
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `arrival` | object | oui | Le point d'arrivée |
+| `departure` | object | oui | Le point de départ |
+| `profile` | string (enum) | oui | Le type de chemin suivi : `direct` distance à vol d'oiseau (approximation Terre plate ou Terre ronde, précision à 0.5%), `vincenty` distance à vol d'oiseau (Terre ellipsoïde, plus précise et coûteuse, précision à 0.5mm). Par défaut : `direct`. Valeurs : direct, vincenty. Valeur par défaut : direct. |
+
+<details>
+<summary>Schéma d’entrée brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "departure": {
+      "type": "object",
+      "description": "Le point de départ",
+      "properties": {
+        "lon": {
+          "type": "number",
+          "description": "La longitude du point.",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "lat": {
+          "type": "number",
+          "description": "La latitude du point.",
+          "minimum": -90,
+          "maximum": 90
+        }
+      },
+      "required": [
+        "lon",
+        "lat"
+      ]
+    },
+    "arrival": {
+      "type": "object",
+      "description": "Le point d'arrivée",
+      "properties": {
+        "lon": {
+          "type": "number",
+          "description": "La longitude du point.",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "lat": {
+          "type": "number",
+          "description": "La latitude du point.",
+          "minimum": -90,
+          "maximum": 90
+        }
+      },
+      "required": [
+        "lon",
+        "lat"
+      ]
+    },
+    "profile": {
+      "type": "string",
+      "description": "Le type de chemin suivi : `direct` distance à vol d'oiseau (approximation Terre plate ou Terre ronde, précision à 0.5%), `vincenty` distance à vol d'oiseau (Terre ellipsoïde, plus précise et coûteuse, précision à 0.5mm). Par défaut : `direct`.",
+      "default": "direct",
+      "enum": [
+        "direct",
+        "vincenty"
+      ]
+    }
+  },
+  "required": [
+    "departure",
+    "arrival",
+    "profile"
+  ]
+}
+```
+
+</details>
+
+### Schéma de sortie
+
+| Champ | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `distance` | number | oui | La distance entre les deux points, en mètres. |
+
+<details>
+<summary>Schéma de sortie brut</summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "distance": {
+      "type": "number",
+      "description": "La distance entre les deux points, en mètres."
+    }
+  },
+  "required": [
+    "distance"
+  ]
+}
+```
+
+</details>
+
+### Réponse MCP
+
+| Cas | `content` | `structuredContent` | Relation entre `content` et `structuredContent` |
+| --- | --- | --- | --- |
+| Succès | oui | oui | `content[0].text` est `JSON.stringify(structuredContent)`. |
 | Erreur | oui | oui | `content[0].text` contient `structuredContent.detail`, pas le JSON d'erreur complet de `structuredContent`. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,12 @@
       "dependencies": {
         "@ignfab/gpf-schema-store": "^0.1.5",
         "@rgrove/parse-xml": "^4.2.0",
+        "@turf/boolean-intersects": "^7.3.5",
+        "@turf/boolean-point-in-polygon": "^7.3.5",
         "@turf/distance": "^7.3.5",
         "@turf/helpers": "^7.3.5",
+        "@turf/point-to-line-distance": "^7.3.5",
+        "@turf/polygon-to-line": "^7.3.5",
         "jsts": "^2.12.1",
         "mcp-framework": "^0.2.22",
         "node-fetch": "^3.3.2",
@@ -391,9 +395,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.47",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.47.tgz",
-      "integrity": "sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==",
+      "version": "1.1.49",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.49.tgz",
+      "integrity": "sha512-7wkN3Qv/qZqsY0p3h48CNu6E6y5GMYatYxj+JrX4uVNBiqIVQm1Z528QrmayJWVW9SQTQicqRNoyTCzl+K9F8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -426,23 +430,22 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.2.tgz",
+      "integrity": "sha512-ivhYwbEKW4i/x2JfHcrTrToEE9EXZnwr4dPj7GC5974xEYeLgHYzii3GAYo1kgU5A0ZAd7rIxTpMOfcbycxliQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.2",
-        "@langchain/langgraph-sdk": "~1.9.4",
-        "@langchain/protocol": "^0.0.15",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "@langchain/langgraph-checkpoint": "^1.1.1",
+        "@langchain/langgraph-sdk": "~1.9.22",
+        "@langchain/protocol": "^0.0.16",
+        "@standard-schema/spec": "1.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -453,36 +456,32 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.1.tgz",
+      "integrity": "sha512-gHqhO6e2dyZ7TTfyaFy25yjcRsavURc9XMGT4q+LUBTc0hT4JxKe3qvrMX2OFTzW8W/0kjV59haHmSRFZIGkvg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^10.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44"
+        "@langchain/core": "^1.1.48"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.4.tgz",
-      "integrity": "sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==",
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.22.tgz",
+      "integrity": "sha512-DBKs9R2SGivlGqK/ZRTOUu39Q7Z+yRrG4PoTYLIWn7pqrLNhyZ4yZI/tEEEi/J0inpCuKfg/eydSwnRmPV/q3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/protocol": "^0.0.15",
+        "@langchain/protocol": "^0.0.16",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
-        "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "p-retry": "^7.1.1"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
@@ -540,20 +539,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/@langchain/mcp-adapters": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.3.tgz",
@@ -601,9 +586,9 @@
       }
     },
     "node_modules/@langchain/protocol": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -842,14 +827,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -874,9 +859,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1891,9 +1876,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1908,9 +1893,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1925,9 +1910,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1942,9 +1927,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1959,9 +1944,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1976,9 +1961,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1996,9 +1981,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -2016,9 +2001,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2036,9 +2021,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2056,9 +2041,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2076,9 +2061,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2096,9 +2081,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2113,9 +2098,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2132,9 +2117,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2149,9 +2134,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2242,6 +2227,85 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.5.tgz",
+      "integrity": "sha512-/qabIt/IuPsGlE6RukJ0zOirc6afNxoK7fK1WBNVnHuJjeOpSkW+7q1QW5XQGXBMv3odcD0ZgRR+MBiAHduYSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.5.tgz",
+      "integrity": "sha512-Pz1GGUC6iL6xGVqhyo+fYg35kl4j/HONMEoC1voN3DcBOCcVlzq+ljvMpvE+oQiR7Q38xLhIxZneLCqMp5YrQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.5.tgz",
+      "integrity": "sha512-Z6GPYjozrmTuzWQD0x7o8RPm+4HC7hz9q23hdB3U1+Qahesv8Mtc+wo82tO4CG6/NRnJ9u79DlEhmR1DxUU4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/distance": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
@@ -2277,6 +2341,135 @@
       "license": "MIT",
       "dependencies": {
         "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.5.tgz",
+      "integrity": "sha512-mR1NAIX+JfpYAJQ9u3gpIV37QzYvBOefDP+/16uBCAOM8Fp12goT8l7WdenT0dvB4wPibbqM2+2kyEl5u9XJog==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.5.tgz",
+      "integrity": "sha512-Mat5tvJcW3grpXCNFcMvjHL3d8hO4eoIgF3qYpXj25BHx/S7SJUOgyCV5x3arC0rCfM/cB71VmNDm9k57ec7bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.5.tgz",
+      "integrity": "sha512-G4bejYKT0vCQZryMhEoS9aLmP7ThDg6nb3zi3wPzELiTrGNOd2YgkWVheQDGCk4hcqEIWZc9fI2alaRSSkkLVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.5.tgz",
+      "integrity": "sha512-pYjBAuQTND0+6Y+v+zlQ7Y68SGjP4iG8qJ5QKjFRbB/yeorTY3m9yiXIN4lSyno3TPzEgBeNULuo26H6ygDyng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.5.tgz",
+      "integrity": "sha512-dBFxmKrjRaAdwc4SCmGyAS2BDPCH35IBNl++Ypd1RB8JR2D3khl3zrTvxrlJ5qoN1WDvyPbvDYCrt2UnTX+8Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -3532,12 +3725,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3713,17 +3906,17 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3977,9 +4170,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3989,9 +4182,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4078,9 +4271,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4312,9 +4505,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5567,10 +5770,25 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5588,7 +5806,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5658,9 +5876,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5874,13 +6092,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.130.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -5890,21 +6108,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -6474,6 +6692,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
@@ -6509,9 +6736,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6524,6 +6751,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
@@ -6745,21 +6978,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6777,17 +6995,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7101,9 +7319,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,12 @@
   "dependencies": {
     "@ignfab/gpf-schema-store": "^0.1.5",
     "@rgrove/parse-xml": "^4.2.0",
+    "@turf/boolean-intersects": "^7.3.5",
+    "@turf/boolean-point-in-polygon": "^7.3.5",
     "@turf/distance": "^7.3.5",
     "@turf/helpers": "^7.3.5",
+    "@turf/point-to-line-distance": "^7.3.5",
+    "@turf/polygon-to-line": "^7.3.5",
     "jsts": "^2.12.1",
     "mcp-framework": "^0.2.22",
     "node-fetch": "^3.3.2",

--- a/src/gpf/itinerary.ts
+++ b/src/gpf/itinerary.ts
@@ -8,8 +8,10 @@ export const NAVIGATION_ITINERARY_SOURCE = "Géoplateforme (calcul d'itinéraire
 export const NAVIGATION_ITINERARY_URL = "https://data.geopf.fr/navigation/itineraire";
 export const ITINERARY_RESOURCE = "bdtopo-osrm";
 export const ITINERARY_PROFILES = ["car", "pedestrian"] as const;
+export const ITINERARY_METRICS = ["time", "distance"] as const;
 
 export type ItineraryProfile = typeof ITINERARY_PROFILES[number];
+export type ItineraryMetrics = typeof ITINERARY_METRICS[number];
 
 type GeoJsonGeometryLike = {
   type: string;
@@ -32,6 +34,7 @@ export type ItineraryGeometryInput = {
     lat: number;
   }
   profile: ItineraryProfile;
+  shortest?: ItineraryMetrics;
   needGeometry?: boolean;
 };
 
@@ -60,7 +63,7 @@ export class NavigationItineraryClient {
       start: `${input.departure.lon},${input.departure.lat}`,
       end: `${input.arrival.lon},${input.arrival.lat}`,
       profile: input.profile,
-      optimization: "fastest",
+      optimization: input.shortest == "distance" ? "shortest" : "fastest",
       timeUnit: "minute",
       distanceUnit: "meter",
       crs: "EPSG:4326",

--- a/src/gpf/itinerary.ts
+++ b/src/gpf/itinerary.ts
@@ -1,0 +1,96 @@
+import { fetchJSONGet } from "../helpers/http.js";
+import logger from "../logger.js";
+import type { JsonFetcher } from "../helpers/http.js";
+import { RateLimiter } from "../helpers/RateLimiter.js";
+import { getEnv } from "../config/env.js";
+
+export const NAVIGATION_ITINERARY_SOURCE = "Géoplateforme (calcul d'itinéraire)";
+export const NAVIGATION_ITINERARY_URL = "https://data.geopf.fr/navigation/itineraire";
+export const ITINERARY_RESOURCE = "bdtopo-osrm";
+export const ITINERARY_PROFILES = ["car", "pedestrian"] as const;
+
+export type ItineraryProfile = typeof ITINERARY_PROFILES[number];
+
+type GeoJsonGeometryLike = {
+  type: string;
+  coordinates: unknown;
+};
+
+type ItineraryResponse = {
+  distance: number;
+  duration: number;
+  geometry?: unknown;
+};
+
+export type ItineraryGeometryInput = {
+  departure: {
+    lon: number;
+    lat: number;
+  },
+  arrival: {
+    lon: number;
+    lat: number;
+  }
+  profile: ItineraryProfile;
+  needGeometry?: boolean;
+};
+
+function isGeoJsonGeometryLike(value: unknown): value is GeoJsonGeometryLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof value.type === "string" &&
+    "coordinates" in value
+  );
+}
+
+export class NavigationItineraryClient {
+  constructor(
+    private rateLimiter: RateLimiter,
+    private fetcher: JsonFetcher<ItineraryResponse> = fetchJSONGet,
+  ) {}
+
+  async getItinerary(input: ItineraryGeometryInput): Promise<ItineraryResponse> {
+    await this.rateLimiter.limit();
+    logger.debug(`[gpf:navigation] getItinerary(${JSON.stringify(input)})...`);
+
+    const urlsearch = new URLSearchParams({
+      resource: ITINERARY_RESOURCE,
+      start: `${input.departure.lon},${input.departure.lat}`,
+      end: `${input.arrival.lon},${input.arrival.lat}`,
+      profile: input.profile,
+      optimization: "fastest",
+      timeUnit: "minute",
+      distanceUnit: "meter",
+      crs: "EPSG:4326",
+      geometryFormat: input.needGeometry ? "geojson" : "polyline", // polyline is much more compact
+      getSteps: "false",
+      getBbox: "false",
+    });
+    urlsearch.append('waysAttributes', "name")
+    const url = `${NAVIGATION_ITINERARY_URL}?${urlsearch.toString()}`;
+
+    const json = await this.fetcher(url);
+    if (!input.needGeometry || !isGeoJsonGeometryLike(json.geometry)) {
+      json.geometry = null;
+    }
+
+    return json;
+  }
+}
+
+let defaultNavigationItineraryClient: NavigationItineraryClient | undefined;
+
+function getDefaultNavigationItineraryClient() {
+  defaultNavigationItineraryClient ??= new NavigationItineraryClient(
+    new RateLimiter({ name: "GPF_NAVIGATION", maxCalls: getEnv().GPF_NAVIGATION_RATE_LIMIT, period: 1 }),
+  );
+  return defaultNavigationItineraryClient;
+}
+
+export const navigationItineraryClient = {
+  getItinerary(input: ItineraryGeometryInput) {
+    return getDefaultNavigationItineraryClient().getItinerary(input);
+  },
+};

--- a/src/helpers/distance.ts
+++ b/src/helpers/distance.ts
@@ -1,41 +1,133 @@
-import GeoJSONReader from 'jsts/org/locationtech/jts/io/GeoJSONReader.js'
-import { DistanceOp } from 'jsts/org/locationtech/jts/operation/distance.js'
-import GeometryFactory from 'jsts/org/locationtech/jts/geom/GeometryFactory.js'
+import turfDistance from "@turf/distance";
+import { booleanIntersects } from "@turf/boolean-intersects";
+import { booleanPointInPolygon } from "@turf/boolean-point-in-polygon";
+import { lineString, point } from "@turf/helpers"
+import { polygonToLine } from "@turf/polygon-to-line";
+import { pointToLineDistance } from "@turf/point-to-line-distance";
+import type { Feature, Geometry, LineString, Point, Position } from "geojson";
 
-import turfDistance from '@turf/distance'
-import {point as turfPoint} from '@turf/helpers'
-import type { Geometry } from "geojson";
+type LineFeature = Feature<LineString>;
+
+
+// Extrait tous les segments d'une géométrie comme LineString features
+function extractSegments(g: Geometry): LineFeature[] {
+  const segments: LineFeature[] = [];
+
+  function fromCoords(coords: Position[]): void {
+    for (let i = 0; i < coords.length - 1; i++)
+      segments.push(lineString([coords[i], coords[i + 1]]));
+  }
+
+  if (g.type === "LineString") fromCoords(g.coordinates);
+  else if (g.type === "MultiLineString") g.coordinates.forEach(fromCoords);
+  else if (g.type === "Polygon") g.coordinates.forEach(fromCoords);
+  else if (g.type === "MultiPolygon")
+    g.coordinates.forEach((rings) => rings.forEach(fromCoords));
+  else if (g.type === "GeometryCollection")
+    g.geometries.forEach((geometry) => segments.push(...extractSegments(geometry)));
+
+  return segments;
+}
+
+// Extrait tous les points d'une géométrie
+function extractPoints(g: Geometry): Feature<Point>[] {
+  const pts: Feature<Point>[] = [];
+
+  function collect(coords: unknown, depth: number): void {
+    if (depth === 0) {
+      pts.push(point(coords as Position));
+      return;
+    }
+
+    if (Array.isArray(coords)) {
+      coords.forEach((coord) => collect(coord, depth - 1));
+    }
+  }
+
+  const depths = {
+    Point: 0, MultiPoint: 1,
+    LineString: 1, MultiLineString: 2,
+    Polygon: 2, MultiPolygon: 3,
+  } as const;
+
+  if (g.type === "GeometryCollection") {
+    g.geometries.forEach((geometry) => pts.push(...extractPoints(geometry)));
+    return pts;
+  }
+
+  collect(g.coordinates, depths[g.type]);
+  return pts;
+}
+
+// Distance min entre un ensemble de points et un ensemble de segments
+function pointsToSegmentsMin(pts: Feature<Point>[], segs: LineFeature[], min = Infinity): number {
+  for (const pt of pts) {
+    for (const seg of segs) {
+      const d = pointToLineDistance(pt, seg, { units: "meters" });
+      if (d < min) {
+        min = d;
+      }
+    }
+  }
+  return min;
+}
 
 /**
- * Compute approximative distance in meters between gA and gB.
- * 
- * TODO: replace the lon/lat planar nearest-point step with a geodesic geometry distance.
+ * Compute geodesic distance in meters between gA and gB.
  *
  * @param {object} gA GeoJSON Geometry
  * @param {object} gB GeoJSON Geometry
  */
-export default function distance(gA: Geometry, gB: Geometry): number {
-    const geojsonReader = new GeoJSONReader(new GeometryFactory())
-    const a = geojsonReader.read(gA);
-    const b = geojsonReader.read(gB);
+export function distance(gA: Geometry, gB: Geometry): number {
+  if (gA.type === "Point" && gB.type === "Point") {
+    return turfDistance(gA, gB, { units: "meters" });
+  }
 
-    /*
-     * Get the 2 nearest points between a and b
-     *
-     * Note that it will project according to longitude and latitude axis,
-     * so it is not really accurate, but it is a good approximation
-     */
-    const nearestPoints = DistanceOp.nearestPoints(a, b);
-    if ( nearestPoints.length !== 2 ) {
-        throw new Error('DistanceOp.nearestPoints should return 2 points');
+  if (gB.type === "Point") {
+    // Make it so that gA is the Point if either gA or gB is a Point with a recursive call
+    return distance(gB, gA);
+  }
+
+  if (gA.type === "Point" && gB.type === "LineString") {
+    return pointToLineDistance(gA, gB, { units: "meters" });
+  }
+
+  if (gA.type === "Point" && gB.type === "Polygon") {
+    if (booleanPointInPolygon(gA, gB)) {
+      return 0;
     }
 
-    /*
-     * haversine distance between the 2 nearest points (see https://turfjs.org/docs/api/distance)
-     */
-    return turfDistance(
-        turfPoint([nearestPoints[0].x, nearestPoints[0].y]), 
-        turfPoint([nearestPoints[1].x, nearestPoints[1].y]), 
-        { units: 'meters' }
-    );
+    const outline = polygonToLine(gB);
+
+    const lineSegments: LineFeature[] = [];
+    const outlineFeatures = outline.type === "FeatureCollection" ? outline.features : [outline];
+
+    for (const feature of outlineFeatures) {
+      if (feature.geometry.type === "LineString") {
+        lineSegments.push(feature as LineFeature);
+      } else {
+        feature.geometry.coordinates.forEach((coords) => {
+          lineSegments.push(lineString(coords));
+        });
+      }
+    }
+
+    return pointsToSegmentsMin([point(gA.coordinates)], lineSegments);
+  }
+
+  try {
+    if (booleanIntersects(gA, gB))
+      return 0;
+  } catch {}
+
+  const ptsA = extractPoints(gA), segsA = extractSegments(gA);
+  const ptsB = extractPoints(gB), segsB = extractSegments(gB);
+
+  const r1 = pointsToSegmentsMin(ptsA, segsB);
+  const r2 = pointsToSegmentsMin(ptsB, segsA);
+
+  return Number((r1 <= r2 ? r1 : r2).toFixed(3)); // round to 1mm precision
 }
+
+
+export default distance

--- a/src/helpers/distance.ts
+++ b/src/helpers/distance.ts
@@ -130,4 +130,79 @@ export function distance(gA: Geometry, gB: Geometry): number {
 }
 
 
+
+// The following code is taken from node-vincenty (with minor changes and typescript annotations)
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
+/* Vincenty Direct Solution of Geodesics on the Ellipsoid (c) Chris Veness 2005-2012              */
+/*                                                                                                */
+/* from: Vincenty direct formula - T Vincenty, "Direct and Inverse Solutions of Geodesics on the  */
+/*       Ellipsoid with application of nested equations", Survey Review, vol XXII no 176, 1975    */
+/*       http://www.ngs.noaa.gov/PUBS_LIB/inverse.pdf                                             */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
+
+function toRad(Value : number) {
+  /** Converts numeric degrees to radians */
+  return Value * Math.PI / 180;
+}
+
+/**
+ * Compute the geodesic distance in meters between two points, using Vincenty formula.
+ *
+ * @param {object} lat1 latitude of the first point
+ * @param {object} lon1 longitude of the first point
+ * @param {object} lat2 latitude of the second point
+ * @param {object} lon2 longitude of the second point
+ */
+export function distanceVincenty(lat1 : number, lon1 : number, lat2 : number, lon2 : number) {
+  var a = 6378137,
+    b = 6356752.314245,
+    f = 1 / 298.257223563;  // WGS-84 ellipsoid params
+
+  var L = toRad(( lon2 - lon1 ));
+  var U1 = Math.atan(( 1 - f ) * Math.tan( toRad(lat1) ));
+  var U2 = Math.atan(( 1 - f ) * Math.tan( toRad(lat2) ));
+  var sinU1 = Math.sin(U1), cosU1 = Math.cos(U1);
+  var sinU2 = Math.sin(U2), cosU2 = Math.cos(U2);
+
+  var lambda = L, lambdaP, iterLimit = 100;
+  do {
+    var sinLambda = Math.sin(lambda), cosLambda = Math.cos(lambda);
+    var sinSigma = Math.sqrt((cosU2*sinLambda) * (cosU2*sinLambda) +
+      (cosU1*sinU2-sinU1*cosU2*cosLambda) * (cosU1*sinU2-sinU1*cosU2*cosLambda));
+    if (sinSigma==0) {
+      // var result = { distance: 0, initialBearing: 0, finalBearing: 0 };
+      return 0;
+    };  // co-incident points
+    var cosSigma = sinU1*sinU2 + cosU1*cosU2*cosLambda;
+    var sigma = Math.atan2(sinSigma, cosSigma);
+    var sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
+    var cosSqAlpha = 1 - sinAlpha*sinAlpha;
+    var cos2SigmaM = cosSigma - 2*sinU1*sinU2/cosSqAlpha;
+    if (isNaN(cos2SigmaM)) cos2SigmaM = 0;  // equatorial line: cosSqAlpha=0 (§6)
+    var C = f/16*cosSqAlpha*(4+f*(4-3*cosSqAlpha));
+    lambdaP = lambda;
+    lambda = L + (1-C) * f * sinAlpha *
+      (sigma + C*sinSigma*(cos2SigmaM+C*cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)));
+  } while (Math.abs(lambda-lambdaP) > 1e-12 && --iterLimit>0);
+
+  if (iterLimit==0) return NaN  // formula failed to converge
+
+  var uSq = cosSqAlpha * (a*a - b*b) / (b*b);
+  var A = 1 + uSq/16384*(4096+uSq*(-768+uSq*(320-175*uSq)));
+  var B = uSq/1024 * (256+uSq*(-128+uSq*(74-47*uSq)));
+  var deltaSigma = B*sinSigma*(cos2SigmaM+B/4*(cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)-
+    B/6*cos2SigmaM*(-3+4*sinSigma*sinSigma)*(-3+4*cos2SigmaM*cos2SigmaM)));
+  var s = b*A*(sigma-deltaSigma);
+
+  s = Number(s.toFixed(3)); // round to 1mm precision
+
+  // // note: to return initial/final bearings in addition to distance, use something like:
+  // var fwdAz = Math.atan2(cosU2*sinLambda,  cosU1*sinU2-sinU1*cosU2*cosLambda);
+  // var revAz = Math.atan2(cosU1*sinLambda, -sinU1*cosU2+cosU1*sinU2*cosLambda);
+  // var result = { distance: s, initialBearing: toDeg(fwdAz), finalBearing: toDeg(revAz) };
+
+  return s;
+}
+
 export default distance

--- a/src/tools/DistanceTool.ts
+++ b/src/tools/DistanceTool.ts
@@ -5,7 +5,7 @@
 import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
-import { NAVIGATION_ITINERARY_SOURCE, navigationItineraryClient } from "../gpf/itinerary.js";
+import { NAVIGATION_ITINERARY_SOURCE, navigationItineraryClient, ITINERARY_METRICS, ItineraryGeometryInput } from "../gpf/itinerary.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { lonSchema, latSchema } from "../helpers/schemas.js";
 import logger from "../logger.js";
@@ -30,6 +30,14 @@ const distanceInputSchema = z.object({
       " `vincenty` distance à vol d'oiseau (Terre ellipsoïde, plus précise et coûteuse, précision à 0.5mm)",
       " `pedestrian` à pied, `car` en voiture",
       ". Par défaut : `direct`."
+    ].join("")),
+  shortest: z
+    .enum(ITINERARY_METRICS)
+    .default("time")
+    .describe(["La métrique à optimiser, lorsqu'il y a un choix:",
+      " `time` chemin le plus rapide,",
+      " `distance` chemin le plus court.",
+      " Cette option est sans effet lorsque `profile=direct` ou `vincenty`."
     ].join(""))
 }).strict();
 
@@ -86,11 +94,7 @@ class DistanceTool extends BaseTool<DistanceInput> {
         }
       } 
       default: {
-        const itinerary = await navigationItineraryClient.getItinerary({
-          departure: input.departure,
-          arrival: input.arrival,
-          profile: input.profile,
-        });
+        const itinerary = await navigationItineraryClient.getItinerary(input as ItineraryGeometryInput);
         return {
           distance: itinerary.distance,
           time: Math.floor(itinerary.duration)

--- a/src/tools/DistanceTool.ts
+++ b/src/tools/DistanceTool.ts
@@ -5,6 +5,7 @@
 import BaseTool from "./BaseTool.js";
 import { z } from "zod";
 
+import { NAVIGATION_ITINERARY_SOURCE, navigationItineraryClient } from "../gpf/itinerary.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
 import { lonSchema, latSchema } from "../helpers/schemas.js";
 import logger from "../logger.js";
@@ -22,11 +23,12 @@ const distanceInputSchema = z.object({
     lat: latSchema,
   }).describe("Le point d'arrivée"),
   profile: z
-    .enum(["direct", "vincenty"])
+    .enum(["direct", "vincenty", "pedestrian", "car"])
     .default("direct")
     .describe(["Le type de chemin suivi :",
       " `direct` distance à vol d'oiseau (approximation Terre plate ou Terre ronde, précision à 0.5%),",
       " `vincenty` distance à vol d'oiseau (Terre ellipsoïde, plus précise et coûteuse, précision à 0.5mm)",
+      " `pedestrian` à pied, `car` en voiture",
       ". Par défaut : `direct`."
     ].join(""))
 }).strict();
@@ -37,15 +39,20 @@ type DistanceInput = z.infer<typeof distanceInputSchema>;
 
 const distanceResultSchema = z.object({
   distance: z.number().describe("La distance entre les deux points, en mètres."),
+  time: z.number().optional().describe("Estimation du temps de trajet, en minutes. Absent si `profile`=`direct` ou `vincenty`."),
 });
 
 // --- Tool ---
 
 class DistanceTool extends BaseTool<DistanceInput> {
   name = "distance";
-  title = "Distance entre deux points";
+  title = "Distance et temps de trajet entre deux points";
   annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;
-  description = `Renvoie la distance (en mètres) entre deux points à partir de leur longitude et latitude.`;
+  description = [
+    `Renvoie la distance (en mètres) entre deux points à partir de leur longitude et latitude.`,
+    `Renvoie aussi une estimation du temps de trajet dans le cas où un profil (marche, voiture) est renseigné.`,
+    `(source : ${NAVIGATION_ITINERARY_SOURCE}).`,
+  ].join("\n");
   protected outputSchemaShape = distanceResultSchema;
 
   schema = distanceInputSchema;
@@ -65,17 +72,28 @@ class DistanceTool extends BaseTool<DistanceInput> {
       case "direct": {
         return {
           distance: distanceInternal({
-          type : "Point",
-          coordinates: [input.departure.lon, input.departure.lat]
-        }, {
-          type : "Point",
-          coordinates: [input.arrival.lon, input.arrival.lat]
-        })
+            type : "Point",
+            coordinates: [input.departure.lon, input.departure.lat]
+          }, {
+            type : "Point",
+            coordinates: [input.arrival.lon, input.arrival.lat]
+          })
         }
       }
       case "vincenty": {
         return {
           distance: distanceVincenty(input.departure.lat, input.departure.lon, input.arrival.lat, input.arrival.lon)
+        }
+      } 
+      default: {
+        const itinerary = await navigationItineraryClient.getItinerary({
+          departure: input.departure,
+          arrival: input.arrival,
+          profile: input.profile,
+        });
+        return {
+          distance: itinerary.distance,
+          time: Math.floor(itinerary.duration)
         }
       }
     }

--- a/src/tools/DistanceTool.ts
+++ b/src/tools/DistanceTool.ts
@@ -1,0 +1,85 @@
+/**
+ * MCP tool exposing distance lookup for a single geographic position.
+ */
+
+import BaseTool from "./BaseTool.js";
+import { z } from "zod";
+
+import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
+import { lonSchema, latSchema } from "../helpers/schemas.js";
+import logger from "../logger.js";
+import { distance as distanceInternal, distanceVincenty } from "../helpers/distance.js"
+
+// --- Schema ---
+
+const distanceInputSchema = z.object({
+  departure: z.object({
+    lon: lonSchema,
+    lat: latSchema,
+  }).describe("Le point de départ"),
+  arrival: z.object({
+    lon: lonSchema,
+    lat: latSchema,
+  }).describe("Le point d'arrivée"),
+  profile: z
+    .enum(["direct", "vincenty"])
+    .default("direct")
+    .describe(["Le type de chemin suivi :",
+      " `direct` distance à vol d'oiseau (approximation Terre plate ou Terre ronde, précision à 0.5%),",
+      " `vincenty` distance à vol d'oiseau (Terre ellipsoïde, plus précise et coûteuse, précision à 0.5mm)",
+      ". Par défaut : `direct`."
+    ].join(""))
+}).strict();
+
+// --- Types ---
+
+type DistanceInput = z.infer<typeof distanceInputSchema>;
+
+const distanceResultSchema = z.object({
+  distance: z.number().describe("La distance entre les deux points, en mètres."),
+});
+
+// --- Tool ---
+
+class DistanceTool extends BaseTool<DistanceInput> {
+  name = "distance";
+  title = "Distance entre deux points";
+  annotations = READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS;
+  description = `Renvoie la distance (en mètres) entre deux points à partir de leur longitude et latitude.`;
+  protected outputSchemaShape = distanceResultSchema;
+
+  schema = distanceInputSchema;
+
+  /**
+   * Resolves the distance query.
+   *
+   * @param input Normalized tool input.
+   * @returns The distance.
+   */
+  async execute(input: DistanceInput) {
+    logger.info(`[tool] execute ${this.name} ...`, {
+      input: input
+    });
+
+    switch (input.profile) {
+      case "direct": {
+        return {
+          distance: distanceInternal({
+          type : "Point",
+          coordinates: [input.departure.lon, input.departure.lat]
+        }, {
+          type : "Point",
+          coordinates: [input.arrival.lon, input.arrival.lat]
+        })
+        }
+      }
+      case "vincenty": {
+        return {
+          distance: distanceVincenty(input.departure.lat, input.departure.lon, input.arrival.lat, input.arrival.lon)
+        }
+      }
+    }
+  }
+}
+
+export default DistanceTool;

--- a/test/gpf/itinerary.test.ts
+++ b/test/gpf/itinerary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { NavigationItineraryClient } from "../../src/gpf/itinerary.js";
+import { RateLimiter } from "../../src/helpers/RateLimiter.js";
+
+describe("NavigationItineraryClient", () => {
+  it("should build an itinerary request and return distance and duration", async () => {
+    const urls: string[] = [];
+    const client = new NavigationItineraryClient(
+      new RateLimiter({ name: "test", maxCalls: 100, period: 1 }),
+      async (url) => {
+        urls.push(url);
+        return {
+          distance: 395174,
+          duration: 212,
+        };
+      },
+    );
+
+    const itinerary = await client.getItinerary({
+      departure: { // 117 rue de Paris, 02100 Saint-Quentin
+        lon: 3.274356,
+        lat: 49.839862,
+      },
+      arrival: { // 8 place de la République, 21000 Dijon
+        lon: 5.044572,
+        lat: 47.326213,
+      },
+      profile: "car",
+    });
+
+    expect(itinerary).toEqual({
+      distance: 395174,
+      duration: 212,
+      geometry: null,
+    });
+
+    const parsedUrl = new URL(urls[0]);
+    expect(parsedUrl.origin + parsedUrl.pathname).toEqual("https://data.geopf.fr/navigation/itineraire");
+    expect(parsedUrl.searchParams.get("resource")).toEqual("bdtopo-osrm");
+    expect(parsedUrl.searchParams.get("start")).toEqual("3.274356,49.839862");
+    expect(parsedUrl.searchParams.get("end")).toEqual("5.044572,47.326213");
+    expect(parsedUrl.searchParams.get("profile")).toEqual("car");
+    expect(parsedUrl.searchParams.get("optimization")).toEqual("fastest");
+    expect(parsedUrl.searchParams.get("timeUnit")).toEqual("minute");
+    expect(parsedUrl.searchParams.get("distanceUnit")).toEqual("meter");
+    expect(parsedUrl.searchParams.get("crs")).toEqual("EPSG:4326");
+    expect(parsedUrl.searchParams.get("geometryFormat")).toEqual("polyline");
+    expect(parsedUrl.searchParams.get("getSteps")).toEqual("false");
+    expect(parsedUrl.searchParams.get("getBbox")).toEqual("false");
+    expect(parsedUrl.searchParams.get("waysAttributes")).toEqual("name");
+  });
+});

--- a/test/helpers/distance.test.ts
+++ b/test/helpers/distance.test.ts
@@ -14,7 +14,7 @@ describe("Test distance",() => {
     describe("Test distance(Point,LineString)", () => {
         it("should return 209731.2m from Besançon to [Paris,Marseille]",() => {
             const result = distance(besancon,parisMarseille);
-            expect(result).toBeCloseTo(209731.2,1);
+            expect(result).toBeCloseTo(192749.6,1);
         });
     });
 

--- a/test/integration/level2-agent/level2-agent.test.ts
+++ b/test/integration/level2-agent/level2-agent.test.ts
@@ -90,6 +90,13 @@ const mcpScenarios = [
     // assuming that it won't often change and that the number is correct at the moment of writing
     // (switch to assertScenarioResult with a range if needed in the future)
     expectedResponseFragments: ["19", "batiments"] 
+  },
+  {
+    testName: "should find that Sivom swimming pool in Mondeville is the nearest pool to the LUX cinema in Caen, and that the walking distance is 29 minutes",
+    userInput: "Quelle est le temps de marche exact entre le cinéma LUX, situé au sud-est de Caen, et la piscine la plus proche ?",
+    toolMode: "mcp",
+    requiredToolCalls: ["geocode", "gpf_wfs_search_types", "gpf_wfs_describe_type", "gpf_wfs_get_features", "distance"],
+    expectedResponseFragments: ["Sivom", "Mondeville", "29 minutes"]
   }
 ] satisfies Level2AgentScenario[];
 

--- a/test/integration/samples.ts
+++ b/test/integration/samples.ts
@@ -23,4 +23,5 @@ export const EXPECTED_TOOL_NAMES = [
   "gpf_wfs_describe_type",
   "gpf_wfs_get_features",
   "gpf_wfs_get_feature_by_id",
+  "distance"
 ] as const;

--- a/test/tools/distance.test.ts
+++ b/test/tools/distance.test.ts
@@ -43,6 +43,7 @@ describe("Test DistanceTool", () => {
         lat: 47.326213,
       },
       profile: "car",
+      shortest: "time",
     });
     expect(response.isError).toBeUndefined();
     expect(response.content[0]).toMatchObject({

--- a/test/tools/distance.test.ts
+++ b/test/tools/distance.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { navigationItineraryClient } from "../../src/gpf/itinerary.js";
+import DistanceTool from "../../src/tools/DistanceTool";
+
+describe("Test DistanceTool", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return itinerary distance and time for car profile", async () => {
+    const tool = new DistanceTool();
+    const getItinerarySpy = vi.spyOn(navigationItineraryClient, "getItinerary").mockResolvedValue({
+      distance: 395174,
+      duration: 212,
+      geometry: null,
+    });
+
+    const response = await tool.toolCall({
+      params: {
+        name: "distance",
+        arguments: {
+          departure: {
+            lon: 3.274356,
+            lat: 49.839862,
+          },
+          arrival: {
+            lon: 5.044572,
+            lat: 47.326213,
+          },
+          profile: "car",
+        },
+      },
+    });
+
+    expect(getItinerarySpy).toHaveBeenCalledWith({
+      departure: {
+        lon: 3.274356,
+        lat: 49.839862,
+      },
+      arrival: {
+        lon: 5.044572,
+        lat: 47.326213,
+      },
+      profile: "car",
+    });
+    expect(response.isError).toBeUndefined();
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+    });
+
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+
+    expect(JSON.parse(textContent.text)).toEqual({
+      distance: 395174,
+      time: 212,
+    });
+    expect(response.structuredContent).toEqual({
+      distance: 395174,
+      time: 212,
+    });
+  });
+});


### PR DESCRIPTION
Replace the previous `distance` helper implementation with a purely turf-based implementation (1c7885d48745562c10aceb93ca4882d1976e2eb0).

Also add a `distance` tool to expose this primitive to the LLM for the specific case of point-to-point computation. This tool works with four different profiles:
- `direct`: distance as the crow flies (close #138).
- `vincenty` for exact ellipsoid distance.
- `car` and `pedestrian`: distances along an itinerary, computed with the Geoplateforme.

With the two latest mode, the time of travel is also returned. The itinerary can be chosen as the shortest time or the shortest distance.