### PR TITLE
Hide the geometric property in GpfDescribeType

### DIFF
--- a/src/tools/GpfDescribeTypeTool.ts
+++ b/src/tools/GpfDescribeTypeTool.ts
@@ -4,7 +4,7 @@
 
 import BaseTool from "./BaseTool.js";
 import { z } from "zod";
-import type { Collection } from "@ignfab/gpf-schema-store";
+import type { Collection, CollectionProperty } from "@ignfab/gpf-schema-store";
 
 import { wfsSchemaStore } from "../wfs/catalog.js";
 import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../helpers/toolAnnotations.js";
@@ -71,7 +71,9 @@ class GpfDescribeTypeTool extends BaseTool<GpfDescribeTypeInput> {
 
     try {
       const featureType: Collection = await wfsSchemaStore.getFeatureType(input.typename);
-      return featureType;
+      // Hide the geometric property from the LLM-facing output to prevent it
+      // from querying it in the `select` of GpfGetFeatures or GpfGetFeatureById.
+      return { ...featureType, properties: featureType.properties.filter((p: CollectionProperty) => !p.defaultCrs) };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       throw new Error(`${message}. Utiliser gpf_search_types pour trouver un type valide.`);

--- a/test/tools/wfs/describeType.test.ts
+++ b/test/tools/wfs/describeType.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import type { Collection } from "@ignfab/gpf-schema-store";
 
 import GpfDescribeTypeTool from "../../../src/tools/GpfDescribeTypeTool";
+import { wfsSchemaStore } from "../../../src/wfs/catalog.js";
+
+vi.mock("../../../src/wfs/catalog.js", () => ({
+    wfsSchemaStore: {
+        getFeatureType: vi.fn(),
+    },
+}));
 
 describe("Test GpfDescribeTypeTool",() => {
     const mockCollection: Collection = {
@@ -125,5 +132,35 @@ describe("Test GpfDescribeTypeTool",() => {
         expect(response.structuredContent).toMatchObject({
             type: "urn:geocontext:problem:execution-error",
         });
+    });
+
+    it("should filter out geometry properties (those with defaultCrs) from the output", async () => {
+        const collectionWithGeometry: Collection = {
+            id: "BDTOPO_V3:batiment",
+            namespace: "BDTOPO_V3",
+            name: "batiment",
+            title: "Batiment",
+            description: "Description de test",
+            properties: [
+                { name: "hauteur", type: "float" },
+                { name: "geometrie", type: "polygon", defaultCrs: "EPSG:2154" },
+            ],
+        };
+
+        vi.mocked(wfsSchemaStore.getFeatureType).mockResolvedValueOnce(collectionWithGeometry);
+
+        const tool = new GpfDescribeTypeTool();
+        const response = await tool.toolCall({
+            params: {
+                name: "gpf_describe_type",
+                arguments: { typename: "BDTOPO_V3:batiment" },
+            },
+        });
+
+        expect(response.isError).toBeUndefined();
+        const properties = (response.structuredContent as { properties: { name: string }[] }).properties;
+        expect(properties).toHaveLength(1);
+        expect(properties[0]).toMatchObject({ name: "hauteur" });
+        expect(properties.find(p => p.name === "geometrie")).toBeUndefined();
     });
 });


### PR DESCRIPTION
Mitigation to #82: this PR proposes hiding the geometric property from the output of GpfDescribeType. This way, the LLM should not believe it can query the geometry as part of the `select`.

The error messages dedicated to the case where the LLM does ask for the geometry in the `select` are still kept, just in case the LLM somewhat guesses the underlying provider is WFS and that it should be able to obtain the geometry by asking for it.