### PR TITLE
feat: Add `spatial_extras` options to GpfGetFeatures(ById)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1100,8 +1100,9 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
 | Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `feature_id` | string | oui | Identifiant GPF exact de l'objet à récupérer, par exemple `commune.8952`. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
-| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Quand `result_type="http_post_request"` ou `result_type="http_get_url"`, la géométrie est automatiquement ajoutée. |
+| `geometry_extra` | array | non | Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
+| `select` | array | non | Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
 | `typename` | string | oui | Nom exact du type GPF à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
 
 <details>
@@ -1129,7 +1130,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
         "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."
+      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."
     },
     "select": {
       "type": "array",
@@ -1138,7 +1139,19 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
         "minLength": 1
       },
       "minItems": 1,
-      "description": "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée."
+      "description": "Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."
+    },
+    "geometry_extra": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "centroid",
+          "bbox"
+        ]
+      },
+      "default": [],
+      "description": "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
     }
   },
   "required": [
@@ -1195,6 +1208,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
 | --- | --- | --- | --- |
 | `bbox_filter` | object | non | Filtre spatial par boîte englobante. Exclusif avec les autres filtres spatiaux. |
 | `dwithin_point_filter` | object | non | Filtre spatial par distance à un point. Exclusif avec les autres filtres spatiaux. |
+| `geometry_extra` | array | non | Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
 | `intersects_feature_filter` | object | non | Filtre spatial par intersection avec un feature GPF de référence. Exclusif avec les autres filtres spatiaux. |
 | `intersects_point_filter` | object | non | Filtre spatial par intersection avec un point. Exclusif avec les autres filtres spatiaux. |
 | `limit` | integer | non | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Valeur par défaut : 100. |
@@ -1467,6 +1481,18 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
       },
       "minItems": 1,
       "description": "Liste ordonnée des critères de tri."
+    },
+    "geometry_extra": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "centroid",
+          "bbox"
+        ]
+      },
+      "default": [],
+      "description": "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
     }
   },
   "required": [

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1100,9 +1100,9 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
 | Champ | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `feature_id` | string | oui | Identifiant GPF exact de l'objet à récupérer, par exemple `commune.8952`. |
-| `geometry_extra` | array | non | Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
-| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
+| `result_type` | string (enum) | non | `results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `spatial_extras` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
 | `select` | array | non | Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
+| `spatial_extras` | array | non | Éléments calculés depuis la géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
 | `typename` | string | oui | Nom exact du type GPF à interroger, par exemple `ADMINEXPRESS-COG.LATEST:commune`. |
 
 <details>
@@ -1130,7 +1130,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
         "http_get_url"
       ],
       "default": "results",
-      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."
+      "description": "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `spatial_extras` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."
     },
     "select": {
       "type": "array",
@@ -1141,7 +1141,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
       "minItems": 1,
       "description": "Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."
     },
-    "geometry_extra": {
+    "spatial_extras": {
       "type": "array",
       "items": {
         "type": "string",
@@ -1151,7 +1151,7 @@ Utiliser `result_type="http_post_request"` pour récupérer une requête POST ro
         ]
       },
       "default": [],
-      "description": "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
+      "description": "Éléments calculés depuis la géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
     }
   },
   "required": [
@@ -1208,13 +1208,13 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
 | --- | --- | --- | --- |
 | `bbox_filter` | object | non | Filtre spatial par boîte englobante. Exclusif avec les autres filtres spatiaux. |
 | `dwithin_point_filter` | object | non | Filtre spatial par distance à un point. Exclusif avec les autres filtres spatiaux. |
-| `geometry_extra` | array | non | Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
 | `intersects_feature_filter` | object | non | Filtre spatial par intersection avec un feature GPF de référence. Exclusif avec les autres filtres spatiaux. |
 | `intersects_point_filter` | object | non | Filtre spatial par intersection avec un point. Exclusif avec les autres filtres spatiaux. |
 | `limit` | integer | non | Nombre maximum d'objets à renvoyer. Valeur par défaut : 100. Maximum : 5000. Valeur par défaut : 100. |
 | `order_by` | array | non | Liste ordonnée des critères de tri. |
 | `result_type` | string (enum) | non | `results` renvoie une FeatureCollection avec les propriétés attributaires uniquement — **les géométries ne sont pas incluses**, ce mode ne peut donc pas être utilisé directement pour cartographier. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant. Avec `http_post_request` ou `http_get_url`, la géométrie est automatiquement ajoutée aux propriétés du `select` pour garantir l'affichage cartographique. Valeurs : results, http_post_request, http_get_url. Valeur par défaut : results. |
 | `select` | array | non | Liste des propriétés non géométriques à renvoyer pour chaque objet. Utiliser `gpf_describe_type` pour connaître les noms exacts disponibles. Exemple : `["code_insee", "nom_officiel"]`. |
+| `spatial_extras` | array | non | Éléments calculés depuis la géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut. Valeur par défaut : []. |
 | `travel_time_filter` | object | non | Filtre spatial par temps de trajet depuis un point (`profile` voiture ou piéton). Exclusif avec les autres filtres spatiaux. |
 | `typename` | string | oui | Nom exact du type GPF à interroger, par exemple `BDTOPO_V3:batiment`. Utiliser `gpf_search_types` pour trouver un `typename` valide. |
 | `where` | array | non | Clauses de filtre attributaire, combinées avec `AND`. |
@@ -1482,7 +1482,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
       "minItems": 1,
       "description": "Liste ordonnée des critères de tri."
     },
-    "geometry_extra": {
+    "spatial_extras": {
       "type": "array",
       "items": {
         "type": "string",
@@ -1492,7 +1492,7 @@ Les noms de propriétés **ne peuvent pas être devinés** : ils sont spécifiqu
         ]
       },
       "default": [],
-      "description": "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
+      "description": "Éléments calculés depuis la géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."
     }
   },
   "required": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@ignfab/gpf-schema-store": "^0.1.5",
         "@rgrove/parse-xml": "^4.2.0",
+        "@turf/bbox": "^7.3.5",
+        "@turf/centroid": "^7.3.5",
         "@turf/distance": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "jsts": "^2.12.1",
@@ -391,9 +393,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.47",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.47.tgz",
-      "integrity": "sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==",
+      "version": "1.1.49",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.49.tgz",
+      "integrity": "sha512-7wkN3Qv/qZqsY0p3h48CNu6E6y5GMYatYxj+JrX4uVNBiqIVQm1Z528QrmayJWVW9SQTQicqRNoyTCzl+K9F8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -426,23 +428,22 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.2.tgz",
+      "integrity": "sha512-ivhYwbEKW4i/x2JfHcrTrToEE9EXZnwr4dPj7GC5974xEYeLgHYzii3GAYo1kgU5A0ZAd7rIxTpMOfcbycxliQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.2",
-        "@langchain/langgraph-sdk": "~1.9.4",
-        "@langchain/protocol": "^0.0.15",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "@langchain/langgraph-checkpoint": "^1.1.1",
+        "@langchain/langgraph-sdk": "~1.9.22",
+        "@langchain/protocol": "^0.0.16",
+        "@standard-schema/spec": "1.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -453,36 +454,32 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.1.tgz",
+      "integrity": "sha512-gHqhO6e2dyZ7TTfyaFy25yjcRsavURc9XMGT4q+LUBTc0hT4JxKe3qvrMX2OFTzW8W/0kjV59haHmSRFZIGkvg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^10.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44"
+        "@langchain/core": "^1.1.48"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.4.tgz",
-      "integrity": "sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==",
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.22.tgz",
+      "integrity": "sha512-DBKs9R2SGivlGqK/ZRTOUu39Q7Z+yRrG4PoTYLIWn7pqrLNhyZ4yZI/tEEEi/J0inpCuKfg/eydSwnRmPV/q3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/protocol": "^0.0.15",
+        "@langchain/protocol": "^0.0.16",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
-        "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "p-retry": "^7.1.1"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
@@ -540,20 +537,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/@langchain/mcp-adapters": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.3.tgz",
@@ -601,9 +584,9 @@
       }
     },
     "node_modules/@langchain/protocol": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -842,14 +825,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -874,9 +857,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1891,9 +1874,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1908,9 +1891,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1925,9 +1908,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1942,9 +1925,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1959,9 +1942,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1976,9 +1959,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1996,9 +1979,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -2016,9 +1999,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2036,9 +2019,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2056,9 +2039,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2076,9 +2059,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2096,9 +2079,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2113,9 +2096,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2132,9 +2115,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2149,9 +2132,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2242,6 +2225,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.5.tgz",
+      "integrity": "sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/distance": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
@@ -2274,6 +2287,20 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
       "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
       "license": "MIT",
       "dependencies": {
         "@turf/helpers": "7.3.5",
@@ -3532,12 +3559,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3713,17 +3740,17 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3977,9 +4004,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3989,9 +4016,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4078,9 +4105,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4312,9 +4339,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5568,9 +5605,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5588,7 +5625,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5658,9 +5695,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5874,13 +5911,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.130.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -5890,21 +5927,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -6509,9 +6546,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6745,21 +6782,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6777,17 +6799,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7101,9 +7123,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   "dependencies": {
     "@ignfab/gpf-schema-store": "^0.1.5",
     "@rgrove/parse-xml": "^4.2.0",
+    "@turf/bbox": "^7.3.5",
+    "@turf/centroid": "^7.3.5",
     "@turf/distance": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "jsts": "^2.12.1",

--- a/src/tools/GpfGetFeatureByIdTool.ts
+++ b/src/tools/GpfGetFeatureByIdTool.ts
@@ -142,7 +142,7 @@ class GpfGetFeatureByIdTool extends BaseTool<GpfGetFeatureByIdInput> {
       typename: input.typename,
       feature_id: input.feature_id,
       select: input.select,
-      geometry_extra: input.geometry_extra,
+      geometry_extra: validatedInput.geometry_extra,
     });
   }
 }

--- a/src/tools/GpfGetFeatureByIdTool.ts
+++ b/src/tools/GpfGetFeatureByIdTool.ts
@@ -19,6 +19,7 @@ import {
 import {
   gpfGetFeatureByIdHttpGetUrlOutputSchema,
   gpfGetFeatureByIdHttpPostRequestOutputSchema,
+  gpfGetFeatureByIdInputObjectSchema,
   gpfGetFeatureByIdInputSchema,
   type GpfGetFeatureByIdInput,
   gpfGetFeatureByIdPublishedInputSchema,
@@ -40,7 +41,9 @@ class GpfGetFeatureByIdTool extends BaseTool<GpfGetFeatureByIdInput> {
 
   // `schema` remains the runtime validation source, while `inputSchema`
   // publishes the MCP-facing variant expected by clients.
-  schema = gpfGetFeatureByIdInputSchema;
+  // The framework requires a plain Zod object here to publish a compatible
+  // input schema. Cross-field runtime validation is applied in `execute`.
+  schema = gpfGetFeatureByIdInputObjectSchema;
 
   /**
    * Exposes an input schema variant that stays compatible with most MCP integrations.
@@ -116,20 +119,21 @@ class GpfGetFeatureByIdTool extends BaseTool<GpfGetFeatureByIdInput> {
    * @returns Either an HTTP preview payload or a transformed FeatureCollection containing one feature.
    */
   async execute(input: GpfGetFeatureByIdInput) {
+    const validatedInput = gpfGetFeatureByIdInputSchema.parse(input);
     logger.info(`[tool] execute ${this.name} ...`, {
-      input: input
+      input: validatedInput
     });
 
-    if (input.result_type === "http_post_request" || input.result_type === "http_get_url") {
+    if (validatedInput.result_type === "http_post_request" || validatedInput.result_type === "http_get_url") {
       // HTTP preview modes are handled here because they return a preview payload,
       // not the actual by-id WFS result.
-      const featureType = await wfsClient.getFeatureType(input.typename);
+      const featureType = await wfsClient.getFeatureType(validatedInput.typename);
       const propertyName = buildPropertyName(featureType, {
         includeGeometry: true,
-        select: input.select,
+        select: validatedInput.select,
       });
-      const request = buildGetFeatureByIdRequest(input.typename, input.feature_id, propertyName);
-      return input.result_type === "http_post_request"
+      const request = buildGetFeatureByIdRequest(validatedInput.typename, validatedInput.feature_id, propertyName);
+      return validatedInput.result_type === "http_post_request"
         ? toWfsHttpPostRequestPayload(request)
         : toWfsHttpGetUrlPayload(request);
     }
@@ -138,6 +142,7 @@ class GpfGetFeatureByIdTool extends BaseTool<GpfGetFeatureByIdInput> {
       typename: input.typename,
       feature_id: input.feature_id,
       select: input.select,
+      geometry_extra: input.geometry_extra,
     });
   }
 }

--- a/src/tools/GpfGetFeatureByIdTool.ts
+++ b/src/tools/GpfGetFeatureByIdTool.ts
@@ -142,7 +142,7 @@ class GpfGetFeatureByIdTool extends BaseTool<GpfGetFeatureByIdInput> {
       typename: input.typename,
       feature_id: input.feature_id,
       select: input.select,
-      geometry_extra: validatedInput.geometry_extra,
+      spatial_extras: validatedInput.spatial_extras,
     });
   }
 }

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -27,7 +27,7 @@ export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
-  geometry_extra?: string[];
+  spatial_extras?: string[];
 };
 
 // --- Internal Types ---
@@ -156,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: (input.geometry_extra ?? []).length > 0,
+    includeGeometry: (input.spatial_extras ?? []).length > 0,
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({
@@ -174,5 +174,5 @@ export async function executeGetFeatureById(
     numberMatched: 1,
   };
 
-  return attachFeatureRefs(singleFeatureCollection, input.typename, input.geometry_extra);
+  return attachFeatureRefs(singleFeatureCollection, input.typename, input.spatial_extras);
 }

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -27,6 +27,7 @@ export type GetFeatureByIdExecutionInput = {
   typename: string;
   feature_id: string;
   select?: string[];
+  geometry_extra?: string[];
 };
 
 // --- Internal Types ---
@@ -155,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: false,
+    includeGeometry: (input.geometry_extra ?? []).length != 0,
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({
@@ -173,5 +174,5 @@ export async function executeGetFeatureById(
     numberMatched: 1,
   };
 
-  return attachFeatureRefs(singleFeatureCollection, input.typename);
+  return attachFeatureRefs(singleFeatureCollection, input.typename, input.geometry_extra);
 }

--- a/src/wfs/byId.ts
+++ b/src/wfs/byId.ts
@@ -156,7 +156,7 @@ export async function executeGetFeatureById(
 ) {
   const featureType: Collection = await wfsClient.getFeatureType(input.typename);
   const propertyName = buildPropertyName(featureType, {
-    includeGeometry: (input.geometry_extra ?? []).length != 0,
+    includeGeometry: (input.geometry_extra ?? []).length > 0,
     select: input.select,
   });
   const featureCollection = await fetchFeatureById({

--- a/src/wfs/features.ts
+++ b/src/wfs/features.ts
@@ -248,7 +248,7 @@ export async function executeQueryFeatures(input: GpfQueryFeaturesInput) {
   }
 
   if (isGetFeaturesQuery) {
-    return attachFeatureRefs(featureCollection, input.typename);
+    return attachFeatureRefs(featureCollection, input.typename, input.geometry_extra);
   } else {
     return {
       numberMatched: getMatchedFeatureCount(featureCollection),

--- a/src/wfs/features.ts
+++ b/src/wfs/features.ts
@@ -248,7 +248,7 @@ export async function executeQueryFeatures(input: GpfQueryFeaturesInput) {
   }
 
   if (isGetFeaturesQuery) {
-    return attachFeatureRefs(featureCollection, input.typename, input.geometry_extra);
+    return attachFeatureRefs(featureCollection, input.typename, input.spatial_extras);
   } else {
     return {
       numberMatched: getMatchedFeatureCount(featureCollection),

--- a/src/wfs/properties.ts
+++ b/src/wfs/properties.ts
@@ -119,6 +119,7 @@ export function validateSelectProperty(featureType: Collection, geometryProperty
  * - when `select` is omitted and `result_type` is `results`, every non-geometric property is returned
  * - when `select` is provided, each property is validated against the embedded catalog
  * - when `result_type` is an HTTP preview mode, the geometry column is appended to the requested selection
+ * - when `result_type` is `results` and `geometry_extra` is non-empty, the geometry column is also appended so centroid/bbox can be derived
  *
  * @param featureType Feature type definition loaded from the embedded catalog.
  * @param geometryProperty Geometry property already resolved for the feature type.
@@ -156,7 +157,7 @@ export function buildSelectList(
       .filter((property: CollectionProperty) => !property.defaultCrs)
       .map((property: CollectionProperty) => property.name);
 
-    if ((input.geometry_extra ?? []).length > 0) {
+    if (shouldIncludeGeometry) {
       return [...nonGeometryProperties, geometryProperty.name];
     }
 

--- a/src/wfs/properties.ts
+++ b/src/wfs/properties.ts
@@ -130,6 +130,10 @@ export function buildSelectList(
   geometryProperty: CollectionProperty,
   input: GpfGetFeaturesInput,
 ) {
+  const shouldIncludeGeometry =
+    (input.result_type === "http_post_request" || input.result_type === "http_get_url") ||
+    (input.result_type === "results" && (input.geometry_extra ?? []).length > 0);
+
   // If `select` is specified, only the requested properties are returned
   // after validation against the embedded catalog.
   if (input.select && input.select.length > 0) {
@@ -137,9 +141,8 @@ export function buildSelectList(
       validateSelectProperty(featureType, geometryProperty, propertyName),
     );
 
-    // For HTTP preview modes, also include the geometry column so the compiled
-    // request stays directly usable for mapping/debugging.
-    if (input.result_type === "http_post_request" || input.result_type === "http_get_url") {
+    // Include geometry when requested by output mode or by geometry_extra.
+    if (shouldIncludeGeometry) {
       return [...selectedProperties, geometryProperty.name];
     }
 
@@ -149,9 +152,15 @@ export function buildSelectList(
   // If `select` is omitted and `result_type="results"`, return every
   // non-geometric property from the feature type.
   if (input.result_type === "results") {
-    return featureType.properties
+    const nonGeometryProperties = featureType.properties
       .filter((property: CollectionProperty) => !property.defaultCrs)
       .map((property: CollectionProperty) => property.name);
+
+    if ((input.geometry_extra ?? []).length > 0) {
+      return [...nonGeometryProperties, geometryProperty.name];
+    }
+
+    return nonGeometryProperties;
   }
 
   // If `select` is omitted and `result_type` is an HTTP preview mode,

--- a/src/wfs/properties.ts
+++ b/src/wfs/properties.ts
@@ -119,7 +119,7 @@ export function validateSelectProperty(featureType: Collection, geometryProperty
  * - when `select` is omitted and `result_type` is `results`, every non-geometric property is returned
  * - when `select` is provided, each property is validated against the embedded catalog
  * - when `result_type` is an HTTP preview mode, the geometry column is appended to the requested selection
- * - when `result_type` is `results` and `geometry_extra` is non-empty, the geometry column is also appended so centroid/bbox can be derived
+ * - when `result_type` is `results` and `spatial_extras` is non-empty, the geometry column is also appended so elements of GPF_GET_FEATURES_SPATIAL_EXTRAS (bbox, centroid, ...) can be derived
  *
  * @param featureType Feature type definition loaded from the embedded catalog.
  * @param geometryProperty Geometry property already resolved for the feature type.
@@ -133,7 +133,7 @@ export function buildSelectList(
 ) {
   const shouldIncludeGeometry =
     (input.result_type === "http_post_request" || input.result_type === "http_get_url") ||
-    (input.result_type === "results" && (input.geometry_extra ?? []).length > 0);
+    (input.result_type === "results" && (input.spatial_extras ?? []).length > 0);
 
   // If `select` is specified, only the requested properties are returned
   // after validation against the embedded catalog.
@@ -142,7 +142,7 @@ export function buildSelectList(
       validateSelectProperty(featureType, geometryProperty, propertyName),
     );
 
-    // Include geometry when requested by output mode or by geometry_extra.
+    // Include geometry when requested by output mode or by spatial_extras.
     if (shouldIncludeGeometry) {
       return [...selectedProperties, geometryProperty.name];
     }

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -17,19 +17,19 @@ function isGeoJson(value: unknown): value is AllGeoJSON {
 }
 
 function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
-  if (geometry_extra.length == 0 || !isGeoJson(geometry)) {
+  if (geometry_extra.length === 0 || !isGeoJson(geometry)) {
     return null;
   }
 
-  const ret : Record<string, unknown> = {}
+  const ret : Record<string, unknown> = {};
 
   if (geometry_extra.includes("centroid")) {
     try {
-      const centr = centroid(geometry).geometry.coordinates
+      const centr = centroid(geometry).geometry.coordinates;
       ret.centroid = {
         lon: centr[0],
         lat: centr[1],
-      }
+      };
     } catch {}
   }
 
@@ -41,7 +41,7 @@ function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
         south: bb[1],
         east: bb[2],
         north: bb[3],
-      }
+      };
     } catch {}
   }
 

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -12,37 +12,38 @@ import { bbox } from "@turf/bbox";
 import { AllGeoJSON } from "@turf/helpers";
 
 
-function isGeoJson(value: unknown): value is AllGeoJSON {
-  return typeof value === "object" && value !== null;
-}
-
 function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
-  if (geometry_extra.length === 0 || !isGeoJson(geometry)) {
+  if (geometry_extra.length === 0) {
     return null;
   }
 
+  const geo = geometry as AllGeoJSON;
   const ret : Record<string, unknown> = {};
 
   if (geometry_extra.includes("centroid")) {
     try {
-      const centr = centroid(geometry).geometry.coordinates;
+      const centr = centroid(geo).geometry.coordinates;
       ret.centroid = {
         lon: centr[0],
         lat: centr[1],
       };
-    } catch {}
+    } catch {
+      ret.centroid = null
+    }
   }
 
   if (geometry_extra.includes("bbox")) {
     try {
-      const bb = bbox(geometry);
+      const bb = bbox(geo);
       ret.bbox = {
         west: bb[0],
         south: bb[1],
         east: bb[2],
         north: bb[3],
       };
-    } catch {}
+    } catch {
+      ret.bbox = null
+    }
   }
 
   return ret;

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -13,16 +13,17 @@ import { AllGeoJSON } from "@turf/helpers";
 
 
 function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
+  const ret : Record<string, unknown> = {};
+
   if (geometry_extra.length === 0) {
-    return null;
+    return ret;
   }
 
   const geo = geometry as AllGeoJSON;
-  const ret : Record<string, unknown> = {};
 
   if (geometry_extra.includes("centroid")) {
     try {
-      const centr = centroid(geo).geometry.coordinates;
+      const centr : GeoJSON.Position = centroid(geo).geometry.coordinates;
       ret.centroid = {
         lon: centr[0],
         lat: centr[1],
@@ -34,13 +35,8 @@ function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
 
   if (geometry_extra.includes("bbox")) {
     try {
-      const bb = bbox(geo);
-      ret.bbox = {
-        west: bb[0],
-        south: bb[1],
-        east: bb[2],
-        north: bb[3],
-      };
+      const bb : GeoJSON.BBox = bbox(geo);
+      ret.bbox = bb;
     } catch {
       ret.bbox = null
     }
@@ -132,7 +128,8 @@ export function transformFeatureCollectionResponse(
 
     const nextFeature: Record<string, unknown> = {
       ...rest,
-      geometry_extra: deriveGeometry(_geometry, geometry_extra),
+      geometry: null,
+      ...deriveGeometry(_geometry, geometry_extra),
     };
 
     if (typeof feature.id === "string") {

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -12,16 +12,16 @@ import { bbox } from "@turf/bbox";
 import { AllGeoJSON } from "@turf/helpers";
 
 
-function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
+function deriveGeometry(geometry: unknown, spatial_extras: string[] = []) {
   const ret : Record<string, unknown> = {};
 
-  if (geometry_extra.length === 0) {
+  if (spatial_extras.length === 0) {
     return ret;
   }
 
   const geo = geometry as AllGeoJSON;
 
-  if (geometry_extra.includes("centroid")) {
+  if (spatial_extras.includes("centroid")) {
     try {
       const centr : GeoJSON.Position = centroid(geo).geometry.coordinates;
       ret.centroid = {
@@ -33,7 +33,7 @@ function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
     }
   }
 
-  if (geometry_extra.includes("bbox")) {
+  if (spatial_extras.includes("bbox")) {
     try {
       const bb : GeoJSON.BBox = bbox(geo);
       ret.bbox = bb;
@@ -109,7 +109,7 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
 // --- Response Transformation ---
 
 /**
- * Replaces raw geometry payloads from a FeatureCollection by the kind specified by `geometry_extra`
+ * Replaces raw geometry payloads from a FeatureCollection by the kind specified by `spatial_extras`
  * and exposes lightweight `feature_ref` objects reusable by follow-up requests.
  *
  * @param featureCollection Raw FeatureCollection returned by the WFS endpoint.
@@ -117,7 +117,7 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
  */
 export function transformFeatureCollectionResponse(
   featureCollection: GenericFeatureCollection,
-  geometry_extra: string[] = [],
+  spatial_extras: string[] = [],
 ): TransformedFeatureCollection {
   if (!Array.isArray(featureCollection.features)) {
     return featureCollection;
@@ -129,7 +129,7 @@ export function transformFeatureCollectionResponse(
     const nextFeature: Record<string, unknown> = {
       ...rest,
       geometry: null,
-      ...deriveGeometry(_geometry, geometry_extra),
+      ...deriveGeometry(_geometry, spatial_extras),
     };
 
     if (typeof feature.id === "string") {
@@ -153,11 +153,11 @@ export function transformFeatureCollectionResponse(
  *
  * @param featureCollection Raw FeatureCollection returned by the WFS endpoint.
  * @param typename Typename of the queried layer.
- * @param geometry_extra List of extra geometry data to include for each feature.
+ * @param spatial_extras List of extra geometry data to include for each feature.
  * @returns A transformed FeatureCollection whose `feature_ref` objects carry the exact typename.
  */
-export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometry_extra: string[] = []) {
-  const transformed = transformFeatureCollectionResponse(featureCollection, geometry_extra);
+export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, spatial_extras: string[] = []) {
+  const transformed = transformFeatureCollectionResponse(featureCollection, spatial_extras);
   if (!Array.isArray(transformed.features)) {
     return transformed;
   }

--- a/src/wfs/response.ts
+++ b/src/wfs/response.ts
@@ -7,6 +7,46 @@
  */
 
 import type { WfsFeatureCollectionResponse } from "./types.js";
+import { centroid } from "@turf/centroid";
+import { bbox } from "@turf/bbox";
+import { AllGeoJSON } from "@turf/helpers";
+
+
+function isGeoJson(value: unknown): value is AllGeoJSON {
+  return typeof value === "object" && value !== null;
+}
+
+function deriveGeometry(geometry: unknown, geometry_extra: string[] = []) {
+  if (geometry_extra.length == 0 || !isGeoJson(geometry)) {
+    return null;
+  }
+
+  const ret : Record<string, unknown> = {}
+
+  if (geometry_extra.includes("centroid")) {
+    try {
+      const centr = centroid(geometry).geometry.coordinates
+      ret.centroid = {
+        lon: centr[0],
+        lat: centr[1],
+      }
+    } catch {}
+  }
+
+  if (geometry_extra.includes("bbox")) {
+    try {
+      const bb = bbox(geometry);
+      ret.bbox = {
+        west: bb[0],
+        south: bb[1],
+        east: bb[2],
+        north: bb[3],
+      }
+    } catch {}
+  }
+
+  return ret;
+}
 
 // --- Response Types ---
 
@@ -72,14 +112,15 @@ export function getMatchedFeatureCount(featureCollection: WfsFeatureCollectionRe
 // --- Response Transformation ---
 
 /**
- * Removes raw geometry payloads from a FeatureCollection, keeps GeoJSON validity by forcing
- * `geometry: null`, and exposes lightweight `feature_ref` objects reusable by follow-up requests.
+ * Replaces raw geometry payloads from a FeatureCollection by the kind specified by `geometry_extra`
+ * and exposes lightweight `feature_ref` objects reusable by follow-up requests.
  *
  * @param featureCollection Raw FeatureCollection returned by the WFS endpoint.
- * @returns A transformed FeatureCollection with raw geometry fields removed, `geometry: null`, and optional `feature_ref` metadata.
+ * @returns A transformed FeatureCollection with raw geometry fields removed and optional `feature_ref` metadata.
  */
 export function transformFeatureCollectionResponse(
   featureCollection: GenericFeatureCollection,
+  geometry_extra: string[] = [],
 ): TransformedFeatureCollection {
   if (!Array.isArray(featureCollection.features)) {
     return featureCollection;
@@ -90,7 +131,7 @@ export function transformFeatureCollectionResponse(
 
     const nextFeature: Record<string, unknown> = {
       ...rest,
-      geometry: null,
+      geometry_extra: deriveGeometry(_geometry, geometry_extra),
     };
 
     if (typeof feature.id === "string") {
@@ -114,10 +155,11 @@ export function transformFeatureCollectionResponse(
  *
  * @param featureCollection Raw FeatureCollection returned by the WFS endpoint.
  * @param typename Typename of the queried layer.
+ * @param geometry_extra List of extra geometry data to include for each feature.
  * @returns A transformed FeatureCollection whose `feature_ref` objects carry the exact typename.
  */
-export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string) {
-  const transformed = transformFeatureCollectionResponse(featureCollection);
+export function attachFeatureRefs(featureCollection: GenericFeatureCollection, typename: string, geometry_extra: string[] = []) {
+  const transformed = transformFeatureCollectionResponse(featureCollection, geometry_extra);
   if (!Array.isArray(transformed.features)) {
     return transformed;
   }

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -30,10 +30,15 @@ export const GPF_SPATIAL_FILTER_DOCNAMES = GPF_GET_FEATURES_SPATIAL_FILTER_KEYS
   .map((name) => `\`${name}\``)
   .join(", ")
   .replace(/, ([^,]*)$/, ' ou $1')
-export const GPF_GET_FEATURES_GEOMETRY_EXTRA = [
+
+export const GPF_GET_FEATURES_SPATIAL_EXTRAS = [
   "centroid",
   "bbox"
 ] as const;
+export const GPF_SPATIAL_EXTRAS_DOCNAMES = GPF_GET_FEATURES_SPATIAL_EXTRAS
+  .map((name) => `\`${name}\``)
+  .join(", ")
+  .replace(/, ([^,]*)$/, ' et $1')
 
 // --- Shared Clauses ---
 
@@ -147,11 +152,11 @@ const gpfSpatialFilterInputSchema = z.object({
 })
 
 const gpfGeometryExtraInputSchema = z.object({
-  geometry_extra: z
-    .array(z.enum(GPF_GET_FEATURES_GEOMETRY_EXTRA))
+  spatial_extras: z
+    .array(z.enum(GPF_GET_FEATURES_SPATIAL_EXTRAS))
     .default([])
     .transform((val) => [...new Set(val)])
-    .describe("Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."),
+    .describe(`Éléments calculés depuis la géométrie à renvoyer pour \`result_type=results\`. Peut inclure ${GPF_SPATIAL_EXTRAS_DOCNAMES}, aucun par défaut.`),
 })
 
 function assertSpatialFilterExclusion(input : Record<string, unknown>, ctx : z.RefinementCtx) {
@@ -167,16 +172,16 @@ function assertSpatialFilterExclusion(input : Record<string, unknown>, ctx : z.R
 }
 
 type GeometryExtraRefinementInput = {
-  geometry_extra: z.output<typeof gpfGetFeaturesInputObjectSchema>["geometry_extra"];
+  spatial_extras: z.output<typeof gpfGetFeaturesInputObjectSchema>["spatial_extras"];
   result_type: z.output<typeof gpfGetFeaturesInputObjectSchema>["result_type"];
 };
 
 function assertGeometryExtraQuery(input: GeometryExtraRefinementInput, ctx: z.RefinementCtx) {
-  if (input.geometry_extra.length > 0 && input.result_type !== "results") {
+  if (input.spatial_extras.length > 0 && input.result_type !== "results") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      path: ["geometry_extra"],
-      message: "`geometry_extra` ne peut être utilisé qu'avec `result_type=results`. Dans les cas `http_post_request` et `http_get_url`, la géométrie complète est renvoyée par la requête."
+      path: ["spatial_extras"],
+      message: "`spatial_extras` ne peut être utilisé qu'avec `result_type=results`. Dans les cas `http_post_request` et `http_get_url`, la géométrie complète est renvoyée par la requête."
     });
   }
 }
@@ -284,7 +289,7 @@ export const gpfGetFeatureByIdInputObjectSchema = z.object({
   result_type: z
     .enum(["results", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."),
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `spatial_extras` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -30,6 +30,10 @@ export const GPF_SPATIAL_FILTER_DOCNAMES = GPF_GET_FEATURES_SPATIAL_FILTER_KEYS
   .map((name) => `\`${name}\``)
   .join(", ")
   .replace(/, ([^,]*)$/, ' ou $1')
+export const GPF_GET_FEATURES_GEOMETRY_EXTRA = [
+  "centroid",
+  "bbox"
+] as const;
 
 // --- Shared Clauses ---
 
@@ -142,6 +146,14 @@ const gpfSpatialFilterInputSchema = z.object({
     .describe("Filtre spatial par temps de trajet depuis un point (`profile` voiture ou piéton). Exclusif avec les autres filtres spatiaux."),
 })
 
+const gpfGeometryExtraInputSchema = z.object({
+  geometry_extra: z
+    .array(z.enum(GPF_GET_FEATURES_GEOMETRY_EXTRA))
+    .default([])
+    .transform((val) => [...new Set(val)])
+    .describe("Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut."),
+})
+
 function assertSpatialFilterExclusion(input : Record<string, unknown>, ctx : z.RefinementCtx) {
   const usedSpatialFilters = GPF_GET_FEATURES_SPATIAL_FILTER_KEYS.filter((key) => input[key] !== undefined);
 
@@ -151,6 +163,21 @@ function assertSpatialFilterExclusion(input : Record<string, unknown>, ctx : z.R
       path: ["spatial_filters"],
       message: `Un seul filtre spatial est autorisé (${usedSpatialFilters.join(", ")} fournis).`,
     });
+  }
+}
+
+type GeometryExtraRefinementInput = {
+  geometry_extra: z.output<typeof gpfGetFeaturesInputObjectSchema>["geometry_extra"];
+  result_type: z.output<typeof gpfGetFeaturesInputObjectSchema>["result_type"];
+};
+
+function assertGeometryExtraQuery(input: GeometryExtraRefinementInput, ctx: z.RefinementCtx) {
+  if (input.geometry_extra.length > 0 && input.result_type != "results") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["geometry_extra"],
+      message: "`geometry_extra` ne peut être utilisé qu'avec `result_type=results`. Dans les cas `http_post_request` et `http_get_url`, la géométrie complète est renvoyée par la requête."
+    })
   }
 }
 
@@ -197,9 +224,12 @@ export const gpfGetFeaturesInputObjectSchema = gpfTypenameInputSchema
     .optional()
     .describe("Liste ordonnée des critères de tri."),
 }))
+  .merge(gpfGeometryExtraInputSchema)
   .strict();
 
-export const gpfGetFeaturesInputSchema = gpfGetFeaturesInputObjectSchema.superRefine(assertSpatialFilterExclusion);
+export const gpfGetFeaturesInputSchema = gpfGetFeaturesInputObjectSchema
+  .superRefine(assertSpatialFilterExclusion)
+  .superRefine(assertGeometryExtraQuery)
 
 // --- `gpf_get_features` Types ---
 
@@ -238,7 +268,7 @@ export type GpfQueryFeaturesInput = GpfGetFeaturesInput | GpfCountFeaturesInput
 
 // --- `gpf_get_feature_by_id` ---
 
-export const gpfGetFeatureByIdInputSchema = z.object({
+export const gpfGetFeatureByIdInputObjectSchema = z.object({
   typename: z
     .string()
     .trim()
@@ -254,18 +284,21 @@ export const gpfGetFeatureByIdInputSchema = z.object({
   result_type: z
     .enum(["results", "http_post_request", "http_get_url"])
     .default("results")
-    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."),
+    .describe("`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant."),
   select: z
     .array(z.string().trim().min(1))
     .min(1)
     .optional()
-    .describe("Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée."),
-}).strict();
+    .describe("Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`."),
+})
+  .merge(gpfGeometryExtraInputSchema)
+  .strict();
 
-// --- `gpf_get_feature_by_id` Types ---
+export const gpfGetFeatureByIdInputSchema = gpfGetFeatureByIdInputObjectSchema
+  .superRefine(assertGeometryExtraQuery)
 
 export type GpfGetFeatureByIdInput = z.infer<typeof gpfGetFeatureByIdInputSchema>;
 
 // --- `gpf_get_feature_by_id` Published Schema ---
 
-export const gpfGetFeatureByIdPublishedInputSchema = generatePublishedInputSchema(gpfGetFeatureByIdInputSchema);
+export const gpfGetFeatureByIdPublishedInputSchema = generatePublishedInputSchema(gpfGetFeatureByIdInputObjectSchema);

--- a/src/wfs/schema.ts
+++ b/src/wfs/schema.ts
@@ -24,7 +24,7 @@ export const GPF_GET_FEATURES_SPATIAL_FILTER_KEYS = [
   "intersects_point_filter",
   "dwithin_point_filter",
   "intersects_feature_filter",
-  "travel_time_filter",
+  "travel_time_filter"
 ] as const;
 export const GPF_SPATIAL_FILTER_DOCNAMES = GPF_GET_FEATURES_SPATIAL_FILTER_KEYS
   .map((name) => `\`${name}\``)
@@ -172,12 +172,12 @@ type GeometryExtraRefinementInput = {
 };
 
 function assertGeometryExtraQuery(input: GeometryExtraRefinementInput, ctx: z.RefinementCtx) {
-  if (input.geometry_extra.length > 0 && input.result_type != "results") {
+  if (input.geometry_extra.length > 0 && input.result_type !== "results") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["geometry_extra"],
       message: "`geometry_extra` ne peut être utilisé qu'avec `result_type=results`. Dans les cas `http_post_request` et `http_get_url`, la géométrie complète est renvoyée par la requête."
-    })
+    });
   }
 }
 
@@ -229,7 +229,7 @@ export const gpfGetFeaturesInputObjectSchema = gpfTypenameInputSchema
 
 export const gpfGetFeaturesInputSchema = gpfGetFeaturesInputObjectSchema
   .superRefine(assertSpatialFilterExclusion)
-  .superRefine(assertGeometryExtraQuery)
+  .superRefine(assertGeometryExtraQuery);
 
 // --- `gpf_get_features` Types ---
 
@@ -295,7 +295,7 @@ export const gpfGetFeatureByIdInputObjectSchema = z.object({
   .strict();
 
 export const gpfGetFeatureByIdInputSchema = gpfGetFeatureByIdInputObjectSchema
-  .superRefine(assertGeometryExtraQuery)
+  .superRefine(assertGeometryExtraQuery);
 
 export type GpfGetFeatureByIdInput = z.infer<typeof gpfGetFeatureByIdInputSchema>;
 

--- a/test/integration/level1-protocol/getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/getfeaturebyid.test.ts
@@ -35,11 +35,13 @@ interface GetFeatureByIdResult {
     type: string;
     id: string;
     properties: Record<string, unknown>;
-    geometry_extra?: Record<string, unknown>;
+    geometry: null;
     feature_ref?: {
       typename: string;
       feature_id: string;
     };
+    bbox?: GeoJSON.BBox;
+    centroid?: { lon: number, lat: number };
   }>;
   totalFeatures?: number;
   numberMatched?: number;
@@ -72,7 +74,8 @@ describe("GetFeatureById (integration)", () => {
     expect(result.features.length).toBe(1);
     expect(result.features[0].id).toBeDefined();
     expect(result.features[0].properties).toBeDefined();
-    expect(result.features[0].geometry_extra).toBeDefined();
+    expect(result.features[0].bbox).toBeUndefined();
+    expect(result.features[0].centroid).toBeUndefined();
   }, INTEGRATION_CONFIG.timeout);
 
   it("should retrieve a centroid and a bbox", async () => {
@@ -86,11 +89,10 @@ describe("GetFeatureById (integration)", () => {
     expect(result.features.length).toBe(1);
     expect(result.features[0].id).toBeDefined();
     expect(result.features[0].properties).toBeDefined();
-    expect(result.features[0].geometry_extra).toBeDefined();
-    const centroid = result.features[0].geometry_extra?.centroid as ({lon: number, lat: number} | undefined)
-    expect(centroid?.lon).toBeCloseTo(2.382778372262143);
-    expect(centroid?.lat).toBeCloseTo(48.8518070503727);
-    expect(result.features[0].geometry_extra?.bbox).toBeDefined();
+    expect(result.features[0].bbox).toBeDefined();
+    expect(result.features[0].centroid).toBeDefined();
+    expect(result.features[0].centroid?.lon).toBeCloseTo(2.382778372262143);
+    expect(result.features[0].centroid?.lat).toBeCloseTo(48.8518070503727);
   }, INTEGRATION_CONFIG.timeout);
 
   it("should return an error for invalid typename", async () => {

--- a/test/integration/level1-protocol/getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/getfeaturebyid.test.ts
@@ -35,7 +35,7 @@ interface GetFeatureByIdResult {
     type: string;
     id: string;
     properties: Record<string, unknown>;
-    geometry?: unknown;
+    geometry_extra?: Record<string, unknown>;
     feature_ref?: {
       typename: string;
       feature_id: string;
@@ -72,6 +72,26 @@ describe("GetFeatureById (integration)", () => {
     expect(result.features.length).toBe(1);
     expect(result.features[0].id).toBeDefined();
     expect(result.features[0].properties).toBeDefined();
+    expect(result.features[0].geometry_extra).toBeDefined();
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should retrieve a centroid and a bbox", async () => {
+    const result = await callTool<GetFeatureByIdResult>(getHandle().client, "gpf_get_feature_by_id", {
+      typename: featureRef.typename,
+      feature_id: featureRef.feature_id,
+      geometry_extra: ["centroid", "bbox"]
+    });
+
+    expectFeatureCollectionWithFeatures(result, 1);
+    expect(result.features.length).toBe(1);
+    expect(result.features[0].id).toBeDefined();
+    expect(result.features[0].properties).toBeDefined();
+    expect(result.features[0].geometry_extra).toBeDefined();
+    expect(result.features[0].geometry_extra?.centroid).toStrictEqual({
+      lon: 2.382778372262143,
+      lat: 48.8518070503727,
+    });
+    expect(result.features[0].geometry_extra?.bbox).toBeDefined();
   }, INTEGRATION_CONFIG.timeout);
 
   it("should return an error for invalid typename", async () => {
@@ -79,6 +99,17 @@ describe("GetFeatureById (integration)", () => {
       callTool(getHandle().client, "gpf_get_feature_by_id", {
         typename: "INVALID:type",
         feature_id: "nonexistent",
+      }),
+    );
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should return an error for when trying to combine `geometry_extra` with a `result_type` other than `request`", async () => {
+    await expectToolCallToThrow(
+      callTool(getHandle().client, "gpf_get_feature_by_id", {
+        typename: featureRef.typename,
+        feature_id: featureRef.feature_id,
+        geometry_extra: ["centroid"],
+        result_type: "http_post_request"
       }),
     );
   }, INTEGRATION_CONFIG.timeout);

--- a/test/integration/level1-protocol/getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/getfeaturebyid.test.ts
@@ -87,10 +87,9 @@ describe("GetFeatureById (integration)", () => {
     expect(result.features[0].id).toBeDefined();
     expect(result.features[0].properties).toBeDefined();
     expect(result.features[0].geometry_extra).toBeDefined();
-    expect(result.features[0].geometry_extra?.centroid).toStrictEqual({
-      lon: 2.382778372262143,
-      lat: 48.8518070503727,
-    });
+    const centroid = result.features[0].geometry_extra?.centroid as ({lon: number, lat: number} | undefined)
+    expect(centroid?.lon).toBeCloseTo(2.382778372262143);
+    expect(centroid?.lat).toBeCloseTo(48.8518070503727);
     expect(result.features[0].geometry_extra?.bbox).toBeDefined();
   }, INTEGRATION_CONFIG.timeout);
 

--- a/test/integration/level1-protocol/getfeaturebyid.test.ts
+++ b/test/integration/level1-protocol/getfeaturebyid.test.ts
@@ -82,7 +82,7 @@ describe("GetFeatureById (integration)", () => {
     const result = await callTool<GetFeatureByIdResult>(getHandle().client, "gpf_get_feature_by_id", {
       typename: featureRef.typename,
       feature_id: featureRef.feature_id,
-      geometry_extra: ["centroid", "bbox"]
+      spatial_extras: ["centroid", "bbox"]
     });
 
     expectFeatureCollectionWithFeatures(result, 1);
@@ -104,12 +104,12 @@ describe("GetFeatureById (integration)", () => {
     );
   }, INTEGRATION_CONFIG.timeout);
 
-  it("should return an error for when trying to combine `geometry_extra` with a `result_type` other than `request`", async () => {
+  it("should return an error for when trying to combine `spatial_extras` with a `result_type` other than `request`", async () => {
     await expectToolCallToThrow(
       callTool(getHandle().client, "gpf_get_feature_by_id", {
         typename: featureRef.typename,
         feature_id: featureRef.feature_id,
-        geometry_extra: ["centroid"],
+        spatial_extras: ["centroid"],
         result_type: "http_post_request"
       }),
     );

--- a/test/integration/level1-protocol/getfeatures.test.ts
+++ b/test/integration/level1-protocol/getfeatures.test.ts
@@ -19,7 +19,7 @@ interface GetFeaturesResult {
     type: string;
     id: string;
     properties: Record<string, unknown>;
-    geometry?: unknown;
+    geometry_extra?: Record<string, unknown>;
     feature_ref?: {
       typename: string;
       feature_id: string;
@@ -54,5 +54,23 @@ describe("GetFeatures (integration)", () => {
         limit: 1,
       }),
     );
+  }, INTEGRATION_CONFIG.timeout);
+
+  it("should include the bbox when asked in geometry_extra", async () => {
+    const result = await callTool<GetFeaturesResult>(getHandle().client, "gpf_get_features", {
+      typename: "BDTOPO_V3:commune",
+      where: [{ property: "code_insee", operator: "eq", value: "75056" }],
+      select: ["code_insee", "nom_officiel"],
+      geometry_extra: ["bbox"],
+      limit: 1,
+    });
+
+    expectFeatureCollectionWithFeatures(result);
+
+    const first = result.features[0];
+    expect(first.geometry_extra).toBeDefined();
+    expect(first.geometry_extra?.bbox).toBeDefined();
+    let bbox = (first.geometry_extra as { bbox?: { west?: number } } | undefined)?.bbox
+    expect(bbox?.west).toBe(2.22421717);
   }, INTEGRATION_CONFIG.timeout);
 });

--- a/test/integration/level1-protocol/getfeatures.test.ts
+++ b/test/integration/level1-protocol/getfeatures.test.ts
@@ -58,12 +58,12 @@ describe("GetFeatures (integration)", () => {
     );
   }, INTEGRATION_CONFIG.timeout);
 
-  it("should include the bbox when asked in geometry_extra", async () => {
+  it("should include the bbox when asked in spatial_extras", async () => {
     const result = await callTool<GetFeaturesResult>(getHandle().client, "gpf_get_features", {
       typename: "BDTOPO_V3:commune",
       where: [{ property: "code_insee", operator: "eq", value: "75056" }],
       select: ["code_insee", "nom_officiel"],
-      geometry_extra: ["bbox"],
+      spatial_extras: ["bbox"],
       limit: 1,
     });
 

--- a/test/integration/level1-protocol/getfeatures.test.ts
+++ b/test/integration/level1-protocol/getfeatures.test.ts
@@ -19,11 +19,13 @@ interface GetFeaturesResult {
     type: string;
     id: string;
     properties: Record<string, unknown>;
-    geometry_extra?: Record<string, unknown>;
+    geometry: null;
     feature_ref?: {
       typename: string;
       feature_id: string;
     };
+    bbox?: GeoJSON.BBox;
+    centroid?: { lon: number, lat: number };
   }>;
   totalFeatures?: number;
   numberMatched?: number;
@@ -68,9 +70,8 @@ describe("GetFeatures (integration)", () => {
     expectFeatureCollectionWithFeatures(result);
 
     const first = result.features[0];
-    expect(first.geometry_extra).toBeDefined();
-    expect(first.geometry_extra?.bbox).toBeDefined();
-    let bbox = (first.geometry_extra as { bbox?: { west?: number } } | undefined)?.bbox
-    expect(bbox?.west).toBe(2.22421717);
+    expect(first.bbox).toBeDefined();
+    expect((first.bbox as GeoJSON.BBox)[0]).toBeCloseTo(2.22421717);
+    expect(first.centroid).toBeUndefined();
   }, INTEGRATION_CONFIG.timeout);
 });

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -73,7 +73,7 @@ describe("Test GpfGetFeatureByIdTool", () => {
             type: "string",
           },
           default: [],
-          description: "Éléments calculés depuis la géométrie pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut.",
+          description: "Éléments calculés depuis la géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut.",
         },
         result_type: {
           type: "string",

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -275,13 +275,9 @@ describe("Test GpfGetFeatureByIdTool", () => {
       throw new Error("expected text content");
     }
     const results = JSON.parse(textContent.text);
-    expect(results.features[0].geometry_extra).toBeDefined();
-    expect(results.features[0].geometry_extra?.bbox).toStrictEqual({
-      west: 2.3,
-      south: 48.8,
-      east: 2.4,
-      north: 48.9
-    });
+    expect(results.features[0].bbox).toBeDefined();
+    expect(results.features[0].bbox).toStrictEqual([2.3, 48.8, 2.4, 48.9]);
+    expect(results.features[0].centroid).toBeUndefined();
   });
 
   it("should fail clearly when the feature is missing", async () => {

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -66,11 +66,20 @@ describe("Test GpfGetFeatureByIdTool", () => {
           minLength: 1,
           description: "Identifiant GPF exact de l'objet à récupérer, par exemple `commune.8952`.",
         },
+        geometry_extra: {
+          type: "array",
+          items: {
+            enum: ["centroid", "bbox"],
+            type: "string",
+          },
+          default: [],
+          description: "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut.",
+        },
         result_type: {
           type: "string",
           enum: ["results", "http_post_request", "http_get_url"],
           default: "results",
-          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant.",
+          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant.",
         },
         select: {
           type: "array",
@@ -79,7 +88,7 @@ describe("Test GpfGetFeatureByIdTool", () => {
             minLength: 1,
           },
           minItems: 1,
-          description: "Liste des propriétés non géométriques à renvoyer. Quand `result_type=\"http_post_request\"` ou `result_type=\"http_get_url\"`, la géométrie est automatiquement ajoutée.",
+          description: "Liste des propriétés non géométriques à renvoyer. Utiliser `gpf_wfs_describe_type` pour connaître les noms exacts disponibles. Exemple : `[\"code_insee\", \"nom_officiel\"]`.",
         },
       },
       required: ["typename", "feature_id"],
@@ -208,12 +217,71 @@ describe("Test GpfGetFeatureByIdTool", () => {
     expect(results.numberMatched).toEqual(1);
     expect(results.numberReturned).toEqual(1);
     expect(results.features).toHaveLength(1);
-    expect(results.features[0].geometry).toBeNull();
     expect(results.features[0].feature_ref).toEqual({
       typename: "ADMINEXPRESS-COG.LATEST:commune",
       feature_id: "commune.1",
     });
     expect(results.features[0].geometry_name).toBeUndefined();
+  });
+
+  it("should include the bbox when asked in geometry_extra", async () => {
+    const tool = new GpfGetFeatureByIdTool();
+    const requests: Array<{ url: string; query: Record<string, string> }> = [];
+    mockGetFeatureType.mockResolvedValue(polygonFeatureType);
+    mockFetchJSONPost.mockImplementation(async (url, _body) => {
+      const [baseUrl, queryString = ""] = url.split("?");
+      requests.push({
+        url: baseUrl,
+        query: Object.fromEntries(new URLSearchParams(queryString).entries()),
+      });
+
+      return {
+        type: "FeatureCollection",
+        totalFeatures: 1,
+        features: [
+          {
+            type: "Feature",
+            id: "commune.1",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+            },
+            geometry_name: "geometrie",
+            properties: {
+              code_insee: "01001",
+            },
+          },
+        ],
+      };
+    });
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          select: ["code_insee"],
+          geometry_extra: ["bbox"],
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query.propertyName).toEqual("code_insee,geometrie");
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const results = JSON.parse(textContent.text);
+    expect(results.features[0].geometry_extra).toBeDefined();
+    expect(results.features[0].geometry_extra?.bbox).toStrictEqual({
+      west: 2.3,
+      south: 48.8,
+      east: 2.4,
+      north: 48.9
+    });
   });
 
   it("should fail clearly when the feature is missing", async () => {
@@ -360,6 +428,38 @@ describe("Test GpfGetFeatureByIdTool", () => {
           name: "result_type",
           code: "invalid_enum_value",
           detail: expect.stringContaining("http_post_request"),
+        }),
+      ]),
+    });
+  });
+
+  it("should reject geometry_extra with http_get_url result_type", async () => {
+    const tool = new GpfGetFeatureByIdTool();
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_get_feature_by_id",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          feature_id: "commune.1",
+          geometry_extra: ["bbox"],
+          result_type: "http_get_url",
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("geometry_extra");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "geometry_extra",
+          code: "custom",
         }),
       ]),
     });

--- a/test/tools/wfs/getFeatureById.test.ts
+++ b/test/tools/wfs/getFeatureById.test.ts
@@ -66,20 +66,20 @@ describe("Test GpfGetFeatureByIdTool", () => {
           minLength: 1,
           description: "Identifiant GPF exact de l'objet à récupérer, par exemple `commune.8952`.",
         },
-        geometry_extra: {
+        spatial_extras: {
           type: "array",
           items: {
             enum: ["centroid", "bbox"],
             type: "string",
           },
           default: [],
-          description: "Éléments de géométrie à renvoyer pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut.",
+          description: "Éléments calculés depuis la géométrie pour `result_type=results`. Peut inclure `centroid` et `bbox`, aucun par défaut.",
         },
         result_type: {
           type: "string",
           enum: ["results", "http_post_request", "http_get_url"],
           default: "results",
-          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `geometry_extra` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant.",
+          description: "`results` renvoie une FeatureCollection normalisée avec exactement un objet et le choix de `spatial_extras` en guise d'information géométrique. `http_post_request` renvoie une requête POST robuste à exécuter directement. `http_get_url` renvoie l'URL GET équivalente, utile pour les consommateurs URL-first ou pour la visualisation dans un outil la supportant.",
         },
         select: {
           type: "array",
@@ -224,7 +224,7 @@ describe("Test GpfGetFeatureByIdTool", () => {
     expect(results.features[0].geometry_name).toBeUndefined();
   });
 
-  it("should include the bbox when asked in geometry_extra", async () => {
+  it("should include the bbox when asked in spatial_extras", async () => {
     const tool = new GpfGetFeatureByIdTool();
     const requests: Array<{ url: string; query: Record<string, string> }> = [];
     mockGetFeatureType.mockResolvedValue(polygonFeatureType);
@@ -262,7 +262,7 @@ describe("Test GpfGetFeatureByIdTool", () => {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
           feature_id: "commune.1",
           select: ["code_insee"],
-          geometry_extra: ["bbox"],
+          spatial_extras: ["bbox"],
         },
       },
     });
@@ -429,7 +429,7 @@ describe("Test GpfGetFeatureByIdTool", () => {
     });
   });
 
-  it("should reject geometry_extra with http_get_url result_type", async () => {
+  it("should reject spatial_extras with http_get_url result_type", async () => {
     const tool = new GpfGetFeatureByIdTool();
 
     const response = await tool.toolCall({
@@ -438,7 +438,7 @@ describe("Test GpfGetFeatureByIdTool", () => {
         arguments: {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
           feature_id: "commune.1",
-          geometry_extra: ["bbox"],
+          spatial_extras: ["bbox"],
           result_type: "http_get_url",
         },
       },
@@ -449,12 +449,12 @@ describe("Test GpfGetFeatureByIdTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    expect(textContent.text).toContain("geometry_extra");
+    expect(textContent.text).toContain("spatial_extras");
     expect(response.structuredContent).toMatchObject({
       type: "urn:geocontext:problem:invalid-tool-params",
       errors: expect.arrayContaining([
         expect.objectContaining({
-          name: "geometry_extra",
+          name: "spatial_extras",
           code: "custom",
         }),
       ]),

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -412,6 +412,38 @@ describe("Test GpfGetFeaturesTool", () => {
     });
   });
 
+  it("should reject geometry_extra with http_get_url result_type", async () => {
+    const tool = new GpfGetFeaturesTool();
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          result_type: "http_get_url",
+          geometry_extra: ["bbox"],
+        },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    expect(textContent.text).toContain("geometry_extra");
+    expect(response.structuredContent).toMatchObject({
+      type: "urn:geocontext:problem:invalid-tool-params",
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          name: "geometry_extra",
+          code: "custom",
+        }),
+      ]),
+    });
+    expect(mockGetFeatureType).not.toHaveBeenCalled();
+    expect(mockFetchJSONPost).not.toHaveBeenCalled();
+  });
+
   it("should reject multiple spatial filters as invalid tool parameters", async () => {
     const tool = new GpfGetFeaturesTool();
     const response = await tool.toolCall({
@@ -584,12 +616,65 @@ describe("Test GpfGetFeaturesTool", () => {
     }
     const results = JSON.parse(textContent.text);
     expect(results).not.toHaveProperty("crs");
-    expect(results.features[0].geometry).toBeNull();
     expect(results.features[0].feature_ref).toEqual({
       typename: "ADMINEXPRESS-COG.LATEST:commune",
       feature_id: "commune.1",
     });
     expect(results.features[0].geometry_name).toBeUndefined();
+  });
+
+  it("should include the bbox when asked in geometry_extra", async () => {
+    const tool = new GpfGetFeaturesTool();
+    mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
+    const requests = captureRequests({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "commune.1",
+          geometry: {
+            type: "Polygon",
+            coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+          },
+          geometry_name: "geometrie",
+          properties: { code_insee: "01001" },
+        },
+      ],
+      totalFeatures: 1,
+    });
+
+    const response = await tool.toolCall({
+      params: {
+        name: "gpf_get_features",
+        arguments: {
+          typename: "ADMINEXPRESS-COG.LATEST:commune",
+          select: ["code_insee"],
+          geometry_extra: ["bbox"],
+          limit: 1,
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].query.propertyName).toEqual("code_insee,geometrie");
+    const textContent = response.content[0];
+    if (textContent.type !== "text") {
+      throw new Error("expected text content");
+    }
+    const results = JSON.parse(textContent.text);
+    expect(results.features[0].geometry_extra).toStrictEqual({
+      bbox: {
+        west: 2.3,
+        south: 48.8,
+        east: 2.4,
+        north: 48.9
+      },
+    });
+    expect(results.features[0].feature_ref).toEqual({
+      typename: "ADMINEXPRESS-COG.LATEST:commune",
+      feature_id: "commune.1",
+    });
   });
 
   it("should set point geometry to null and keep feature_ref", async () => {
@@ -626,7 +711,6 @@ describe("Test GpfGetFeaturesTool", () => {
       throw new Error("expected text content");
     }
     const results = JSON.parse(textContent.text);
-    expect(results.features[0].geometry).toBeNull();
     expect(results.features[0].feature_ref).toEqual({
       typename: "BDTOPO_V3:point_d_acces",
       feature_id: "point_d_acces.1",

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -663,14 +663,7 @@ describe("Test GpfGetFeaturesTool", () => {
       throw new Error("expected text content");
     }
     const results = JSON.parse(textContent.text);
-    expect(results.features[0].geometry_extra).toStrictEqual({
-      bbox: {
-        west: 2.3,
-        south: 48.8,
-        east: 2.4,
-        north: 48.9
-      },
-    });
+    expect(results.features[0].bbox).toStrictEqual([2.3, 48.8, 2.4, 48.9]);
     expect(results.features[0].feature_ref).toEqual({
       typename: "ADMINEXPRESS-COG.LATEST:commune",
       feature_id: "commune.1",

--- a/test/tools/wfs/getFeatures.test.ts
+++ b/test/tools/wfs/getFeatures.test.ts
@@ -412,7 +412,7 @@ describe("Test GpfGetFeaturesTool", () => {
     });
   });
 
-  it("should reject geometry_extra with http_get_url result_type", async () => {
+  it("should reject spatial_extras with http_get_url result_type", async () => {
     const tool = new GpfGetFeaturesTool();
     const response = await tool.toolCall({
       params: {
@@ -420,7 +420,7 @@ describe("Test GpfGetFeaturesTool", () => {
         arguments: {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
           result_type: "http_get_url",
-          geometry_extra: ["bbox"],
+          spatial_extras: ["bbox"],
         },
       },
     });
@@ -430,12 +430,12 @@ describe("Test GpfGetFeaturesTool", () => {
     if (textContent.type !== "text") {
       throw new Error("expected text content");
     }
-    expect(textContent.text).toContain("geometry_extra");
+    expect(textContent.text).toContain("spatial_extras");
     expect(response.structuredContent).toMatchObject({
       type: "urn:geocontext:problem:invalid-tool-params",
       errors: expect.arrayContaining([
         expect.objectContaining({
-          name: "geometry_extra",
+          name: "spatial_extras",
           code: "custom",
         }),
       ]),
@@ -623,7 +623,7 @@ describe("Test GpfGetFeaturesTool", () => {
     expect(results.features[0].geometry_name).toBeUndefined();
   });
 
-  it("should include the bbox when asked in geometry_extra", async () => {
+  it("should include the bbox when asked in spatial_extras", async () => {
     const tool = new GpfGetFeaturesTool();
     mockFeatureTypes({ [polygonFeatureType.id]: polygonFeatureType });
     const requests = captureRequests({
@@ -649,7 +649,7 @@ describe("Test GpfGetFeaturesTool", () => {
         arguments: {
           typename: "ADMINEXPRESS-COG.LATEST:commune",
           select: ["code_insee"],
-          geometry_extra: ["bbox"],
+          spatial_extras: ["bbox"],
           limit: 1,
         },
       },

--- a/test/wfs/queryPreparation.test.ts
+++ b/test/wfs/queryPreparation.test.ts
@@ -26,7 +26,7 @@ describe("gpfGetFeatures/queryPreparation", () => {
     typename: "ADMINEXPRESS-COG.LATEST:commune",
     limit: 100,
     result_type: "results",
-    geometry_extra: []
+    spatial_extras: []
   };
 
   it("should compile where clauses", () => {

--- a/test/wfs/queryPreparation.test.ts
+++ b/test/wfs/queryPreparation.test.ts
@@ -26,6 +26,7 @@ describe("gpfGetFeatures/queryPreparation", () => {
     typename: "ADMINEXPRESS-COG.LATEST:commune",
     limit: 100,
     result_type: "results",
+    geometry_extra: []
   };
 
   it("should compile where clauses", () => {

--- a/test/wfs/response.test.ts
+++ b/test/wfs/response.test.ts
@@ -44,7 +44,7 @@ describe("wfs_engine/response", () => {
       expect(features[0]).toEqual({
         id: "commune.1",
         properties: { code_insee: "94080" },
-        geometry: null,
+        geometry_extra: null,
         feature_ref: { typename: null, feature_id: "commune.1" },
       });
     });
@@ -62,8 +62,67 @@ describe("wfs_engine/response", () => {
       expect(features[0]).toEqual({
         id: 42,
         properties: { name: "test" },
-        geometry: null,
+        geometry_extra: null,
       });
+    });
+
+    it("should return a GeometryCollection with bbox when only bbox is requested", () => {
+      const result = transformFeatureCollectionResponse({
+        type: "FeatureCollection",
+        features: [
+          {
+            id: "commune.1",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+            },
+            geometry_name: "geometrie",
+            properties: { code_insee: "94080" },
+          },
+        ],
+      }, ["bbox"]);
+
+      const features = getFeatures(result);
+
+      expect(features[0].geometry_extra).toStrictEqual({
+        bbox: {
+          west: 2.3,
+          south: 48.8,
+          east: 2.4,
+          north: 48.9,
+        },
+      });
+    });
+
+    it("should return centroid and bbox in geometry_extra when requested", () => {
+      const result = transformFeatureCollectionResponse({
+        type: "FeatureCollection",
+        features: [
+          {
+            id: "commune.1",
+            geometry: {
+              type: "Polygon",
+              coordinates: [[[2.3, 48.8], [2.4, 48.8], [2.4, 48.9], [2.3, 48.9], [2.3, 48.8]]],
+            },
+            geometry_name: "geometrie",
+            properties: { code_insee: "94080" },
+          },
+        ],
+      }, ["centroid", "bbox"]);
+
+      const features = getFeatures(result);
+      expect(features[0].geometry_extra).toBeDefined();
+      expect(features[0].geometry_extra).toMatchObject({
+        bbox: {
+          west: 2.3,
+          south: 48.8,
+          east: 2.4,
+          north: 48.9,
+        },
+      });
+      const geometryExtraCentroid = features[0].geometry_extra as { centroid?: { lon: number; lat: number } };
+      expect(geometryExtraCentroid.centroid?.lon).toBeCloseTo(2.35);
+      expect(geometryExtraCentroid.centroid?.lat).toBeCloseTo(48.85);
     });
   });
 

--- a/test/wfs/response.test.ts
+++ b/test/wfs/response.test.ts
@@ -87,7 +87,7 @@ describe("wfs_engine/response", () => {
       expect(features[0].bbox).toStrictEqual([2.3, 48.8, 2.4, 48.9]);
     });
 
-    it("should return centroid and bbox in geometry_extra when requested", () => {
+    it("should return centroid and bbox in spatial_extras when requested", () => {
       const result = transformFeatureCollectionResponse({
         type: "FeatureCollection",
         features: [

--- a/test/wfs/response.test.ts
+++ b/test/wfs/response.test.ts
@@ -44,7 +44,7 @@ describe("wfs_engine/response", () => {
       expect(features[0]).toEqual({
         id: "commune.1",
         properties: { code_insee: "94080" },
-        geometry_extra: null,
+        geometry: null,
         feature_ref: { typename: null, feature_id: "commune.1" },
       });
     });
@@ -62,7 +62,7 @@ describe("wfs_engine/response", () => {
       expect(features[0]).toEqual({
         id: 42,
         properties: { name: "test" },
-        geometry_extra: null,
+        geometry: null,
       });
     });
 
@@ -84,14 +84,7 @@ describe("wfs_engine/response", () => {
 
       const features = getFeatures(result);
 
-      expect(features[0].geometry_extra).toStrictEqual({
-        bbox: {
-          west: 2.3,
-          south: 48.8,
-          east: 2.4,
-          north: 48.9,
-        },
-      });
+      expect(features[0].bbox).toStrictEqual([2.3, 48.8, 2.4, 48.9]);
     });
 
     it("should return centroid and bbox in geometry_extra when requested", () => {
@@ -111,18 +104,10 @@ describe("wfs_engine/response", () => {
       }, ["centroid", "bbox"]);
 
       const features = getFeatures(result);
-      expect(features[0].geometry_extra).toBeDefined();
-      expect(features[0].geometry_extra).toMatchObject({
-        bbox: {
-          west: 2.3,
-          south: 48.8,
-          east: 2.4,
-          north: 48.9,
-        },
-      });
-      const geometryExtraCentroid = features[0].geometry_extra as { centroid?: { lon: number; lat: number } };
-      expect(geometryExtraCentroid.centroid?.lon).toBeCloseTo(2.35);
-      expect(geometryExtraCentroid.centroid?.lat).toBeCloseTo(48.85);
+      expect(features[0].bbox).toStrictEqual([2.3, 48.8, 2.4, 48.9]);
+      const features0centroid = features[0] as { centroid?: { lon: number; lat: number } };
+      expect(features0centroid.centroid?.lon).toBeCloseTo(2.35);
+      expect(features0centroid.centroid?.lat).toBeCloseTo(48.85);
     });
   });
 


### PR DESCRIPTION
Add a `geometry_extra` field on both queries and responses of `GpfGetFeatures` and `GpfGetFeaturesById` tools.

The query field is a list of geometry elements, so far only restricted to `bbox` and `centroid` (the list is empty by default). Eventually, this is meant to include both geometrical features (those of #137) and metadata (#136).

The response is an object of the form
```
geometry_extra: {
   bbox?: {
      west: number,
      south: number,
      east: number,
      north: number,
   },
   centroid?: {
      lon: number,
      lat: number,
   },
   distance_to_point_filter?: number,
   ...
}
```
each field appearing only if it is part of the initial query.

Replace PR #155 (same idea but refactored)